### PR TITLE
feat: support local dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ The following table provides a brief comparison:
 | Static type checking                                                                    | :white_check_mark:           | :x:                |
 | Generate a `.luarc` file with dependencies                                              | :white_check_mark:           | :x:                |
 | Git dependencies in local projects                                                      | :white_check_mark:           | :x:                |
-| Vendor sources for offline use                                                          | :white_check_mark:           | :x:                |
+| Local dependencies in local projects                                                    | :white_check_mark:           | :x:                |
 | Multiple projects in a single workspace                                                 | :white_check_mark:           | :x:                |
+| Vendor sources for offline use                                                          | :white_check_mark:           | :x:                |
 | Load RockSpecs and LuaRocks manifests with [full sandboxing](https://github.com/kyren/piccolo) | :white_check_mark:       | :x:                |
 
 [^1]: Supported via a compatibility layer that uses LuaRocks as a backend.

--- a/lux-lib/resources/test/sample-projects/multi-project-local-deps/.gitignore
+++ b/lux-lib/resources/test/sample-projects/multi-project-local-deps/.gitignore
@@ -1,0 +1,2 @@
+.lux
+.direnv

--- a/lux-lib/resources/test/sample-projects/multi-project-local-deps/lux.toml
+++ b/lux-lib/resources/test/sample-projects/multi-project-local-deps/lux.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["projects/foo", "projects/bar"]

--- a/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/bar/lux.toml
+++ b/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/bar/lux.toml
@@ -1,0 +1,15 @@
+package = "bar"
+version = "1.0.0"
+lua = ">=5.1"
+
+[description]
+summary = ""
+maintainer = "lumen-labs"
+labels = [""]
+
+[dependencies.foo]
+path = "../foo"
+version = "1.0.0"
+
+[run]
+args = ["src/main.lua"]

--- a/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/bar/src/main.lua
+++ b/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/bar/src/main.lua
@@ -1,0 +1,1 @@
+return require("foo")

--- a/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/foo/lux.toml
+++ b/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/foo/lux.toml
@@ -1,0 +1,11 @@
+package = "foo"
+version = "1.0.0"
+lua = ">=5.1"
+
+[description]
+summary = ""
+maintainer = "lumen-labs"
+labels = [""]
+
+[run]
+args = ["src/main.lua"]

--- a/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/foo/src/foo.lua
+++ b/lux-lib/resources/test/sample-projects/multi-project-local-deps/projects/foo/src/foo.lua
@@ -1,0 +1,1 @@
+return true

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -67,6 +67,8 @@ struct DependencyTableEntry {
     #[serde(default)]
     git: Option<RemoteGitUrlShorthand>,
     #[serde(default)]
+    path: Option<PathBuf>,
+    #[serde(default)]
     rev: Option<String>,
 }
 
@@ -89,17 +91,17 @@ where
                         Ok(PackageReq { name, version_req }.into())
                     }
                     DependencyEntry::Detailed(entry) => {
-                        let source = match (entry.git, entry.rev) {
-                            (None, None) => Ok(None),
-                            (None, Some(_)) => Err(de::Error::custom(format!(
+                        let source = match (entry.git, entry.rev, entry.path) {
+                            (None, None, None) => Ok(None),
+                            (None, Some(_), None) => Err(de::Error::custom(format!(
                                 "dependency {} specifies a 'rev', but missing a 'git' field",
                                 &name
                             ))),
-                            (Some(git), Some(rev)) => Ok(Some(RockSourceSpec::Git(GitSource {
+                            (Some(git), Some(rev), None) => Ok(Some(RockSourceSpec::Git(GitSource {
                                 url: git.into(),
                                 checkout_ref: Some(rev),
                             }))),
-                            (Some(git), None) => Ok(Some(RockSourceSpec::Git(GitSource {
+                            (Some(git), None, None) => Ok(Some(RockSourceSpec::Git(GitSource {
                                 url: git.into(),
                                 checkout_ref: Some(
                                     entry
@@ -110,6 +112,11 @@ where
                                         .to_string(),
                                 ),
                             }))),
+                            (None, None, Some(path)) => Ok(Some(RockSourceSpec::File(path))),
+                            (_, _, Some(_)) => Err(de::Error::custom(format!(
+                                "dependency '{}' specifies a 'path', which cannot be combined with 'git' or 'rev'",
+                                &name
+                            ))),
                         }?;
                         Ok(LuaDependencySpec {
                             package_req: PackageReq {
@@ -315,14 +322,33 @@ impl PartialProjectToml {
             )?,
             // Merge dependencies internally with lua version
             // so the output of `dependencies()` is consistent
-            dependencies: PerPlatform::new(project_toml.dependencies.unwrap_or_default()),
+            dependencies: PerPlatform::new(
+                project_toml
+                    .dependencies
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|dep| self.resolve_lua_dependency_spec(dep))
+                    .collect_vec(),
+            ),
+            test_dependencies: PerPlatform::new(
+                project_toml
+                    .test_dependencies
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|dep| self.resolve_lua_dependency_spec(dep))
+                    .collect_vec(),
+            ),
             build_dependencies: PerPlatform::new(
-                project_toml.build_dependencies.unwrap_or_default(),
+                project_toml
+                    .build_dependencies
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|dep| self.resolve_lua_dependency_spec(dep))
+                    .collect_vec(),
             ),
             external_dependencies: PerPlatform::new(
                 project_toml.external_dependencies.unwrap_or_default(),
             ),
-            test_dependencies: PerPlatform::new(project_toml.test_dependencies.unwrap_or_default()),
             test: PerPlatform::new(TestSpec::try_from(
                 project_toml.test.clone().unwrap_or_default(),
             )?),
@@ -446,6 +472,17 @@ impl PartialProjectToml {
 
             // Keep the project root the same, as it is not part of the lua rockspec
             project_root: self.project_root,
+        }
+    }
+
+    fn resolve_lua_dependency_spec(&self, dep: LuaDependencySpec) -> LuaDependencySpec {
+        match &dep.source {
+            Some(RockSourceSpec::File(path)) if path.is_dir() => dep,
+            Some(RockSourceSpec::File(path)) => LuaDependencySpec {
+                source: Some(RockSourceSpec::File(self.project_root.join(path))),
+                ..dep
+            },
+            _ => dep,
         }
     }
 }

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -375,12 +375,12 @@ mod tests {
         let work_dir: PathBuf = workspace_root.join("projects");
         let workspace = Workspace::from(&work_dir).unwrap().unwrap();
         assert_eq!(workspace.members.len(), 2);
-        let foo = workspace.try_member(&Some("foo".into())).unwrap();
+        let foo = workspace.select_member(&"foo".into()).unwrap();
         assert_eq!(
             foo.root().to_path_buf(),
             workspace_root.join("projects/foo").to_path_buf()
         );
-        let bar = workspace.try_member(&Some("bar".into())).unwrap();
+        let bar = workspace.select_member(&"bar".into()).unwrap();
         assert_eq!(
             bar.root().to_path_buf(),
             workspace_root.join("projects/bar").to_path_buf()

--- a/lux-lib/tests/build_workspace.rs
+++ b/lux-lib/tests/build_workspace.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use assert_fs::prelude::PathCopy;
+use assert_fs::TempDir;
+use lux_lib::lua_version::LuaVersion;
+use lux_lib::operations::BuildWorkspace;
+use lux_lib::workspace::Workspace;
+use lux_lib::{config::ConfigBuilder, lua_installation::detect_installed_lua_version};
+
+#[tokio::test]
+async fn test_build_multi_workspace_local_dependencies() {
+    let sample_project: PathBuf = "resources/test/sample-projects/multi-project-local-deps".into();
+    let workspace_root = TempDir::new().unwrap();
+    workspace_root.copy_from(&sample_project, &["**"]).unwrap();
+
+    let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
+
+    let config = ConfigBuilder::new()
+        .unwrap()
+        .lua_version(lua_version.clone())
+        .build()
+        .unwrap();
+    let workspace = Workspace::from_exact(&workspace_root).unwrap().unwrap();
+    BuildWorkspace::new(&workspace, &config)
+        .no_lock(false)
+        .only_deps(false)
+        .build()
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Stacked on #1503.
Closes #1148.

For now, this builds local dependencies twice (once as a dependency, then as the main package).
In most cases, this should not be an issue, as we by default only force a rebuild for entrypoints. If it does turn out to be awkward, we can address it in a follow-up PR or  #1108.