### PR TITLE
feat: support workspaces with multiple projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following table provides a brief comparison:
 | Generate a `.luarc` file with dependencies                                              | :white_check_mark:           | :x:                |
 | Git dependencies in local projects                                                      | :white_check_mark:           | :x:                |
 | Vendor sources for offline use                                                          | :white_check_mark:           | :x:                |
+| Multiple projects in a single workspace                                                 | :white_check_mark:           | :x:                |
 | Load RockSpecs and LuaRocks manifests with [full sandboxing](https://github.com/kyren/piccolo) | :white_check_mark:       | :x:                |
 
 [^1]: Supported via a compatibility layer that uses LuaRocks as a backend.

--- a/lux-lib/resources/test/sample-projects/multi-project/.gitignore
+++ b/lux-lib/resources/test/sample-projects/multi-project/.gitignore
@@ -1,0 +1,2 @@
+.lux
+.direnv

--- a/lux-lib/resources/test/sample-projects/multi-project/lux.toml
+++ b/lux-lib/resources/test/sample-projects/multi-project/lux.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["projects/foo", "projects/bar"]

--- a/lux-lib/resources/test/sample-projects/multi-project/projects/bar/lux.toml
+++ b/lux-lib/resources/test/sample-projects/multi-project/projects/bar/lux.toml
@@ -1,0 +1,11 @@
+package = "bar"
+version = "1.0.0"
+lua = ">=5.1"
+
+[description]
+summary = ""
+maintainer = "lumen-labs"
+labels = [""]
+
+[run]
+args = ["src/main.lua"]

--- a/lux-lib/resources/test/sample-projects/multi-project/projects/bar/src/main.lua
+++ b/lux-lib/resources/test/sample-projects/multi-project/projects/bar/src/main.lua
@@ -1,0 +1,1 @@
+print("Hello from bar")

--- a/lux-lib/resources/test/sample-projects/multi-project/projects/foo/lux.toml
+++ b/lux-lib/resources/test/sample-projects/multi-project/projects/foo/lux.toml
@@ -1,0 +1,11 @@
+package = "foo"
+version = "1.0.0"
+lua = ">=5.1"
+
+[description]
+summary = ""
+maintainer = "lumen-labs"
+labels = [""]
+
+[run]
+args = ["src/main.lua"]

--- a/lux-lib/resources/test/sample-projects/multi-project/projects/foo/src/main.lua
+++ b/lux-lib/resources/test/sample-projects/multi-project/projects/foo/src/main.lua
@@ -1,0 +1,1 @@
+print("Hello from foo")

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -16,7 +16,10 @@ use crate::{
     package::PackageName,
     project::{Project, ProjectError, PROJECT_TOML},
     tree::{Tree, TreeError},
+    workspace::workspace_toml::WorkspaceToml,
 };
+
+pub mod workspace_toml;
 
 pub const WORKSPACE_TOML: &str = PROJECT_TOML;
 pub(crate) const LUX_DIR_NAME: &str = ".lux";
@@ -51,10 +54,14 @@ pub enum WorkspaceError {
     ReadLuxTOML(String, io::Error),
     #[error("error deserializing workspace TOML:\n{0}")]
     TOML(String),
+    #[error("no project found at `{0}`")]
+    ProjectNotFound(PathBuf),
     #[error("error deserializing project TOML:\n{0}")]
     Project(#[from] ProjectError),
     #[error("no project or workspace found")]
     NoWorkspaceOrProject,
+    #[error("empty workspace at `{0}`")]
+    EmptyWorkspace(PathBuf),
     #[error(transparent)]
     Lockfile(#[from] LockfileError),
     #[error("not in a lux project or workspace directory")]
@@ -255,9 +262,9 @@ impl Workspace {
                 WorkspaceError::ReadLuxTOML(toml_path.to_string_lossy().to_string(), err)
             })?;
             let root = start.as_ref();
-
-            if toml_content.contains("[workspace]") {
-                unimplemented!("multi-project workspaces")
+            let toml_obj: Option<toml::Table> = toml::from_str(&toml_content).ok();
+            if toml_obj.is_some_and(|toml| toml.contains_key("workspace")) {
+                Ok(Some(Self::from_toml(&toml_content, root)?))
             } else {
                 let project =
                     Project::from_exact(root)?.ok_or(WorkspaceError::NoWorkspaceOrProject)?;
@@ -287,8 +294,9 @@ impl Workspace {
                     let toml_content = std::fs::read_to_string(&path).map_err(|err| {
                         WorkspaceError::ReadLuxTOML(path.to_string_lossy().to_string(), err)
                     })?;
-                    if toml_content.contains("[workspace]") {
-                        unimplemented!("multi-project workspaces")
+                    let toml_obj: Option<toml::Table> = toml::from_str(&toml_content).ok();
+                    if toml_obj.is_some_and(|toml| toml.contains_key("workspace")) {
+                        Ok(Some(Self::from_toml(&toml_content, root)?))
                     } else {
                         if let Some(parent) = root.parent() {
                             match Self::from(parent)? {
@@ -311,9 +319,29 @@ impl Workspace {
                 }
             }
             // NOTE: If we hit a read error, it could be because we haven't found a PROJECT_TOML
-            // and have started searching too far upwards.
+            // or WORKSPACE_TOML and have started searching too far upwards.
             // See for example https://github.com/lumen-oss/lux/issues/532
             _ => Ok(None),
+        }
+    }
+
+    fn from_toml(toml_content: &str, root: &Path) -> Result<Self, WorkspaceError> {
+        let toml = WorkspaceToml::new(toml_content)
+            .map_err(|err| WorkspaceError::TOML(err.to_string()))?;
+        let mut members = Vec::new();
+        for relative_project_path in toml.workspace.members {
+            let project_path = root.join(relative_project_path);
+            match Project::from_exact(&project_path)? {
+                Some(project) => members.push(project),
+                None => return Err(WorkspaceError::ProjectNotFound(project_path)),
+            }
+        }
+        match NonEmpty::from_vec(members) {
+            Some(members) => Ok(Workspace {
+                root: WorkspaceRoot(root.to_path_buf()),
+                members,
+            }),
+            None => Err(WorkspaceError::EmptyWorkspace(root.to_path_buf())),
         }
     }
 }
@@ -335,6 +363,28 @@ mod tests {
         assert_eq!(workspace.members.len(), 1);
         let project = workspace.members.first();
         assert_eq!(project.root().to_path_buf(), project_root.to_path_buf());
+    }
+
+    #[tokio::test]
+    async fn find_multi_project_workspace() {
+        let sample_workspace: PathBuf = "resources/test/sample-projects/multi-project/".into();
+        let workspace_root = assert_fs::TempDir::new().unwrap();
+        workspace_root
+            .copy_from(&sample_workspace, &["**"])
+            .unwrap();
+        let work_dir: PathBuf = workspace_root.join("projects");
+        let workspace = Workspace::from(&work_dir).unwrap().unwrap();
+        assert_eq!(workspace.members.len(), 2);
+        let foo = workspace.try_member(&Some("foo".into())).unwrap();
+        assert_eq!(
+            foo.root().to_path_buf(),
+            workspace_root.join("projects/foo").to_path_buf()
+        );
+        let bar = workspace.try_member(&Some("bar".into())).unwrap();
+        assert_eq!(
+            bar.root().to_path_buf(),
+            workspace_root.join("projects/bar").to_path_buf()
+        );
     }
 
     #[tokio::test]

--- a/lux-lib/src/workspace/workspace_toml.rs
+++ b/lux-lib/src/workspace/workspace_toml.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// The `lux.toml` file for a workspace.
+/// Used to deserialize a workspace with multiple projects.
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct WorkspaceToml {
+    pub workspace: WorkspaceSpec,
+}
+
+/// The `lux.toml` file for a workspace.
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct WorkspaceSpec {
+    /// Paths (relative to the workspace root) of projects to include in the workspace.
+    pub members: Vec<PathBuf>,
+}
+
+impl WorkspaceToml {
+    pub(super) fn new(toml_content: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(toml_content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parse_workspace_toml() {
+        let toml_content = r#"
+            [workspace]
+            members = [
+                "foo",
+                "projects/bar",
+            ]
+        "#;
+        let workspace_toml = WorkspaceToml::new(toml_content).unwrap();
+        assert_eq!(
+            workspace_toml.workspace.members,
+            vec![PathBuf::from("foo"), PathBuf::from("projects/bar")]
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #1502.
Closes #1325.

This does not yet add support for local dependencies (#1148, e.g. packages in a workspace depending on each other). That will follow in a later PR:

- #1508