### PR TITLE
feat(fmt): source editorconfig for stylua

### DIFF
--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -32,6 +32,8 @@ pub fn format(args: Fmt) -> Result<()> {
     let config: Config = std::fs::read_to_string("stylua.toml")
         .or_else(|_| std::fs::read_to_string(".stylua.toml"))
         .map(|config: String| toml::from_str(&config).unwrap_or_default())
+        // Since stylua allows prefixing some `editorconfig` keys with `stylua_`, the config
+        // has to be parsed by the lib and cannot be serialized directly from the toml file.
         .or_else(|_| stylua_lib::editorconfig::parse(Config::new(), &project.root().join("*.lua")))
         .unwrap_or_default();
 

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -32,6 +32,7 @@ pub fn format(args: Fmt) -> Result<()> {
     let config: Config = std::fs::read_to_string("stylua.toml")
         .or_else(|_| std::fs::read_to_string(".stylua.toml"))
         .map(|config: String| toml::from_str(&config).unwrap_or_default())
+        .or_else(|_| stylua_lib::editorconfig::parse(Config::new(), &project.root().join("*.lua")))
         .unwrap_or_default();
 
     WalkDir::new(project.root().join("src"))

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -32,8 +32,6 @@ pub fn format(args: Fmt) -> Result<()> {
     let config: Config = std::fs::read_to_string("stylua.toml")
         .or_else(|_| std::fs::read_to_string(".stylua.toml"))
         .map(|config: String| toml::from_str(&config).unwrap_or_default())
-        // Since stylua allows prefixing some `editorconfig` keys with `stylua_`, the config
-        // has to be parsed by the lib and cannot be serialized directly from the toml file.
         .or_else(|_| stylua_lib::editorconfig::parse(Config::new(), &project.root().join("*.lua")))
         .unwrap_or_default();
 


### PR DESCRIPTION
This PR enables using an `.editorconfig` file to configure stylua when using `lx fmt`.

 I had to dig through the `stylua` code, but I believe this is how it implements editorconfig parsing. Since it supports keys prefixed with `stylua_`, it has to be parsed by the lib and can't just be loaded to toml.

see: https://github.com/JohnnyMorganz/StyLua/blob/f6c04aeb815a8d39592b961a85f1583797b05fba/src/cli/config.rs#L126-L127

I'm new to this project and new to rust, so I'm welcome to any feedback 