### PR TITLE
feat(lua): restore platform build targets and add freebsd support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,6 @@
                   cmakeMinimal
                   zlib
                   gnum4
-                  readline
                 ])
                 ++ (lib.optional (!isDarwin) self.checks.${system}.git-hooks-check.enabledPackages)
                 ++ (lib.filter (pkg: !(lib.hasPrefix "lua" pkg.name)) pkgs.lux-cli.buildInputs)

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
                   cmakeMinimal
                   zlib
                   gnum4
+                  readline
                 ])
                 ++ (lib.optional (!isDarwin) self.checks.${system}.git-hooks-check.enabledPackages)
                 ++ (lib.filter (pkg: !(lib.hasPrefix "lua" pkg.name)) pkgs.lux-cli.buildInputs)

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -440,12 +440,19 @@ async fn do_build_lua_unix(
     let progress = args.progress;
     let install_dir = args.install_dir;
 
-    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", &pkg_version)));
+    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", pkg_version)));
 
-    let build_target = if cfg!(target_os = "linux") && matches!(&lua_version, LuaVersion::Lua54) {
-        "linux"
+    let build_target = if cfg!(target_os = "linux") {
+        if matches!(&lua_version, LuaVersion::Lua54) {
+            "linux"
+        } else {
+            "linux-readline"
+        }
+    } else if cfg!(target_os = "macos") {
+        "macosx"
+    } else if cfg!(target_os = "freebsd") {
+        "freebsd"
     } else {
-        // For other lua versions, the "linux" target uses readline.
         "generic"
     };
 

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -477,7 +477,7 @@ async fn do_build_lua_unix(
         Ok(output) if build_target != "generic" => {
             progress.map(|p| {
                 p.println(format!(
-                    r#"⚠️ WARNING: Could not build for platform '{build_target}'. Attempting a 'generic' platform build.
+                    r#"⚠️ WARNING: Could not build Lua target '{build_target}'. Attempting a 'generic' Lua target build.
 Some functionality may be limited, including dynamic module loading and REPL history.
     
 stderr:

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -440,8 +440,6 @@ async fn do_build_lua_unix(
     let progress = args.progress;
     let install_dir = args.install_dir;
 
-    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", pkg_version)));
-
     let build_target = if cfg!(target_os = "linux") {
         // only lua 5.4 has a specific `linux-readline` target
         if matches!(&lua_version, LuaVersion::Lua54) {
@@ -457,6 +455,13 @@ async fn do_build_lua_unix(
         "generic"
     };
 
+    progress.map(|p| {
+        p.set_message(format!(
+            "🛠️ Building Lua {} ({})",
+            pkg_version, build_target
+        ))
+    });
+
     match Command::new(config.make_cmd())
         .current_dir(build_dir)
         .stdout(Stdio::piped())
@@ -466,6 +471,43 @@ async fn do_build_lua_unix(
         .await
     {
         Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+        // The lua build may fail for some platform specific reason.
+        // Typically, the `readline` headers cannot be found. In these
+        // cases, try the build again with the `generic` platform target.
+        Ok(output) if build_target != "generic" => {
+            utils::log_command_output(&output, config);
+            progress.map(|p| {
+                p.println(format!(
+                    "Could not build for platform {build_target}. Attempting a generic platform build.\n{}",
+                    "Some functionality may be limited, including dynamic module loading and REPL history.",
+                ))
+            });
+            match Command::new(config.make_cmd())
+                .current_dir(build_dir)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .arg("generic")
+                .output()
+                .await
+            {
+                Ok(output) if output.status.success() => utils::log_command_output(&output, config),
+                Ok(output) => {
+                    return Err(BuildLuaError::CommandFailure {
+                        name: "build".into(),
+                        status: output.status,
+                        stdout: String::from_utf8_lossy(&output.stdout).into(),
+                        stderr: String::from_utf8_lossy(&output.stderr).into(),
+                    });
+                }
+                Err(err) => {
+                    return Err(BuildLuaError::Io(io::Error::other(format!(
+                        "Failed to run `{} build`:\n{}",
+                        config.make_cmd(),
+                        err,
+                    ))))
+                }
+            }
+        }
         Ok(output) => {
             return Err(BuildLuaError::CommandFailure {
                 name: "build".into(),

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -159,7 +159,7 @@ async fn do_build_luajit_unix(args: BuildLua<'_>, build_dir: &Path) -> Result<()
         _ => {}
     }
     let compiler_path = which::which(&compiler_path)
-        .map_err(|err| io::Error::other(format!("cannot find {}:\n{}", &compiler_path, err)))?;
+        .map_err(|err| io::Error::other(format!("cannot find {}:\n{}", compiler_path, err)))?;
     let compiler_path = compiler_path.to_slash_lossy().to_string();
     let compiler_args = compiler.cflags_env();
     let compiler_args = compiler_args.to_string_lossy();
@@ -392,7 +392,7 @@ async fn do_build_lua(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
             .unwrap_unchecked()
     };
 
-    progress.map(|p| p.set_message(format!("📥 Downloading {}", &source_url)));
+    progress.map(|p| p.set_message(format!("📥 Downloading {}", source_url)));
 
     let response = crate::reqwest::new_https_client(args.config)?
         .get(source_url)
@@ -482,7 +482,7 @@ async fn do_build_lua_unix(
         }
     };
 
-    progress.map(|p| p.set_message(format!("💻 Installing Lua {}", &pkg_version)));
+    progress.map(|p| p.set_message(format!("💻 Installing Lua {}", pkg_version)));
 
     match Command::new(config.make_cmd())
         .current_dir(build_dir)
@@ -524,7 +524,7 @@ async fn do_build_lua_msvc(
     let progress = args.progress;
     let install_dir = args.install_dir;
 
-    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", &pkg_version)));
+    progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", pkg_version)));
 
     let lib_dir = install_dir.join("lib");
     fs::create_dir_all(&lib_dir).await.map_err(|err| {
@@ -604,7 +604,7 @@ async fn do_build_lua_msvc(
         .out_dir(&src_dir)
         .try_compile_intermediates()?;
 
-    progress.map(|p| p.set_message(format!("💻 Installing Lua {}", &pkg_version)));
+    progress.map(|p| p.set_message(format!("💻 Installing Lua {}", pkg_version)));
 
     let target = host.to_string();
     let link =

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -475,11 +475,15 @@ async fn do_build_lua_unix(
         // Typically, the `readline` headers cannot be found. In these
         // cases, try the build again with the `generic` platform target.
         Ok(output) if build_target != "generic" => {
-            utils::log_command_output(&output, config);
             progress.map(|p| {
                 p.println(format!(
-                    "Could not build for platform {build_target}. Attempting a generic platform build.\n{}",
-                    "Some functionality may be limited, including dynamic module loading and REPL history.",
+                    r#"⚠️ WARNING: Could not build for platform '{build_target}'. Attempting a 'generic' platform build.
+Some functionality may be limited, including dynamic module loading and REPL history.
+    
+stderr:
+{}
+"#,
+                    String::from_utf8_lossy(&output.stderr)
                 ))
             });
             match Command::new(config.make_cmd())

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -443,10 +443,11 @@ async fn do_build_lua_unix(
     progress.map(|p| p.set_message(format!("🛠️ Building Lua {}", pkg_version)));
 
     let build_target = if cfg!(target_os = "linux") {
+        // only lua 5.4 has a specific `linux-readline` target
         if matches!(&lua_version, LuaVersion::Lua54) {
-            "linux"
-        } else {
             "linux-readline"
+        } else {
+            "linux"
         }
     } else if cfg!(target_os = "macos") {
         "macosx"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

This PR restores the correct platform build targets when building lua distributions.

The targets were actually removed in a previous commit, but this introduced a bug where, at least on macOS, `lx lua` could not load dynamic modules because it was compiling with the `generic` target. I went ahead and added a build target for `freebsd` as well for completeness, but I don't have a way to test/verify the target.

The previous commit and current behavior also make a distinction between lua version 5.4 and whether to use `linux-readline` or the `linux` build target. I kept this branch in, but I don't know how necessary it is.

I also removed some redundant references on strings because of a clippy warning.

I think this should also fix issues when running tests on non-5.4 lua versions, which I believed was caused by the incorrect version handling in the build path.

<!-- Please check what applies. -->

- [X] Fits [CONTRIBUTING.md].
- [X] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
