### PR TITLE
fix(gen-rockspec): multi-line strings and quotes

### DIFF
--- a/lux-lib/src/lua_rockspec/serde_util.rs
+++ b/lux-lib/src/lua_rockspec/serde_util.rs
@@ -189,6 +189,8 @@ impl Display for DisplayLuaValue {
             DisplayLuaValue::String(s) => {
                 if s.contains('\n') {
                     write!(buf, "[[\n{s}\n]]")?;
+                } else if s.contains("\"") {
+                    write!(buf, "'{s}'")?;
                 } else {
                     write!(buf, "\"{s}\"")?;
                 }
@@ -314,6 +316,9 @@ mod tests {
     fn display_lua_value() {
         let value = DisplayLuaValue::String("hello".to_string());
         assert_eq!(format!("{value}"), "\"hello\"");
+
+        let value = DisplayLuaValue::String("foo\"bar".to_string());
+        assert_eq!(format!("{value}"), "'foo\"bar'");
 
         let value = DisplayLuaValue::String(
             r#"first line

--- a/lux-lib/src/lua_rockspec/serde_util.rs
+++ b/lux-lib/src/lua_rockspec/serde_util.rs
@@ -320,6 +320,9 @@ mod tests {
         let value = DisplayLuaValue::String("foo\"bar".to_string());
         assert_eq!(format!("{value}"), "'foo\"bar'");
 
+        let value = DisplayLuaValue::String(r#"foo\\bar"#.to_string());
+        assert_eq!(format!("{value}"), r#""foo\\bar""#);
+
         let value = DisplayLuaValue::String(
             r#"first line
 second line"#

--- a/lux-lib/src/lua_rockspec/serde_util.rs
+++ b/lux-lib/src/lua_rockspec/serde_util.rs
@@ -186,7 +186,13 @@ impl Display for DisplayLuaValue {
             //DisplayLuaValue::Nil => write!(f, "nil"),
             //DisplayLuaValue::Number(n) => write!(f, "{n}"),
             DisplayLuaValue::Boolean(b) => write!(buf, "{b}")?,
-            DisplayLuaValue::String(s) => write!(buf, "\"{s}\"")?,
+            DisplayLuaValue::String(s) => {
+                if s.contains('\n') {
+                    write!(buf, "[[\n{s}\n]]")?;
+                } else {
+                    write!(buf, "\"{s}\"")?;
+                }
+            }
             DisplayLuaValue::List(l) => {
                 writeln!(buf, "{{")?;
                 for item in l {
@@ -308,6 +314,13 @@ mod tests {
     fn display_lua_value() {
         let value = DisplayLuaValue::String("hello".to_string());
         assert_eq!(format!("{value}"), "\"hello\"");
+
+        let value = DisplayLuaValue::String(
+            r#"first line
+second line"#
+                .to_string(),
+        );
+        assert_eq!(format!("{value}"), "[[\nfirst line\nsecond line\n]]");
 
         let value = DisplayLuaValue::Boolean(true);
         assert_eq!(format!("{value}"), "true");


### PR DESCRIPTION
Fixes #1531.