### PR TITLE
refactor(test): rename test modules to tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,9 @@ We use the following tools:
 
 ### Nix dev shell
 
-- Requires [flakes](https://nixos.wiki/wiki/Flakes) to be enabled.
+> [!IMPORTANT]
+>
+> Requires [flakes](https://nixos.wiki/wiki/Flakes) to be enabled.
 
 For Nix users, we provide a `devShell` that can bootstrap
 everything needed to build, format and lint Lux.
@@ -66,7 +68,7 @@ everything needed to build, format and lint Lux.
 To enter a development shell:
 
 ```console
-nix develop
+nix develop ".#lua51-ci"
 ```
 
 To apply formatting and run linters, run

--- a/lux-cli/src/add.rs
+++ b/lux-cli/src/add.rs
@@ -128,7 +128,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use assert_fs::{prelude::PathCopy, TempDir};
     use lux_lib::config::ConfigBuilder;
     use serial_test::serial;

--- a/lux-cli/src/run_lua.rs
+++ b/lux-cli/src/run_lua.rs
@@ -167,7 +167,7 @@ Build options (if running a repl for a project):
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::path::PathBuf;
 
     use lux_lib::config::ConfigBuilder;

--- a/lux-lib/src/build/patch.rs
+++ b/lux-lib/src/build/patch.rs
@@ -136,7 +136,7 @@ pub(crate) fn do_apply(args: Patch<'_>) -> Result<(), PatchError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{config::ConfigBuilder, progress::MultiProgress};
 
     use super::*;

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -524,7 +524,7 @@ fn parse_lua_version_from_output(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{config::ConfigBuilder, progress::MultiProgress};
 
     use super::*;

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -240,7 +240,7 @@ async fn install_manifest_entries<T>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use io::Read;
 

--- a/lux-lib/src/operations/fetch_vendored.rs
+++ b/lux-lib/src/operations/fetch_vendored.rs
@@ -153,7 +153,7 @@ fn load_vendored_package(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use assert_fs::{
         prelude::{FileTouch, FileWriteStr, PathChild, PathCreateDir},
         TempDir,

--- a/lux-lib/src/operations/gen_luarc.rs
+++ b/lux-lib/src/operations/gen_luarc.rs
@@ -136,7 +136,7 @@ fn update_luarc_content(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::*;
 

--- a/lux-lib/src/operations/run_lua.rs
+++ b/lux-lib/src/operations/run_lua.rs
@@ -180,7 +180,7 @@ async fn detect_lua_module(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::str::FromStr;
 
     use super::*;

--- a/lux-lib/src/package/outdated.rs
+++ b/lux-lib/src/package/outdated.rs
@@ -65,7 +65,7 @@ impl Display for PackageSpec {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::path::PathBuf;
 
     use url::Url;

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -220,7 +220,7 @@ impl Display for BinPath {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/lux-lib/src/remote_package_source/mod.rs
+++ b/lux-lib/src/remote_package_source/mod.rs
@@ -115,7 +115,7 @@ impl<'de> Deserialize<'de> for RemotePackageSource {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     const LUAROCKS_ROCKSPEC: &str = "

--- a/lux-lib/src/rockspec/lua_dependency.rs
+++ b/lux-lib/src/rockspec/lua_dependency.rs
@@ -175,7 +175,7 @@ pub enum LuaDependencyType<T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use ottavino::{Closure, Executor, Fuel, Lua, Value};
     use ottavino_util::serde::from_value;

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -102,7 +102,7 @@ fn do_search(which: Which<'_>) -> Result<PathBuf, WhichError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
     use assert_fs::prelude::PathCopy;


### PR DESCRIPTION
Closes #1572.
Renamed test modules to `tests` for consistency and updated `CONTRIBUTING.md` to use the Lua CI development shell.

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
