### PR TITLE
docs(config): add documentation for `Config` and `ConfigBuilder`

### DIFF
--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -23,6 +23,9 @@ const DEFAULT_USER_AGENT: &str = concat!("lux-lib/", env!("CARGO_PKG_VERSION"));
 #[error("could not find a valid home directory")]
 pub struct NoValidHomeDirectory;
 
+/// This holds the live configuration values used across `lux`.
+/// It's completely immutable once built, so you can't just change these fields on the fly.
+/// If you need to build one or modify settings, use `ConfigBuilder`.
 #[derive(Debug, Clone)]
 pub struct Config {
     enable_development_packages: bool,
@@ -215,6 +218,9 @@ pub enum ConfigError {
     CompilerToolchain(#[from] cc::Error),
 }
 
+/// A flexible builder pattern struct for assembling a `Config`.
+/// Everything here is an `Option` so we can overlay configurations
+/// (e.g., read file defaults first, then override with CLI arguments).
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct ConfigBuilder {
     #[serde(

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -24,7 +24,7 @@ const DEFAULT_USER_AGENT: &str = concat!("lux-lib/", env!("CARGO_PKG_VERSION"));
 pub struct NoValidHomeDirectory;
 
 /// The resolved configuration for a Lux session.
-/// Can be constructed via [``ConfigBuilder``], which supports layering multiple
+/// Can be constructed via [`ConfigBuilder`], which supports layering multiple
 /// configuration sources (config file, CLI flags, environment variables).
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -23,9 +23,9 @@ const DEFAULT_USER_AGENT: &str = concat!("lux-lib/", env!("CARGO_PKG_VERSION"));
 #[error("could not find a valid home directory")]
 pub struct NoValidHomeDirectory;
 
-/// This holds the live configuration values used across `lux`.
-/// It's completely immutable once built, so you can't just change these fields on the fly.
-/// If you need to build one or modify settings, use `ConfigBuilder`.
+/// The resolved configuration for a Lux session.
+/// Can be constructed via [``ConfigBuilder``], which supports layering multiple
+/// configuration sources (config file, CLI flags, environment variables).
 #[derive(Debug, Clone)]
 pub struct Config {
     enable_development_packages: bool,
@@ -218,9 +218,12 @@ pub enum ConfigError {
     CompilerToolchain(#[from] cc::Error),
 }
 
-/// A flexible builder pattern struct for assembling a `Config`.
-/// Everything here is an `Option` so we can overlay configurations
-/// (e.g., read file defaults first, then override with CLI arguments).
+/// Incrementally builds a [`Config`] by layering configuration sources.
+///
+/// - Call [`ConfigBuilder::default`] to start with a blank slate,
+///   or call [`ConfigBuilder::new`] to start from a deserialised configuration file.
+/// - Populate the fields from overriding sources (e.g. CLI arguments).
+/// - Finish with [`ConfigBuilder::build`].
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct ConfigBuilder {
     #[serde(


### PR DESCRIPTION
### Summary

- Added docstring for `Config` struct
- Added docstring for `ConfigBuilder` struct

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [ x ] Fits [CONTRIBUTING.md].
- [ x ] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
