### PR TITLE
fix(build)!: read-only file system error when `src/init.lua` exists

### DIFF
--- a/lux-lib/src/build/builtin.rs
+++ b/lux-lib/src/build/builtin.rs
@@ -13,7 +13,7 @@ use crate::{
         backend::{BuildBackend, BuildInfo, RunBuildArgs},
         utils,
     },
-    lua_rockspec::{BuiltinBuildSpec, LuaModule, ModuleSpec},
+    lua_rockspec::{BuiltinBuildSpec, LuaModule, ModuleSpec, ParseLuaModuleError},
     tree::TreeError,
 };
 
@@ -31,6 +31,8 @@ pub enum BuiltinBuildError {
     Io(#[from] io::Error),
     #[error(transparent)]
     Tree(#[from] TreeError),
+    #[error(transparent)]
+    ParseLuaModule(#[from] ParseLuaModuleError),
 }
 
 impl BuildBackend for BuiltinBuildSpec {
@@ -46,7 +48,7 @@ impl BuildBackend for BuiltinBuildSpec {
         let progress = args.progress;
 
         // Detect all Lua modules
-        let modules = autodetect_modules(build_dir, source_paths(build_dir, &self.modules))
+        let modules = autodetect_modules(build_dir, source_paths(build_dir, &self.modules))?
             .into_iter()
             .chain(self.modules)
             .collect::<HashMap<_, _>>();
@@ -153,7 +155,7 @@ fn source_paths(build_dir: &Path, modules: &HashMap<LuaModule, ModuleSpec>) -> H
 fn autodetect_modules(
     build_dir: &Path,
     exclude: HashSet<PathBuf>,
-) -> HashMap<LuaModule, ModuleSpec> {
+) -> Result<HashMap<LuaModule, ModuleSpec>, ParseLuaModuleError> {
     WalkDir::new(build_dir.join("src"))
         .into_iter()
         .chain(WalkDir::new(build_dir.join("lua")))
@@ -183,20 +185,28 @@ fn autodetect_modules(
             // The rockspec requires the format to be like this, and representing our
             // data in this form allows us to respect any overrides made by the user (which follow
             // the `module.name` format, not our internal one).
-            let pathbuf = diff.components().skip(1).collect::<PathBuf>();
-            let mut lua_module = LuaModule::from_pathbuf(pathbuf);
-
-            // NOTE(mrcjkb): `LuaModule` does not parse as "<module>.init" from files named "init.lua"
-            // To make sure we don't change the file structure when installing, we append it here.
-            if file.file_name().to_string_lossy().as_bytes() == b"init.lua" {
-                unsafe {
-                    lua_module = lua_module.join(&LuaModule::from_str("init").unwrap_unchecked())
+            let mut pathbuf = diff.components().skip(1).collect::<PathBuf>();
+            let lua_module = if pathbuf
+                .parent()
+                .is_none_or(|parent| parent.as_os_str().is_empty())
+            {
+                pathbuf.set_extension("");
+                LuaModule::from_pathbuf(pathbuf)
+            } else {
+                let mut lua_module = LuaModule::from_pathbuf(pathbuf)?;
+                // NOTE(mrcjkb): `LuaModule` does not parse as "<module>.init" from files named "init.lua"
+                // To make sure we don't change the file structure when installing, we append it here.
+                if file.file_name().to_string_lossy().as_bytes() == b"init.lua" {
+                    unsafe {
+                        lua_module =
+                            lua_module.join(&LuaModule::from_str("init").unwrap_unchecked())
+                    }
                 }
-            }
-
-            (lua_module, ModuleSpec::SourcePath(diff))
+                Ok(lua_module)
+            };
+            lua_module.map(|lua_module| (lua_module, ModuleSpec::SourcePath(diff)))
         })
-        .collect()
+        .try_collect()
 }
 
 fn autodetect_bin_scripts(build_dir: &Path) -> Vec<PathBuf> {

--- a/lux-lib/src/lua_rockspec/build/builtin.rs
+++ b/lux-lib/src/lua_rockspec/build/builtin.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use path_slash::PathBufExt;
 use serde::{de, Deserialize, Deserializer};
 use std::{collections::HashMap, convert::Infallible, fmt::Display, path::PathBuf, str::FromStr};
 use thiserror::Error;
@@ -43,7 +44,7 @@ impl LuaModule {
         PathBuf::from(self.0.replace('.', std::path::MAIN_SEPARATOR_STR) + extension)
     }
 
-    pub fn from_pathbuf(path: PathBuf) -> Self {
+    pub fn from_pathbuf(path: PathBuf) -> Result<Self, ParseLuaModuleError> {
         let extension = path
             .extension()
             .map(|ext| ext.to_string_lossy().to_string())
@@ -54,7 +55,13 @@ impl LuaModule {
             .trim_end_matches(format!(".{extension}").as_str())
             .trim_end_matches(std::path::MAIN_SEPARATOR_STR)
             .replace(std::path::MAIN_SEPARATOR_STR, ".");
-        LuaModule(module)
+        if module.is_empty() {
+            Err(ParseLuaModuleError::EmptyModule(
+                path.to_slash_lossy().to_string(),
+            ))
+        } else {
+            Ok(LuaModule(module))
+        }
     }
 
     pub fn join(&self, other: &LuaModule) -> LuaModule {
@@ -67,15 +74,23 @@ impl LuaModule {
 }
 
 #[derive(Error, Debug)]
-#[error("could not parse lua module from {0}.")]
-pub struct ParseLuaModuleError(String);
+pub enum ParseLuaModuleError {
+    #[error("could not parse Lua module from '{0}'.")]
+    FromString(String),
+    #[error("path '{0}' resulted in an empty Lua module.")]
+    EmptyModule(String),
+}
 
 impl FromStr for LuaModule {
     type Err = ParseLuaModuleError;
 
-    // NOTE: We may want to add some validations
+    // NOTE: We may want to add some additional validations
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(LuaModule(s.into()))
+        if s.is_empty() {
+            Err(ParseLuaModuleError::EmptyModule(s.into()))
+        } else {
+            Ok(LuaModule(s.into()))
+        }
     }
 }
 
@@ -432,13 +447,13 @@ mod tests {
 
     #[tokio::test]
     pub async fn parse_lua_module_from_path() {
-        let lua_module = LuaModule::from_pathbuf("foo/init.lua".into());
+        let lua_module = LuaModule::from_pathbuf("foo/init.lua".into()).unwrap();
         assert_eq!(&lua_module.0, "foo");
-        let lua_module = LuaModule::from_pathbuf("foo/bar.lua".into());
+        let lua_module = LuaModule::from_pathbuf("foo/bar.lua".into()).unwrap();
         assert_eq!(&lua_module.0, "foo.bar");
-        let lua_module = LuaModule::from_pathbuf("foo/bar/init.lua".into());
+        let lua_module = LuaModule::from_pathbuf("foo/bar/init.lua".into()).unwrap();
         assert_eq!(&lua_module.0, "foo.bar");
-        let lua_module = LuaModule::from_pathbuf("foo/bar/baz.lua".into());
+        let lua_module = LuaModule::from_pathbuf("foo/bar/baz.lua".into()).unwrap();
         assert_eq!(&lua_module.0, "foo.bar.baz");
     }
 

--- a/lux-lib/src/lua_rockspec/build/mod.rs
+++ b/lux-lib/src/lua_rockspec/build/mod.rs
@@ -4,17 +4,14 @@ mod make;
 mod rust_mlua;
 mod tree_sitter;
 
-pub use builtin::{BuiltinBuildSpec, LuaModule, ModulePaths, ModuleSpec};
+pub use builtin::{BuiltinBuildSpec, LuaModule, ModulePaths, ModuleSpec, ParseLuaModuleError};
 pub use cmake::*;
 pub use make::*;
 use path_slash::PathBufExt;
 pub use rust_mlua::*;
 pub use tree_sitter::*;
 
-use builtin::{
-    ModulePathsMissingSources, ModuleSpecAmbiguousPlatformOverride, ModuleSpecInternal,
-    ParseLuaModuleError,
-};
+use builtin::{ModulePathsMissingSources, ModuleSpecAmbiguousPlatformOverride, ModuleSpecInternal};
 
 use itertools::Itertools;
 

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -319,4 +319,40 @@ mod tests {
         assert!(bin_dir.join("foo").is_file());
         assert!(bin_dir.join("bar").is_file());
     }
+
+    #[tokio::test]
+    /// Non-regression for #1563
+    async fn builtin_build_support_src_init_lua() {
+        let data_dir: PathBuf = assert_fs::TempDir::new().unwrap().path().into();
+        let project_root =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/sample-projects/init/");
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        temp_dir.copy_from(&project_root, &["**"]).unwrap();
+        let project_root = temp_dir.path();
+        let src_dir = project_root.join("src");
+        tokio::fs::create_dir_all(&src_dir).await.unwrap();
+        let init_lua_file = src_dir.join("init.lua");
+        tokio::fs::write(&init_lua_file, "print('hello')")
+            .await
+            .unwrap();
+        let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
+        let config = ConfigBuilder::new()
+            .unwrap()
+            .data_dir(Some(data_dir))
+            .lua_version(lua_version)
+            .build()
+            .unwrap();
+        let workspace = Workspace::from_exact(project_root).unwrap().unwrap();
+        let package = BuildWorkspace::new(&workspace, &config)
+            .no_lock(false)
+            .only_deps(false)
+            .build()
+            .await
+            .unwrap();
+        let package = package.first().unwrap();
+        let tree = workspace.tree(&config).unwrap();
+        let layout = tree.installed_rock_layout(package).unwrap();
+        let src_dir = layout.src;
+        assert!(src_dir.join("init.lua").is_file());
+    }
 }


### PR DESCRIPTION
Fixes #1563.

This is breaking for `lux-lib`, because it propagates `ParseLuaModuleError` as a build error.