### PR TITLE
feat(fmt): source editorconfig for emmylua-codestyle

### DIFF
--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -29,11 +29,13 @@ pub fn format(args: Fmt) -> Result<()> {
         "`lx fmt` can only be executed in a lux project! Run `lx new` to create one.",
     )?;
 
-    let config: Config = std::fs::read_to_string("stylua.toml")
+    let stylua_config: Config = std::fs::read_to_string("stylua.toml")
         .or_else(|_| std::fs::read_to_string(".stylua.toml"))
         .map(|config: String| toml::from_str(&config).unwrap_or_default())
         .or_else(|_| stylua_lib::editorconfig::parse(Config::new(), &project.root().join("*.lua")))
         .unwrap_or_default();
+
+    let emmylua_config = std::path::absolute(".editorconfig");
 
     let workspace_or_file = args
         .workspace_or_file
@@ -63,13 +65,16 @@ pub fn format(args: Fmt) -> Result<()> {
                 let formatted_code = match args.backend {
                     FmtBackend::Stylua => stylua_lib::format_code(
                         &unformatted_code,
-                        config,
+                        stylua_config,
                         None,
                         stylua_lib::OutputVerification::Full,
                     )
                     .context(format!("error formatting {} with stylua.", file.display()))?,
                     FmtBackend::EmmyluaCodestyle => {
                         let uri = file.to_slash_lossy().to_string();
+                        if let Ok(config) = &emmylua_config {
+                            emmylua_codestyle::update_code_style(&uri, &config.to_slash_lossy());
+                        }
                         emmylua_codestyle::reformat_code(
                             &unformatted_code,
                             &uri,
@@ -93,12 +98,15 @@ pub fn format(args: Fmt) -> Result<()> {
         let formatted_code = match args.backend {
             FmtBackend::Stylua => stylua_lib::format_code(
                 &unformatted_code,
-                config,
+                stylua_config,
                 None,
                 stylua_lib::OutputVerification::Full,
             )?,
             FmtBackend::EmmyluaCodestyle => {
                 let uri = rockspec.to_slash_lossy().to_string();
+                if let Ok(config) = &emmylua_config {
+                    emmylua_codestyle::update_code_style(&uri, &config.to_slash_lossy());
+                };
                 emmylua_codestyle::reformat_code(
                     &unformatted_code,
                     &uri,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

This PR enables sourcing emmylua-codestyle configuration from a top-level `.editorconfig` file.

The implementation first resolves the editorconfig path, and if it exists, it calles `emmylua_codestyle::update_code_style()` for every file being formatted. The documentation for `emmylua_codestyle::update_code_style` is non-existant, so I had to guess and check how the function works from looking at the [source code](https://github.com/search?q=repo%3ACppCXY%2FEmmyLuaCodeStyle%20UpdateCodeStyle(&type=code))

 I tried moving the `update_code_style` call outside of the loop to put it with the path resolution check, but I was getting segfaults. I believe this is due to how the `workspace_uri` path is resolved in the upstream code, but I am not certain.
 
 I've tested this patch locally, and it picks up the appropriate config, and I haven't found any other issues so far. I've also tested without an editorconfig present.

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
