### PR TITLE
feat(generate-rockspec): add `--porcelain` flag

### DIFF
--- a/lux-cli/src/generate_rockspec.rs
+++ b/lux-cli/src/generate_rockspec.rs
@@ -16,17 +16,22 @@ pub struct GenerateRockspec {
 
 pub async fn generate_rockspec(data: GenerateRockspec) -> Result<()> {
     let workspace = Workspace::current_or_err()?;
+
+    let targets: Vec<&Project> = match &data.package {
+        Some(package) => vec![workspace.select_member(package)?],
+        None => workspace.members().into_iter().collect(),
+    };
+
     let mut generated_paths = Vec::new();
 
-    if let Some(package) = data.package {
-        let path =
-            generate_project_rockspec(workspace.select_member(&package)?, data.porcelain).await?;
-        generated_paths.push(path.to_string_lossy().into_owned());
-    } else {
-        for project in workspace.members() {
-            let path = generate_project_rockspec(project, data.porcelain).await?;
-            generated_paths.push(path.to_string_lossy().into_owned());
+    for project in targets {
+        let path = generate_project_rockspec(project).await?;
+
+        if !data.porcelain {
+            println!("Wrote rockspec to {}", path.display());
         }
+
+        generated_paths.push(path.to_string_lossy().into_owned());
     }
 
     // If porcelain mode is active, print all gathered paths as a single JSON array
@@ -37,7 +42,7 @@ pub async fn generate_rockspec(data: GenerateRockspec) -> Result<()> {
     Ok(())
 }
 
-async fn generate_project_rockspec(project: &Project, porcelain: bool) -> Result<PathBuf> {
+async fn generate_project_rockspec(project: &Project) -> Result<PathBuf> {
     let toml = project.toml().into_remote(None)?;
     let rockspec = toml.to_lua_remote_rockspec_string()?;
 
@@ -46,10 +51,6 @@ async fn generate_project_rockspec(project: &Project, porcelain: bool) -> Result
         .join(format!("{}-{}.rockspec", toml.package(), toml.version()));
 
     tokio::fs::write(&path, rockspec).await?;
-
-    if !porcelain {
-        println!("Wrote rockspec to {}", path.display());
-    }
 
     Ok(path)
 }

--- a/lux-cli/src/generate_rockspec.rs
+++ b/lux-cli/src/generate_rockspec.rs
@@ -1,28 +1,43 @@
 use clap::Args;
 use eyre::Result;
 use lux_lib::{package::PackageName, project::Project, rockspec::Rockspec, workspace::Workspace};
+use std::path::PathBuf;
 
 #[derive(Args)]
 pub struct GenerateRockspec {
     /// Package to generate the rockspec for.
     #[arg(short, long, visible_short_alias = 'p')]
     package: Option<PackageName>,
+
+    /// Control the command's output to emit a JSON list of paths.
+    #[arg(long)]
+    porcelain: bool,
 }
 
 pub async fn generate_rockspec(data: GenerateRockspec) -> Result<()> {
     let workspace = Workspace::current_or_err()?;
+    let mut generated_paths = Vec::new();
 
     if let Some(package) = data.package {
-        generate_project_rockspec(workspace.select_member(&package)?).await
+        let path =
+            generate_project_rockspec(workspace.select_member(&package)?, data.porcelain).await?;
+        generated_paths.push(path.to_string_lossy().into_owned());
     } else {
         for project in workspace.members() {
-            generate_project_rockspec(project).await?;
+            let path = generate_project_rockspec(project, data.porcelain).await?;
+            generated_paths.push(path.to_string_lossy().into_owned());
         }
-        Ok(())
     }
+
+    // If porcelain mode is active, print all gathered paths as a single JSON array
+    if data.porcelain {
+        println!("{}", serde_json::to_string(&generated_paths)?);
+    }
+
+    Ok(())
 }
 
-async fn generate_project_rockspec(project: &Project) -> Result<()> {
+async fn generate_project_rockspec(project: &Project, porcelain: bool) -> Result<PathBuf> {
     let toml = project.toml().into_remote(None)?;
     let rockspec = toml.to_lua_remote_rockspec_string()?;
 
@@ -32,6 +47,9 @@ async fn generate_project_rockspec(project: &Project) -> Result<()> {
 
     tokio::fs::write(&path, rockspec).await?;
 
-    println!("Wrote rockspec to {}", path.display());
-    Ok(())
+    if !porcelain {
+        println!("Wrote rockspec to {}", path.display());
+    }
+
+    Ok(path)
 }

--- a/lux-cli/src/generate_rockspec.rs
+++ b/lux-cli/src/generate_rockspec.rs
@@ -9,7 +9,7 @@ pub struct GenerateRockspec {
     #[arg(short, long, visible_short_alias = 'p')]
     package: Option<PackageName>,
 
-    /// Control the command's output to emit a JSON list of paths.
+    /// Output a JSON list of paths to the generated rockspecs.
     #[arg(long)]
     porcelain: bool,
 }
@@ -34,7 +34,6 @@ pub async fn generate_rockspec(data: GenerateRockspec) -> Result<()> {
         generated_paths.push(path.to_string_lossy().into_owned());
     }
 
-    // If porcelain mode is active, print all gathered paths as a single JSON array
     if data.porcelain {
         println!("{}", serde_json::to_string(&generated_paths)?);
     }


### PR DESCRIPTION
Hi! This is my first time contributing to this crate, so please let me know if I missed any conventions or need to adjust anything.

### What this PR does
This PR introduces a `--porcelain` flag to the `generate-rockspec` command to provide machine-readable output. 

### Changes Made
- Added the `porcelain: bool` flag to the `GenerateRockspec` arguments struct.
- Modified `generate_rockspec` to collect `generated_paths` during execution.
- Conditionalized the standard console logs to only trigger when `--porcelain` is false.
- Serialized and printed the collected paths as JSON upon successful execution.

### Local Testing Notes

The logic simply hooks into and reuses the existing codebase design, but I am currently experiencing an environment issue trying to compile the test suite locally. Even when switching back to the main branch, I am hitting an mlua-sys build error regarding duplicate feature flags:

    compile_error!("You can enable only one of the features: lua55, lua54, lua53, lua52, lua51, luajit, luajit52, luau");

Because of this local blocker, I wanted to open this PR to see if the automated CI environment compiles and passes successfully, or if there is something I need to fix in my code or environment.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [ x ] Fits [CONTRIBUTING.md].
- [ x ] Fits [No LLM / No AI Policy].

Closes #1553

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy