### PR TITLE
ci: give lux-lua its own separate release version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
   dist-package:
     name: ${{ matrix.target }}
     if: github.repository_owner == 'lumen-oss' && (
-      ( github.event_name == 'release' && startsWith(github.event.release.name, 'v')) ||
+      ( github.event_name == 'release' && (startsWith(github.event.release.name, 'v') || startsWith(github.event.release.name, 'lux-lua-v'))) ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'pull_request'
       )
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload .deb package to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.os, 'ubuntu') && github.event_name == 'release'
+        if: startsWith(matrix.os, 'ubuntu') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/*.deb
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload AppImage to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.os, 'ubuntu') && github.event_name == 'release'
+        if: startsWith(matrix.os, 'ubuntu') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/*.AppImage
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload PKGBUILD to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.target, 'x86_64-unknown-linux-gnu') && github.event_name == 'release'
+        if: startsWith(matrix.target, 'x86_64-unknown-linux-gnu') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/PKGBUILD
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload tar archive to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.target, 'x86_64-unknown-linux-gnu') && github.event_name == 'release'
+        if: startsWith(matrix.target, 'x86_64-unknown-linux-gnu') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/*.tar.gz
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload dmg archive to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.os, 'macos') && github.event_name == 'release'
+        if: startsWith(matrix.os, 'macos') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/*.dmg
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload msi installer to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.os, 'windows') && github.event_name == 'release'
+        if: startsWith(matrix.os, 'windows') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/*.msi
@@ -232,7 +232,7 @@ jobs:
 
       - name: Upload exe installer to release
         uses: svenstaro/upload-release-action@v2
-        if: startsWith(matrix.os, 'windows') && github.event_name == 'release'
+        if: startsWith(matrix.os, 'windows') && github.event_name == 'release' && startsWith(github.event.release.name, 'v')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/dist/*-setup.exe

--- a/lux-lua/Cargo.toml
+++ b/lux-lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lux-lua"
-version.workspace = true
+version = "0.28.1"
 edition = "2021"
 publish = false
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -14,6 +14,13 @@ name = "lux-lib"
 semver_check = true
 
 [[package]]
+name = "lux-lua"
+git_tag_name = "lux-lua-v{{ version }}"
+git_release_name = "lux-lua v{{ version }}"
+semver_check = false
+git_only = true
+
+[[package]]
 name = "lux-workspace-hack"
 changelog_update = false
 release = false


### PR DESCRIPTION
it's tedious to have to synchronize to the lux-cli version at all times (we can't ever provide incremental updates to lux-lua). this adds github-only releases to lux-lua and also does the proper artifact building for those releases.