### PR TITLE
feat(http): set User-Agent header on outbound HTTP requests

### DIFF
--- a/lux-lib/src/lib.rs
+++ b/lux-lib/src/lib.rs
@@ -28,5 +28,18 @@ pub(crate) mod variables;
 /// two versions match (meaning we can safely communicate with the server).
 pub const TOOL_VERSION: &str = "1.0.0";
 
+/// User-Agent string sent on all outbound HTTP traffic to luarocks-compatible servers.
+pub const USER_AGENT: &str = concat!("lux/", env!("CARGO_PKG_VERSION"));
+
+/// Returns a reqwest::Client preconfigured with the lux User-Agent header.
+/// Use this for every outbound HTTP request to a luarocks server so the
+/// upstream operator can see adoption / version distribution.
+pub fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .expect("failed to build default reqwest client")
+}
+
 // The largest known files (Lua manifests) use up roughly ~500k steps.
 pub const ROCKSPEC_FUEL_LIMIT: i32 = 1_000_000;

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -151,7 +151,13 @@ impl LuaRocksInstallation {
         use std::io::Cursor;
         let file_name = "luarocks-3.13.0-windows-64";
         let url = format!("https://luarocks.github.io/luarocks/releases/{file_name}.zip");
-        let response = reqwest::get(url).await?.error_for_status()?.bytes().await?;
+        let response = crate::http_client()
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?;
         let hash = response.hash()?;
         let expected_hash: Integrity = unsafe {
             "sha256-CJet5dRZ1VzRliqUgVN0WmdJ/rNFQDxoqqkgc4hVerk="

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -101,7 +101,7 @@ pub(crate) async fn manifest_from_cache_or_server(
     // needing to pull it from the luarocks servers each time).
     let cache = mk_manifest_cache(&url, config).await?;
 
-    let client = Client::new();
+    let client = crate::http_client();
 
     // Read the metadata of the local cache and attempt to get the last modified date.
     if let Ok(metadata) = fs::metadata(&cache).await {
@@ -152,7 +152,7 @@ pub(crate) async fn manifest_from_server_only(
     let manifest_version = LuaVersion::from(config)?.version_compatibility_str();
     let url = mk_manifest_url(server_url, &manifest_version, config)?;
     let cache = mk_manifest_cache(&url, config).await?;
-    let client = Client::new();
+    let client = crate::http_client();
     bar.map(|bar| bar.set_message(format!("📥 Downloading manifest from {}", &url)));
     get_manifest(url, manifest_version.clone(), &cache, &client).await
 }

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -394,7 +394,7 @@ async fn do_build_lua(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
 
     progress.map(|p| p.set_message(format!("📥 Downloading {}", &source_url)));
 
-    let response = reqwest::Client::new()
+    let response = crate::http_client()
         .get(source_url)
         .send()
         .await?

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -239,7 +239,7 @@ async fn download_remote_rock(
         RemotePackageSource::LuarocksRockspec(url) => {
             let package = &remote_package.package;
             let rockspec_name = format!("{}-{}.rockspec", package.name(), package.version());
-            let bytes = reqwest::Client::new()
+            let bytes = crate::http_client()
                 .get(format!("{}/{}", &url, rockspec_name))
                 .send()
                 .await
@@ -457,7 +457,7 @@ where
         });
         let full_rock_name = mk_packed_rock_name(package.name(), package.version(), ext);
         let url = server_url.join(&full_rock_name)?;
-        let response = reqwest::Client::new().get(url.clone()).send().await?;
+        let response = crate::http_client().get(url.clone()).send().await?;
         let bytes = if response.status().is_success() {
             response.bytes().await
         } else {
@@ -466,7 +466,7 @@ where
                     let full_rock_name =
                         mk_packed_rock_name(package.name(), package.version(), ext);
                     let url = server_url.join(&full_rock_name)?;
-                    reqwest::Client::new()
+                    crate::http_client()
                         .get(url.clone())
                         .send()
                         .await?

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -238,7 +238,7 @@ async fn do_fetch_src<R: Rockspec>(
         RockSourceSpec::Url(url) => {
             progress.map(|p| p.set_message(format!("📥 Downloading {}", url.to_owned())));
 
-            let response = reqwest::Client::new()
+            let response = crate::http_client()
                 .get(url.clone())
                 .send()
                 .await?

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -6,8 +6,8 @@ use crate::progress::{Progress, ProgressBar};
 use crate::project::project_toml::RemoteProjectTomlValidationError;
 use crate::remote_package_db::RemotePackageDB;
 use crate::rockspec::Rockspec;
-use crate::TOOL_VERSION;
 use crate::{config::Config, project::Project};
+use crate::{TOOL_VERSION, USER_AGENT};
 
 use bon::Builder;
 use reqwest::StatusCode;
@@ -224,7 +224,10 @@ async fn upload_from_project(args: ProjectUpload<'_>) -> Result<(), UploadError>
     let progress = args.progress;
     let package_db = args.package_db;
 
-    let client = Client::builder().https_only(true).build()?;
+    let client = Client::builder()
+        .https_only(true)
+        .user_agent(USER_AGENT)
+        .build()?;
 
     helpers::ensure_tool_version(&client, config.server()).await?;
     helpers::ensure_user_exists(&client, &api_key, config.server()).await?;


### PR DESCRIPTION
Closes #1479

Adds a `USER_AGENT` constant and an `http_client()` helper in `lux-lib/src/lib.rs` so every outbound HTTP request to a luarocks server identifies itself as `lux/<CARGO_PKG_VERSION>`. As you said in the issue, the luarocks CLI sends `LuaRocks/3.11.0 ...`; this is the same idea so the server-side maintainers can see adoption + version distribution.

## What this PR does NOT touch

- Test files and fixtures continue to use `reqwest::Client::new()`; they hit local mocks where a UA isn't useful and dropping in `http_client()` would require plumbing through `lux-lib`.
- `TOOL_VERSION` (the API-compat string) is unchanged; this PR only adds `USER_AGENT`.
- No reqwest feature flags or version changes.

## Verification

- `cargo build -p lux-lib` and `cargo build -p lux-lib --no-default-features` both clean.
  - The full workspace build needs `gpg-error` system lib (gpgme feature), which I don't have on this machine, so I built lux-lib directly.
- `codex review --base upstream/main` returned: "No actionable correctness issues were found in the diff. The changes consistently apply a configured reqwest User-Agent while preserving the existing upload HTTPS-only client configuration."
- `git diff --check` clean.

Once merged, luarocks.org will see traffic like `User-Agent: lux/0.36.4` from every lux instance.

