### PR TITLE
feat(rockspec): support non-lua file extensions in `install.lua`

### DIFF
--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -34,7 +34,12 @@ pub(crate) fn copy_lua_to_module_path(
     target_module: &LuaModule,
     target_dir: &Path,
 ) -> io::Result<()> {
-    let target = target_dir.join(target_module.to_lua_path());
+    // Some rockspecs abuse `install.lua` to install non-lua files, such as teal (`.tl`) files.
+    let target_module_path = source
+        .extension()
+        .map(|ext| target_module.to_file_path(&format!(".{}", ext.to_string_lossy().as_ref())))
+        .unwrap_or_else(|| target_module.to_lua_path());
+    let target = target_dir.join(target_module_path);
 
     if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent).map_err(|err| {

--- a/lux-lib/src/lua_rockspec/build/builtin.rs
+++ b/lux-lib/src/lua_rockspec/build/builtin.rs
@@ -39,7 +39,7 @@ impl LuaModule {
         PathBuf::from(self.0.replace('.', std::path::MAIN_SEPARATOR_STR))
     }
 
-    fn to_file_path(&self, extension: &str) -> PathBuf {
+    pub(crate) fn to_file_path(&self, extension: &str) -> PathBuf {
         PathBuf::from(self.0.replace('.', std::path::MAIN_SEPARATOR_STR) + extension)
     }
 


### PR DESCRIPTION
Some rockspecs abuse `install.lua` to install non-rockspec files, such as teal `.tl` files.
This retains the file extension of the source files, ensuring compatibility with luarocks.

See also: https://github.com/lumen-oss/lux/issues/1092.

This doesn't officially add Teal support, but it allows people to install common Teal packages from luarocks.org.