### PR TITLE
refactor(deps): replace unmaintained `tempdir` with `tempfile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,12 +1679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "full_moon"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,7 +2946,7 @@ dependencies = [
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "stylua",
- "tempdir",
+ "tempfile",
  "termcolor",
  "termtree",
  "text_trees",
@@ -3008,7 +3002,7 @@ dependencies = [
  "pkg-config",
  "predicates",
  "proptest",
- "remove_dir_all 1.0.0",
+ "remove_dir_all",
  "reqwest",
  "semver",
  "serde",
@@ -3024,7 +3018,7 @@ dependencies = [
  "stylua",
  "tar",
  "target-lexicon 0.13.3",
- "tempdir",
+ "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "toml 0.9.6",
@@ -4110,19 +4104,6 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -4161,21 +4142,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4272,15 +4238,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4385,15 +4342,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "remove_dir_all"
@@ -5526,16 +5474,6 @@ checksum = "03b7eb4d0d43724ba9ba6a6717420ee68aee377816a3edbb45db8c18862b1431"
 dependencies = [
  "byteorder",
  "png 0.17.16",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all 0.5.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ strum = { version = "0.27" }
 strum_macros = "0.27"
 stylua = { version = "2.1", features = ["fromstr", "lua52"] }
 target-lexicon = "0.13"
-tempdir = "0.3"
+tempfile = "3.22"
 toml = "0.9"
 tokio = { version = "1.47", features = ["full"] }
 walkdir = "2.5"

--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 stylua = { workspace = true }
-tempdir = { workspace = true }
+tempfile = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }
 walkdir = { workspace = true }

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -15,7 +15,7 @@ use lux_lib::{
     rockspec::Rockspec as _,
     tree,
 };
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 #[derive(Debug, Clone)]
 pub enum PackageOrRockspec {
@@ -72,8 +72,8 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let user_tree = config.user_tree(lua_version.clone())?;
             match user_tree.match_rocks(&package_req)? {
                 lux_lib::tree::RockMatches::NotFound(_) => {
-                    let temp_dir = TempDir::new("lux-pack")?.into_path();
-                    let temp_config = config.with_tree(temp_dir);
+                    let temp_dir = tempdir()?;
+                    let temp_config = config.with_tree(temp_dir.path().to_path_buf());
                     let tree = temp_config.user_tree(lua_version.clone())?;
                     let packages = Install::new(&temp_config)
                         .package(
@@ -123,9 +123,9 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                     "expected a path to a .rockspec or a package requirement."
                 )),
             }?;
-            let temp_dir = TempDir::new("lux-pack")?.into_path();
+            let temp_dir = tempdir()?;
             let bar = progress.map(|p| p.new_bar());
-            let config = config.with_tree(temp_dir);
+            let config = config.with_tree(temp_dir.path().to_path_buf());
             let lua = LuaInstallation::new(
                 &lua_version,
                 &config,

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -74,7 +74,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 stylua = { workspace = true }
 target-lexicon = { workspace = true }
-tempdir = { workspace = true }
+tempfile = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }
 walkdir = { workspace = true }

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -306,7 +306,7 @@ where
 
     let tree = build.tree;
 
-    let temp_dir = tempdir::TempDir::new(&rockspec.package().to_string())?;
+    let temp_dir = tempfile::tempdir()?;
 
     let source_metadata = match build.source_spec {
         Some(RemotePackageSourceSpec::SrcRock(SrcRockSource { bytes, source_url })) => {

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -134,7 +134,7 @@ pub(crate) async fn compile_c_files(
     // See https://github.com/rust-lang/cc-rs/issues/594#issuecomment-2110551057
 
     let mut build = cc::Build::new();
-    let intermediate_dir = tempdir::TempDir::new(target_module.as_str())?;
+    let intermediate_dir = tempfile::tempdir()?;
     let build = build
         .cargo_output(config.verbose())
         .cargo_metadata(config.verbose())
@@ -170,8 +170,8 @@ pub(crate) async fn compile_c_files(
     let output_path = parent.join(&file);
 
     let output = if compiler.is_like_msvc() {
-        let def_temp_dir = tempdir::TempDir::new("msvc-def")?.into_path().to_path_buf();
-        let def_file = mk_def_file(def_temp_dir, &file, target_module)?;
+        let def_temp_dir = tempfile::tempdir()?;
+        let def_file = mk_def_file(def_temp_dir.path(), &file, target_module)?;
         let cmd = compiler.to_command();
         let mut cmd: tokio::process::Command = cmd.into();
         cmd.arg("/NOLOGO")
@@ -226,7 +226,7 @@ pub(crate) async fn compile_c_files(
 
 /// On MSVC, we need to create Lua definitions manually
 fn mk_def_file(
-    dir: PathBuf,
+    dir: &Path,
     output_file_name: &str,
     target_module: &LuaModule,
 ) -> io::Result<PathBuf> {
@@ -343,7 +343,7 @@ pub(crate) async fn compile_c_modules(
         )
         .collect_vec();
 
-    let intermediate_dir = tempdir::TempDir::new(target_module.as_str())?;
+    let intermediate_dir = tempfile::tempdir()?;
     let build = build
         .cargo_output(config.verbose())
         .cargo_metadata(config.verbose())
@@ -408,8 +408,8 @@ pub(crate) async fn compile_c_modules(
 
     let output_path = parent.join(&file);
     let output = if is_msvc {
-        let def_temp_dir = tempdir::TempDir::new("msvc-def")?.into_path().to_path_buf();
-        let def_file = mk_def_file(def_temp_dir, &file, target_module)?;
+        let def_temp_dir = tempfile::tempdir()?;
+        let def_file = mk_def_file(def_temp_dir.path(), &file, target_module)?;
         let cmd = build.try_get_compiler()?.to_command();
         let mut cmd: tokio::process::Command = cmd.into();
         cmd.arg("/NOLOGO")

--- a/lux-lib/src/git/utils.rs
+++ b/lux-lib/src/git/utils.rs
@@ -3,7 +3,7 @@ use std::io;
 use git2::{AutotagOption, FetchOptions, Repository};
 use git_url_parse::GitUrl;
 use itertools::Itertools;
-use tempdir::TempDir;
+use tempfile::tempdir;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -38,7 +38,7 @@ pub(crate) fn latest_semver_tag_or_commit_sha(url: &GitUrl) -> Result<SemVerTagO
 }
 
 fn latest_semver_tag(url: &GitUrl) -> Result<Option<String>, GitError> {
-    let temp_dir = TempDir::new("lux-git-meta").map_err(GitError::CreateTempDir)?;
+    let temp_dir = tempdir().map_err(GitError::CreateTempDir)?;
 
     let url_str = url.to_string();
     let repo = Repository::init_bare(&temp_dir).map_err(GitError::BareRepoInit)?;
@@ -72,7 +72,7 @@ fn latest_semver_tag(url: &GitUrl) -> Result<Option<String>, GitError> {
 }
 
 fn latest_commit_sha(url: &GitUrl) -> Result<Option<String>, GitError> {
-    let temp_dir = TempDir::new("lux-git-meta").map_err(GitError::CreateTempDir)?;
+    let temp_dir = tempdir().map_err(GitError::CreateTempDir)?;
     let url_str = url.to_string();
     let repo = Repository::init_bare(&temp_dir).map_err(GitError::BareRepoInit)?;
     let mut remote = repo

--- a/lux-lib/src/hash.rs
+++ b/lux-lib/src/hash.rs
@@ -4,7 +4,6 @@ use ssri::{Algorithm, Integrity, IntegrityOpts};
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use tempdir::TempDir;
 
 pub trait HasIntegrity {
     fn hash(&self) -> io::Result<Integrity>;
@@ -31,12 +30,6 @@ impl HasIntegrity for Path {
     fn hash(&self) -> io::Result<Integrity> {
         let path_buf: PathBuf = self.into();
         path_buf.hash()
-    }
-}
-
-impl HasIntegrity for TempDir {
-    fn hash(&self) -> io::Result<Integrity> {
-        self.path().hash()
     }
 }
 

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -370,15 +370,15 @@ fn starts_with_any(str: &str, prefixes: Vec<&str>) -> bool {
 #[cfg(test)]
 mod tests {
 
-    use tempdir::TempDir;
+    use assert_fs::TempDir;
 
     use super::*;
 
     #[tokio::test]
     async fn parse_source_url() {
-        let dir = TempDir::new("lux-test").unwrap().into_path();
+        let dir = TempDir::new().unwrap();
         let url: SourceUrl = format!("file://{}", dir.to_string_lossy()).parse().unwrap();
-        assert_eq!(url, SourceUrl::File(dir));
+        assert_eq!(url, SourceUrl::File(dir.path().to_path_buf()));
         let url: SourceUrl = "ftp://example.com/foo".parse().unwrap();
         assert!(matches!(url, SourceUrl::Url { .. }));
         let url: SourceUrl = "git://example.com/foo".parse().unwrap();

--- a/lux-lib/src/manifest/mod.rs
+++ b/lux-lib/src/manifest/mod.rs
@@ -67,7 +67,7 @@ async fn get_manifest(
         let mut archive = ZipArchive::new(std::io::Cursor::new(manifest_bytes))
             .map_err(|err| ManifestFromServerError::ZipRead(url.clone(), err))?;
 
-        let temp = tempdir::TempDir::new("lux-manifest")?;
+        let temp = tempfile::tempdir()?;
 
         archive
             .extract_unwrapped_root_dir(&temp, zip::read::root_dir_common_filter)

--- a/lux-lib/src/operations/unpack.rs
+++ b/lux-lib/src/operations/unpack.rs
@@ -212,8 +212,8 @@ fn get_single_archive_entry(dir: &Path) -> Result<Option<(PathBuf, Option<&str>)
 #[cfg(test)]
 mod tests {
     use crate::{config::ConfigBuilder, progress::MultiProgress};
+    use assert_fs::TempDir;
     use std::fs::File;
-    use tempdir::TempDir;
 
     use super::*;
 
@@ -224,10 +224,12 @@ mod tests {
             .join("test")
             .join("luatest-0.2-1.src.rock");
         let file = File::open(&test_rock_path).unwrap();
-        let dest = TempDir::new("lux-test").unwrap();
+        let dest = TempDir::new().unwrap();
         let config = ConfigBuilder::new().unwrap().build().unwrap();
         let progress = MultiProgress::new(&config);
         let bar = progress.map(MultiProgress::new_bar);
-        unpack_src_rock(file, dest.into_path(), &bar).await.unwrap();
+        unpack_src_rock(file, dest.to_path_buf(), &bar)
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
The `tempdir` crate has been unmaintained for about 7 years.

Fixes https://github.com/lumen-oss/lux/security/dependabot/19