### PR TITLE
fix(fmt): allow specifying relative paths

### DIFF
--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -36,7 +36,6 @@ pub fn format(args: Fmt) -> Result<()> {
 
     let workspace_or_file = args
         .workspace_or_file
-        .as_ref()
         .map(|path| std::path::absolute(path).ok())
         .flatten();
 

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -37,7 +37,8 @@ pub fn format(args: Fmt) -> Result<()> {
     let workspace_or_file = args
         .workspace_or_file
         .as_ref()
-        .map(|path| project.root().join(path));
+        .map(|path| std::path::absolute(path).ok())
+        .flatten();
 
     WalkDir::new(project.root().join("src"))
         .into_iter()

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -34,6 +34,11 @@ pub fn format(args: Fmt) -> Result<()> {
         .map(|config: String| toml::from_str(&config).unwrap_or_default())
         .unwrap_or_default();
 
+    let workspace_or_file = args
+        .workspace_or_file
+        .as_ref()
+        .map(|path| project.root().join(path));
+
     WalkDir::new(project.root().join("src"))
         .into_iter()
         .chain(WalkDir::new(project.root().join("lua")))
@@ -43,11 +48,9 @@ pub fn format(args: Fmt) -> Result<()> {
         .chain(WalkDir::new(project.root().join("tests")))
         .filter_map(Result::ok)
         .filter(|file| {
-            args.workspace_or_file
+            workspace_or_file
                 .as_ref()
-                .is_none_or(|workspace_or_file| {
-                    file.path().to_path_buf().starts_with(workspace_or_file)
-                })
+                .is_none_or(|workspace_or_file| file.path().starts_with(workspace_or_file))
         })
         .try_for_each(|file| {
             if PathBuf::from(file.file_name())

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -36,8 +36,8 @@ pub fn format(args: Fmt) -> Result<()> {
 
     let workspace_or_file = args
         .workspace_or_file
-        .map(|path| std::path::absolute(path).ok())
-        .flatten();
+        .map(|path| std::path::absolute(path))
+        .transpose()?;
 
     WalkDir::new(project.root().join("src"))
         .into_iter()

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -36,7 +36,7 @@ pub fn format(args: Fmt) -> Result<()> {
 
     let workspace_or_file = args
         .workspace_or_file
-        .map(|path| std::path::absolute(path))
+        .map(std::path::absolute)
         .transpose()?;
 
     WalkDir::new(project.root().join("src"))


### PR DESCRIPTION
This PR allows passing relative paths of files and folders to `lx fmt`. Relative paths are now resolved against the project root folder. It is still possible to pass absolute paths since `Path.join` will replace the path if so. 

I also removed what I believe to be an unnecessary call to `to_path_buf()`.

Previously, the `startswith` check would only pass if absolute paths were provided since the `file.path()` is absolute. 
