### PR TITLE
feat!: set user agent header for web requests

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -17,6 +17,8 @@ use lux_lib::{
     lua_version::LuaVersion,
 };
 
+const DEFAULT_USER_AGENT: &str = concat!("lux/", env!("CARGO_PKG_VERSION"));
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -53,7 +55,8 @@ async fn main() -> Result<()> {
         )
         .verbose(Some(cli.verbose))
         .no_progress(Some(cli.no_progress))
-        .no_prompt(Some(cli.no_prompt));
+        .no_prompt(Some(cli.no_prompt))
+        .user_agent(Some(cli.user_agent.unwrap_or(DEFAULT_USER_AGENT.into())));
 
     if cli.nvim {
         config_builder = config_builder.entrypoint_layout(RockLayoutConfig::new_nvim_layout());

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -164,6 +164,11 @@ pub struct Cli {
     #[arg(long)]
     pub no_luarc: bool,
 
+    /// The user agent to set when making web requests.
+    /// Default is "lux/<version>"
+    #[arg(long)]
+    pub user_agent: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -17,6 +17,7 @@ pub mod external_deps;
 pub mod tree;
 
 const DEV_PATH: &str = "dev/";
+const DEFAULT_USER_AGENT: &str = concat!("lux-lib/", env!("CARGO_PKG_VERSION"));
 
 #[derive(Error, Debug)]
 #[error("could not find a valid home directory")]
@@ -48,6 +49,10 @@ pub struct Config {
     cache_dir: PathBuf,
     data_dir: PathBuf,
     vendor_dir: Option<PathBuf>,
+
+    /// The user agent to set when making web requests.
+    /// Default: "lux-lib/<version>".
+    user_agent: String,
 
     generate_luarc: bool,
 }
@@ -181,6 +186,10 @@ impl Config {
         self.vendor_dir.as_ref()
     }
 
+    pub fn user_agent(&self) -> &str {
+        &self.user_agent
+    }
+
     pub fn generate_luarc(&self) -> bool {
         self.generate_luarc
     }
@@ -241,6 +250,7 @@ pub struct ConfigBuilder {
     /// Does not affect existing install trees.
     #[serde(default)]
     entrypoint_layout: RockLayoutConfig,
+    user_agent: Option<String>,
     generate_luarc: Option<bool>,
 }
 
@@ -390,6 +400,13 @@ impl ConfigBuilder {
         }
     }
 
+    pub fn user_agent(self, user_agent: Option<String>) -> Self {
+        Self {
+            user_agent: user_agent.or(self.user_agent),
+            ..self
+        }
+    }
+
     pub fn generate_luarc(self, generate: Option<bool>) -> Self {
         Self {
             generate_luarc: generate.or(self.generate_luarc),
@@ -433,6 +450,7 @@ impl ConfigBuilder {
             cache_dir,
             data_dir,
             vendor_dir: self.vendor_dir,
+            user_agent: self.user_agent.unwrap_or(DEFAULT_USER_AGENT.into()),
             generate_luarc: self.generate_luarc.unwrap_or(true),
         })
     }
@@ -465,6 +483,7 @@ impl From<Config> for ConfigBuilder {
             vendor_dir: value.vendor_dir,
             external_deps: value.external_deps,
             entrypoint_layout: value.entrypoint_layout,
+            user_agent: Some(value.user_agent),
             generate_luarc: Some(value.generate_luarc),
         }
     }

--- a/lux-lib/src/lib.rs
+++ b/lux-lib/src/lib.rs
@@ -21,6 +21,7 @@ pub mod upload;
 pub mod which;
 
 pub(crate) mod remote_package_source;
+pub(crate) mod reqwest;
 pub(crate) mod variables;
 
 /// An internal string describing the server-side API version that we support.

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -101,7 +101,11 @@ pub(crate) async fn manifest_from_cache_or_server(
     // needing to pull it from the luarocks servers each time).
     let cache = mk_manifest_cache(&url, config).await?;
 
-    let client = Client::new();
+    #[cfg(not(test))]
+    let client = crate::reqwest::new_https_client(config)?;
+
+    #[cfg(test)]
+    let client = crate::reqwest::new_http_client(config)?;
 
     // Read the metadata of the local cache and attempt to get the last modified date.
     if let Ok(metadata) = fs::metadata(&cache).await {
@@ -152,7 +156,7 @@ pub(crate) async fn manifest_from_server_only(
     let manifest_version = LuaVersion::from(config)?.version_compatibility_str();
     let url = mk_manifest_url(server_url, &manifest_version, config)?;
     let cache = mk_manifest_cache(&url, config).await?;
-    let client = Client::new();
+    let client = crate::reqwest::new_https_client(config)?;
     bar.map(|bar| bar.set_message(format!("📥 Downloading manifest from {}", &url)));
     get_manifest(url, manifest_version.clone(), &cache, &client).await
 }

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -394,7 +394,7 @@ async fn do_build_lua(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
 
     progress.map(|p| p.set_message(format!("📥 Downloading {}", &source_url)));
 
-    let response = reqwest::Client::new()
+    let response = crate::reqwest::new_https_client(args.config)?
         .get(source_url)
         .send()
         .await?

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -60,10 +60,10 @@ impl<'a> Download<'a> {
     /// Download the package's Rockspec.
     pub async fn download_rockspec(self) -> Result<DownloadedRockspec, SearchAndDownloadError> {
         match self.package_db {
-            Some(db) => download_rockspec(self.package_req, db, self.progress).await,
+            Some(db) => download_rockspec(self.package_req, db, self.progress, self.config).await,
             None => {
                 let db = RemotePackageDB::from_config(self.config, self.progress).await?;
-                download_rockspec(self.package_req, &db, self.progress).await
+                download_rockspec(self.package_req, &db, self.progress, self.config).await
             }
         }
     }
@@ -76,13 +76,25 @@ impl<'a> Download<'a> {
     ) -> Result<DownloadedPackedRock, SearchAndDownloadError> {
         match self.package_db {
             Some(db) => {
-                download_src_rock_to_file(self.package_req, destination_dir, db, self.progress)
-                    .await
+                download_src_rock_to_file(
+                    self.package_req,
+                    destination_dir,
+                    db,
+                    self.progress,
+                    self.config,
+                )
+                .await
             }
             None => {
                 let db = RemotePackageDB::from_config(self.config, self.progress).await?;
-                download_src_rock_to_file(self.package_req, destination_dir, &db, self.progress)
-                    .await
+                download_src_rock_to_file(
+                    self.package_req,
+                    destination_dir,
+                    &db,
+                    self.progress,
+                    self.config,
+                )
+                .await
             }
         }
     }
@@ -92,10 +104,13 @@ impl<'a> Download<'a> {
         self,
     ) -> Result<DownloadedPackedRockBytes, SearchAndDownloadError> {
         match self.package_db {
-            Some(db) => search_and_download_src_rock(self.package_req, db, self.progress).await,
+            Some(db) => {
+                search_and_download_src_rock(self.package_req, db, self.progress, self.config).await
+            }
             None => {
                 let db = RemotePackageDB::from_config(self.config, self.progress).await?;
-                search_and_download_src_rock(self.package_req, &db, self.progress).await
+                search_and_download_src_rock(self.package_req, &db, self.progress, self.config)
+                    .await
             }
         }
     }
@@ -104,10 +119,12 @@ impl<'a> Download<'a> {
         self,
     ) -> Result<RemoteRockDownload, SearchAndDownloadError> {
         match self.package_db {
-            Some(db) => download_remote_rock(self.package_req, db, self.progress).await,
+            Some(db) => {
+                download_remote_rock(self.package_req, db, self.progress, self.config).await
+            }
             None => {
                 let db = RemotePackageDB::from_config(self.config, self.progress).await?;
-                download_remote_rock(self.package_req, &db, self.progress).await
+                download_remote_rock(self.package_req, &db, self.progress, self.config).await
             }
         }
     }
@@ -211,8 +228,9 @@ async fn download_rockspec(
     package_req: &PackageReq,
     package_db: &RemotePackageDB,
     progress: &Progress<ProgressBar>,
+    config: &Config,
 ) -> Result<DownloadedRockspec, SearchAndDownloadError> {
-    let rockspec = match download_remote_rock(package_req, package_db, progress).await? {
+    let rockspec = match download_remote_rock(package_req, package_db, progress, config).await? {
         RemoteRockDownload::RockspecOnly {
             rockspec_download: rockspec,
         } => rockspec,
@@ -232,6 +250,7 @@ async fn download_remote_rock(
     package_req: &PackageReq,
     package_db: &RemotePackageDB,
     progress: &Progress<ProgressBar>,
+    config: &Config,
 ) -> Result<RemoteRockDownload, SearchAndDownloadError> {
     let remote_package = package_db.find(package_req, None, progress)?;
     progress.map(|p| p.set_message(format!("📥 Downloading rockspec for {package_req}")));
@@ -239,7 +258,7 @@ async fn download_remote_rock(
         RemotePackageSource::LuarocksRockspec(url) => {
             let package = &remote_package.package;
             let rockspec_name = format!("{}-{}.rockspec", package.name(), package.version());
-            let bytes = reqwest::Client::new()
+            let bytes = crate::reqwest::new_https_client(config)?
                 .get(format!("{}/{}", &url, rockspec_name))
                 .send()
                 .await
@@ -277,7 +296,7 @@ async fn download_remote_rock(
             } else {
                 url
             };
-            let rock = download_binary_rock(&remote_package.package, url, progress).await?;
+            let rock = download_binary_rock(&remote_package.package, url, progress, config).await?;
             let rockspec = DownloadedRockspec {
                 rockspec: unpack_rockspec(&rock).await?,
                 source: remote_package.source,
@@ -296,7 +315,7 @@ async fn download_remote_rock(
             } else {
                 url.clone()
             };
-            let rock = download_src_rock(&remote_package.package, &url, progress).await?;
+            let rock = download_src_rock(&remote_package.package, &url, progress, config).await?;
             let rockspec = DownloadedRockspec {
                 rockspec: unpack_rockspec(&rock).await?,
                 source: remote_package.source,
@@ -344,12 +363,15 @@ pub enum SearchAndDownloadError {
     LocalSource,
     #[error("cannot download from a local rock or embedded rockspec source.")]
     NonURLSource,
+    #[error("client error:\n{0}")]
+    Request(#[from] reqwest::Error),
 }
 
 async fn search_and_download_src_rock(
     package_req: &PackageReq,
     package_db: &RemotePackageDB,
     progress: &Progress<ProgressBar>,
+    config: &Config,
 ) -> Result<DownloadedPackedRockBytes, SearchAndDownloadError> {
     let filter = Some(RemotePackageTypeFilterSpec {
         rockspec: false,
@@ -361,7 +383,7 @@ async fn search_and_download_src_rock(
         .source
         .url()
         .ok_or(SearchAndDownloadError::NonURLSource)?;
-    Ok(download_src_rock(&remote_package.package, &source_url, progress).await?)
+    Ok(download_src_rock(&remote_package.package, &source_url, progress, config).await?)
 }
 
 #[derive(Error, Debug)]
@@ -376,8 +398,14 @@ pub(crate) async fn download_src_rock(
     package: &PackageSpec,
     server_url: &Url,
     progress: &Progress<ProgressBar>,
+    config: &Config,
 ) -> Result<DownloadedPackedRockBytes, DownloadSrcRockError> {
-    ArchiveDownload::new(package, server_url, "src.rock", progress)
+    ArchiveDownload::new()
+        .package(package)
+        .server_url(server_url)
+        .config(config)
+        .progress(progress)
+        .ext("src.rock")
         .download()
         .await
 }
@@ -386,9 +414,15 @@ pub(crate) async fn download_binary_rock(
     package: &PackageSpec,
     server_url: &Url,
     progress: &Progress<ProgressBar>,
+    config: &Config,
 ) -> Result<DownloadedPackedRockBytes, DownloadSrcRockError> {
     let ext = format!("{}.rock", luarocks::current_platform_luarocks_identifier());
-    ArchiveDownload::new(package, server_url, &ext, progress)
+    ArchiveDownload::new()
+        .package(package)
+        .server_url(server_url)
+        .config(config)
+        .progress(progress)
+        .ext(&ext)
         .fallback_ext("all.rock")
         .download()
         .await
@@ -399,10 +433,11 @@ async fn download_src_rock_to_file(
     destination_dir: Option<PathBuf>,
     package_db: &RemotePackageDB,
     progress: &Progress<ProgressBar>,
+    config: &Config,
 ) -> Result<DownloadedPackedRock, SearchAndDownloadError> {
     progress.map(|p| p.set_message(format!("📥 Downloading {package_req}")));
 
-    let rock = search_and_download_src_rock(package_req, package_db, progress).await?;
+    let rock = search_and_download_src_rock(package_req, package_db, progress, config).await?;
     let full_rock_name = mk_packed_rock_name(&rock.name, &rock.version, "src.rock");
     tokio::fs::write(
         destination_dir
@@ -422,24 +457,22 @@ async fn download_src_rock_to_file(
 #[derive(Builder)]
 #[builder(start_fn = new, finish_fn(name = _build, vis = ""))]
 struct ArchiveDownload<'a> {
-    #[builder(start_fn)]
     package: &'a PackageSpec,
 
-    #[builder(start_fn)]
     server_url: &'a Url,
 
-    #[builder(start_fn)]
     ext: &'a str,
 
-    #[builder(start_fn)]
     progress: &'a Progress<ProgressBar>,
 
     fallback_ext: Option<&'a str>,
+
+    config: &'a Config,
 }
 
 impl<State> ArchiveDownloadBuilder<'_, State>
 where
-    State: archive_download_builder::State,
+    State: archive_download_builder::State + archive_download_builder::IsComplete,
 {
     async fn download(self) -> Result<DownloadedPackedRockBytes, DownloadSrcRockError> {
         let args = self._build();
@@ -457,7 +490,10 @@ where
         });
         let full_rock_name = mk_packed_rock_name(package.name(), package.version(), ext);
         let url = server_url.join(&full_rock_name)?;
-        let response = reqwest::Client::new().get(url.clone()).send().await?;
+        let response = crate::reqwest::new_https_client(args.config)?
+            .get(url.clone())
+            .send()
+            .await?;
         let bytes = if response.status().is_success() {
             response.bytes().await
         } else {
@@ -466,7 +502,7 @@ where
                     let full_rock_name =
                         mk_packed_rock_name(package.name(), package.version(), ext);
                     let url = server_url.join(&full_rock_name)?;
-                    reqwest::Client::new()
+                    crate::reqwest::new_https_client(args.config)?
                         .get(url.clone())
                         .send()
                         .await?

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -238,7 +238,9 @@ async fn do_fetch_src<R: Rockspec>(
         RockSourceSpec::Url(url) => {
             progress.map(|p| p.set_message(format!("📥 Downloading {}", url.to_owned())));
 
-            let response = reqwest::Client::new()
+            // NOTE: We don't enforce HTTPS when fetching sources because some rockspecs
+            // have HTTP URLs in `source.url`.
+            let response = crate::reqwest::new_http_client(config)?
                 .get(url.clone())
                 .send()
                 .await?
@@ -329,7 +331,8 @@ async fn do_fetch_src_rock(
     let dest_dir = fetch.dest_dir;
     let config = fetch.config;
     let progress = fetch.progress;
-    let src_rock = operations::download_src_rock(package, config.server(), progress).await?;
+    let src_rock =
+        operations::download_src_rock(package, config.server(), progress, fetch.config).await?;
     let hash = src_rock.bytes.hash()?;
     let cursor = Cursor::new(src_rock.bytes);
     let mime_type = infer::get(cursor.get_ref()).map(|file_type| file_type.mime_type());

--- a/lux-lib/src/reqwest.rs
+++ b/lux-lib/src/reqwest.rs
@@ -1,0 +1,17 @@
+use reqwest::Client;
+
+use crate::config::Config;
+
+/// Returns a pre-configured HTTPS-only client.
+pub(crate) fn new_https_client(config: &Config) -> Result<Client, reqwest::Error> {
+    Client::builder()
+        .https_only(true)
+        .user_agent(config.user_agent())
+        .build()
+}
+
+/// Returns a pre-configured HTTP client.
+/// Used in tests and to fetch sources, which may be HTTP URLs.
+pub(crate) fn new_http_client(config: &Config) -> Result<Client, reqwest::Error> {
+    Client::builder().user_agent(config.user_agent()).build()
+}

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -10,11 +10,8 @@ use crate::TOOL_VERSION;
 use crate::{config::Config, project::Project};
 
 use bon::Builder;
+use reqwest::multipart::{Form, Part};
 use reqwest::StatusCode;
-use reqwest::{
-    multipart::{Form, Part},
-    Client,
-};
 use serde::Deserialize;
 use serde_enum_str::Serialize_enum_str;
 use thiserror::Error;
@@ -224,7 +221,7 @@ async fn upload_from_project(args: ProjectUpload<'_>) -> Result<(), UploadError>
     let progress = args.progress;
     let package_db = args.package_db;
 
-    let client = Client::builder().https_only(true).build()?;
+    let client = crate::reqwest::new_https_client(args.config)?;
 
     helpers::ensure_tool_version(&client, config.server()).await?;
     helpers::ensure_user_exists(&client, &api_key, config.server()).await?;

--- a/lux-lua/src/config.rs
+++ b/lux-lua/src/config.rs
@@ -3,6 +3,8 @@ use mlua::{ExternalResult, Lua, Table};
 
 use crate::lua_impls::{ConfigBuilderLua, ConfigLua};
 
+const DEFAULT_USER_AGENT: &str = concat!("lux-lua/", env!("CARGO_PKG_VERSION"));
+
 pub fn config(lua: &Lua) -> mlua::Result<Table> {
     let table = lua.create_table()?;
 
@@ -10,6 +12,7 @@ pub fn config(lua: &Lua) -> mlua::Result<Table> {
         "default",
         lua.create_function(|_, ()| {
             ConfigBuilder::default()
+                .user_agent(Some(DEFAULT_USER_AGENT.into()))
                 .build()
                 .map(ConfigLua)
                 .into_lua_err()


### PR DESCRIPTION
- Wraps `reqwest::Client` constructor/builder calls with a `new_https_client` wrapper.
- Sets the user agent from the config, with the following defaults:
  - lux-cli: `lux/<version>`
  - lux-lib: `lux-lib/<version>`
  - lux-lua: `lux-lua/<version>`
  (Note that `<version>` may be different for each of the crates).
- **BREAKING:** ~All~ Most web requests are now HTTPS-only (previously, only `upload` requests were).
  I suggest YAGNI for HTTP support - We can enable it again if people need it.