### PR TITLE
style: use single quotes for error messages

### DIFF
--- a/lux-lib/src/build/cmake.rs
+++ b/lux-lib/src/build/cmake.rs
@@ -37,7 +37,7 @@ pub enum CMakeError {
     Io(io::Error),
     #[error("failed to write CMakeLists.txt: {0}")]
     WriteCmakeListsError(io::Error),
-    #[error("failed to run `cmake` step: `{0}` command not found!")]
+    #[error("failed to run `cmake` step: '{0}' command not found!")]
     CommandNotFound(String),
     #[error(transparent)]
     VariableSubstitutionError(#[from] VariableSubstitutionError),

--- a/lux-lib/src/build/make.rs
+++ b/lux-lib/src/build/make.rs
@@ -34,7 +34,7 @@ pub enum MakeError {
     },
     #[error("failed to run `make` step: {0}")]
     Io(io::Error),
-    #[error("failed to run `make` step: `{0}` command not found!")]
+    #[error("failed to run `make` step: '{0}' command not found!")]
     CommandNotFound(String),
     #[error(transparent)]
     VariableSubstitutionError(#[from] VariableSubstitutionError),

--- a/lux-lib/src/lua_rockspec/partial.rs
+++ b/lux-lib/src/lua_rockspec/partial.rs
@@ -33,7 +33,7 @@ pub struct PartialLuaRockspec {
 pub enum PartialRockspecError {
     #[error("rockspec execution exceeded fuel limit of {ROCKSPEC_FUEL_LIMIT} steps")]
     FuelLimitExceeded,
-    #[error("field `{0}` should not be declared in extra.rockspec")]
+    #[error("field '{0}' should not be declared in extra.rockspec")]
     ExtraneousField(String),
     #[error("error while parsing rockspec: {0}")]
     Lua(#[from] ottavino::ExternError),

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -85,7 +85,7 @@ pub enum ExecError {
     InstallCommand(#[from] InstallCommandError),
     #[error(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
-    #[error("failed to execute `{0}`:\n{1}")]
+    #[error("failed to execute '{0}':\n{1}")]
     Io(String, io::Error),
 }
 

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -21,7 +21,7 @@ use crate::{
 use super::RunLuaError;
 
 #[derive(Debug, Error)]
-#[error("`{0}` should not be used as a `command` as it is not cross-platform.
+#[error("'{0}' should not be used as a `command` as it is not cross-platform.
 You should only change the default `command` if it is a different Lua interpreter that behaves identically on all platforms.
 Consider removing the `command` field and letting Lux choose the default Lua interpreter instead.")]
 pub struct RunCommandError(String);

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -88,7 +88,7 @@ pub enum RunTestsError {
     BuildProject(#[from] BuildWorkspaceError),
     #[error("tests failed!")]
     TestFailure,
-    #[error("failed to execute `{0}`: {1}")]
+    #[error("failed to execute '{0}': {1}")]
     RunCommandFailure(String, io::Error),
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -113,7 +113,7 @@ pub enum UploadError {
     ApiKeyUnspecified(#[from] ApiKeyUnspecified),
     ValidationError(#[from] RemoteProjectTomlValidationError),
     #[error(
-        "unsupported version: `{0}`.\nLux can upload packages with a SemVer version, 'dev' or 'scm'"
+        "unsupported version: '{0}'.\nLux can upload packages with a SemVer version, 'dev' or 'scm'"
     )]
     UnsupportedVersion(String),
     #[error("{0}")] // We don't know the concrete error type

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -54,21 +54,21 @@ pub enum WorkspaceError {
     ReadLuxTOML(String, io::Error),
     #[error("error deserializing workspace TOML:\n{0}")]
     TOML(String),
-    #[error("no project found at `{0}`")]
+    #[error("no project found at '{0}'")]
     ProjectNotFound(PathBuf),
     #[error("error deserializing project TOML:\n{0}")]
     Project(#[from] ProjectError),
     #[error("no project or workspace found")]
     NoWorkspaceOrProject,
-    #[error("empty workspace at `{0}`")]
+    #[error("empty workspace at '{0}'")]
     EmptyWorkspace(PathBuf),
     #[error(transparent)]
     Lockfile(#[from] LockfileError),
-    #[error("not a lux project or workspace directory:\n`{0}`")]
+    #[error("not a lux project or workspace directory:\n'{0}'")]
     NotAWorkspaceDir(PathBuf),
     #[error("package must be specified in a multi-project workspace")]
     NoPackageSpecified,
-    #[error("package `{0}` not found in workspace `{1}`")]
+    #[error("package '{0}' not found in workspace '{1}'")]
     PackageNotFound(PackageName, WorkspaceRoot),
 }
 


### PR DESCRIPTION
### Summary
Changed backticks to use single quotes across error. I'm unsure if something like `make` should be changed too though, lmk if you want them to be changed as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [ x ] Fits [CONTRIBUTING.md].
- [ x ] Fits [No LLM / No AI Policy].

resolves #1575 

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
