### PR TITLE
fix(dependencies)!: improve git remote URL parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,30 +2097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "git-url-parse"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
-dependencies = [
- "getset",
- "nom 8.0.0",
- "thiserror 2.0.18",
- "url",
-]
-
-[[package]]
 name = "git2"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,7 +3275,6 @@ dependencies = [
  "emmylua_codestyle",
  "emmylua_formatter",
  "eyre",
- "git-url-parse",
  "git2",
  "ignore",
  "indicatif",
@@ -3351,7 +3326,6 @@ dependencies = [
  "flate2",
  "fs_extra",
  "futures",
- "git-url-parse",
  "git2",
  "glob",
  "gpgme",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ mlua = { version = "0.11", features = [
   "error-send",
   "async",
 ] }
-git-url-parse = "0.6"
 git2 = { version = "0.21", features = ["ssh", "https"] }
 ignore = "0.4"
 indicatif = "0.18"

--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -36,7 +36,6 @@ text_trees = "0.1"
 url = "2.5"
 whoami = "2.1"
 
-git-url-parse = { workspace = true }
 git2 = { workspace = true }
 ignore = { workspace = true }
 indicatif = { workspace = true }

--- a/lux-cli/src/utils/github_metadata.rs
+++ b/lux-cli/src/utils/github_metadata.rs
@@ -50,7 +50,7 @@ pub async fn get_metadata_for(directory: Option<&PathBuf>) -> Result<Option<Repo
             None => return Ok(None),
         };
 
-        let repo = parsed_url.repo().into_owned();
+        let repo = parsed_url.repo().to_string();
 
         let octocrab = octocrab::instance();
         let repo_handler = octocrab.repos(owner, repo);

--- a/lux-cli/src/utils/github_metadata.rs
+++ b/lux-cli/src/utils/github_metadata.rs
@@ -1,7 +1,6 @@
 use eyre::Result;
 use git2::Repository;
-use git_url_parse::types::provider::GenericProvider;
-use git_url_parse::GitUrl;
+use lux_lib::git::url::RemoteGitUrl;
 use path_absolutize::Absolutize as _;
 use std::io;
 use std::path::Path;
@@ -44,10 +43,14 @@ pub async fn get_metadata_for(directory: Option<&PathBuf>) -> Result<Option<Repo
 
     // NOTE(vhyrro): Temporary value is required. Thank the borrow checker.
     let ret = if let Ok(remote) = repo.find_remote("origin")?.url() {
-        let parsed_url = GitUrl::parse(remote)?;
-        let provider: GenericProvider = parsed_url.provider_info()?;
+        let parsed_url: RemoteGitUrl = remote.parse()?;
 
-        let (owner, repo) = (provider.owner().to_string(), provider.repo().to_string());
+        let owner = match parsed_url.owner() {
+            Some(owner) => owner.to_owned(),
+            None => return Ok(None),
+        };
+
+        let repo = parsed_url.repo().into_owned();
 
         let octocrab = octocrab::instance();
         let repo_handler = octocrab.repos(owner, repo);

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -72,7 +72,6 @@ tree-sitter-loader = "0.26"
 url = "2.5"
 vfs = "0.13"
 
-git-url-parse = { workspace = true }
 git2 = { workspace = true }
 ignore = { workspace = true }
 indicatif = { workspace = true }

--- a/lux-lib/src/git/shorthand.rs
+++ b/lux-lib/src/git/shorthand.rs
@@ -136,59 +136,70 @@ fn prefix_parser<'a>(
         })
 }
 
-// A more lenient parser that defaults to github: if there is not prefix
+// A parser for scp-style git URLs, converting them into ssh: URLs.
+fn scp_style_parser<'a>(
+) -> impl Parser<'a, &'a str, RemoteGitUrlShorthand, chumsky::extra::Err<Rich<'a, char>>> {
+    none_of(":/")
+        .repeated()
+        .collect::<String>()
+        .then(
+            just(':')
+                .ignore_then(just("//").not())
+                .ignore_then(any().repeated().collect::<String>()),
+        )
+        .try_map(|(host, path), span| {
+            let inner = format!("git+ssh://{host}/{path}")
+                .parse::<RemoteGitUrl>()
+                .map_err(|err| {
+                    Rich::custom(span, format!("error parsing scp style git url: {err}"))
+                })?;
+            Ok(RemoteGitUrlShorthand(inner))
+        })
+}
+
+// A parser that tries to parse as such:
+//
+// * If it can be parsed exactly as one of our shorthand prefixes, it is expanded into that host reference.
+// * If it can be parsed as a simple owner/repo pair, it is considered to be a github shorthand reference.
+// * If the string has at least one colon, and the first colon does not follow any slashes and is not immediately followed by two slashes, it is considered to be in scp style.
 fn parser<'a>(
 ) -> impl Parser<'a, &'a str, RemoteGitUrlShorthand, chumsky::extra::Err<Rich<'a, char>>> {
-    let git_host_prefix = just(GITHUB)
-        .or(just(GITLAB).or(just(SOURCEHUT).or(just(CODEBERG))))
-        .then_ignore(just(":"))
-        .or_not()
-        .map(|prefix| match prefix {
-            Some(GITHUB) => GitHost::Github,
-            Some(GITLAB) => GitHost::Gitlab,
-            Some(SOURCEHUT) => GitHost::Sourcehut,
-            Some(CODEBERG) => GitHost::Codeberg,
-            _ => GitHost::default(),
-        });
-    let owner_repo = none_of('/')
+    let owner_repo = none_of(":/")
         .repeated()
         .collect::<String>()
         .separated_by(just('/'))
         .exactly(2)
         .collect::<Vec<String>>()
         .map(to_tuple);
-    git_host_prefix
-        .then(owner_repo)
-        .try_map(|(host, (owner, repo)), span| {
-            let url = url_from_git_host(host, owner, repo).map_err(|err| {
+    owner_repo
+        .try_map(|(owner, repo), span| {
+            let url = url_from_git_host(GitHost::default(), owner, repo).map_err(|err| {
                 Rich::custom(span, format!("error parsing git url shorthand: {err}"))
             })?;
             Ok(url)
         })
+        .or(prefix_parser())
+        .or(scp_style_parser())
 }
 
 impl Display for RemoteGitUrlShorthand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0.host == "github.com" {
-            format!("{}:{}/{}", GITHUB, self.0.owner, self.0.repo)
-        } else if self.0.host == "gitlab.com" {
-            format!("{}:{}/{}", GITLAB, self.0.owner, self.0.repo)
-        } else if self.0.host == "git.sr.ht" {
-            format!(
-                "{}:{}/{}",
-                SOURCEHUT,
-                self.0.owner.replace('~', ""),
-                self.0.repo
-            )
-        } else if self.0.host == "codeberg.org" {
-            format!(
-                "{}:{}/{}",
-                CODEBERG,
-                self.0.owner.replace('~', ""),
-                self.0.repo
-            )
-        } else {
-            format!("{}", self.0)
+        match (self.0.url.host_str(), self.0.owner()) {
+            (Some("github.com"), Some(owner)) => {
+                format!("{}:{}/{}", GITHUB, owner, self.0.repo())
+            }
+            (Some("gitlab.com"), Some(owner)) => {
+                format!("{}:{}/{}", GITLAB, owner, self.0.repo())
+            }
+            (Some("git.sr.ht"), Some(owner)) => {
+                format!("{}:{}/{}", SOURCEHUT, owner.replace('~', ""), self.0.repo())
+            }
+            (Some("codeberg.org"), Some(owner)) => {
+                format!("{}:{}/{}", CODEBERG, owner.replace('~', ""), self.0.repo())
+            }
+            _ => {
+                format!("{}", self.0)
+            }
         }
         .fmt(f)
     }
@@ -201,17 +212,17 @@ mod tests {
     #[tokio::test]
     async fn owner_repo_shorthand() {
         let url_shorthand: RemoteGitUrlShorthand = "lumen-oss/lux".parse().unwrap();
-        assert_eq!(url_shorthand.0.owner, "lumen-oss".to_string());
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
     }
 
     #[tokio::test]
     async fn github_shorthand() {
         let url_shorthand_str = "github:lumen-oss/lux";
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
-        assert_eq!(url_shorthand.0.host, "github.com".to_string());
-        assert_eq!(url_shorthand.0.owner, "lumen-oss".to_string());
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -219,9 +230,9 @@ mod tests {
     async fn gitlab_shorthand() {
         let url_shorthand_str = "gitlab:lumen-oss/lux";
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
-        assert_eq!(url_shorthand.0.host, "gitlab.com".to_string());
-        assert_eq!(url_shorthand.0.owner, "lumen-oss".to_string());
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.url.host_str(), Some("gitlab.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -229,9 +240,9 @@ mod tests {
     async fn sourcehut_shorthand() {
         let url_shorthand_str = "sourcehut:lumen-oss/lux";
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
-        assert_eq!(url_shorthand.0.host, "git.sr.ht".to_string());
-        assert_eq!(url_shorthand.0.owner, "~lumen-oss".to_string());
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.url.host_str(), Some("git.sr.ht"));
+        assert_eq!(url_shorthand.0.owner(), Some("~lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -239,9 +250,9 @@ mod tests {
     async fn codeberg_shorthand() {
         let url_shorthand_str = "codeberg:lumen-oss/lux";
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
-        assert_eq!(url_shorthand.0.host, "codeberg.org".to_string());
-        assert_eq!(url_shorthand.0.owner, "~lumen-oss".to_string());
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.url.host_str(), Some("codeberg.org"));
+        assert_eq!(url_shorthand.0.owner(), Some("~lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -249,9 +260,9 @@ mod tests {
     async fn regular_https_url() {
         let url_shorthand: RemoteGitUrlShorthand =
             "https://github.com/lumen-oss/lux.git".parse().unwrap();
-        assert_eq!(url_shorthand.0.host, "github.com".to_string());
-        assert_eq!(url_shorthand.0.owner, "lumen-oss".to_string());
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
         assert_eq!(
             url_shorthand.to_string(),
             "github:lumen-oss/lux".to_string()
@@ -259,15 +270,65 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn regular_ssh_url() {
+    async fn git_plus_https_url() {
+        let url_shorthand: RemoteGitUrlShorthand =
+            "git+https://github.com/lumen-oss/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn git_scheme_url() {
+        let url_shorthand: RemoteGitUrlShorthand =
+            "git://git@github.com/lumen-oss/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn ssh_url() {
+        let url_shorthand: RemoteGitUrlShorthand =
+            "ssh://git@github.com/lumen-oss/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn git_plus_ssh_url() {
+        let url_shorthand: RemoteGitUrlShorthand = "git+ssh://git@github.com/lumen-oss/lux.git"
+            .parse()
+            .unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn scp_style_url() {
         let url_str = "git@github.com:lumen-oss/lux.git";
         let url_shorthand: RemoteGitUrlShorthand = url_str.parse().unwrap();
-        assert_eq!(url_shorthand.0.host, "github.com".to_string());
-        assert_eq!(
-            url_shorthand.0.owner,
-            "git@github.com:lumen-oss".to_string(),
-        );
-        assert_eq!(url_shorthand.0.repo, "lux".to_string());
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
     }
 
     #[tokio::test]

--- a/lux-lib/src/git/shorthand.rs
+++ b/lux-lib/src/git/shorthand.rs
@@ -148,7 +148,7 @@ fn scp_style_parser<'a>(
                 .ignore_then(any().repeated().collect::<String>()),
         )
         .try_map(|(host, path), span| {
-            let inner = format!("git+ssh://{host}/{path}")
+            let inner = format!("ssh://{host}/{path}")
                 .parse::<RemoteGitUrl>()
                 .map_err(|err| {
                     Rich::custom(span, format!("error parsing scp style git url: {err}"))
@@ -213,7 +213,7 @@ mod tests {
     async fn owner_repo_shorthand() {
         let url_shorthand: RemoteGitUrlShorthand = "lumen-oss/lux".parse().unwrap();
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
     }
 
     #[tokio::test]
@@ -222,7 +222,7 @@ mod tests {
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -232,7 +232,7 @@ mod tests {
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("gitlab.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -242,7 +242,7 @@ mod tests {
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("git.sr.ht"));
         assert_eq!(url_shorthand.0.owner(), Some("~lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -252,7 +252,7 @@ mod tests {
         let url_shorthand: RemoteGitUrlShorthand = url_shorthand_str.parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("codeberg.org"));
         assert_eq!(url_shorthand.0.owner(), Some("~lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(url_shorthand.to_string(), url_shorthand_str.to_string());
     }
 
@@ -262,7 +262,7 @@ mod tests {
             "https://github.com/lumen-oss/lux.git".parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(
             url_shorthand.to_string(),
             "github:lumen-oss/lux".to_string()
@@ -270,16 +270,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn git_plus_https_url() {
+    async fn regular_http_url() {
         let url_shorthand: RemoteGitUrlShorthand =
-            "git+https://github.com/lumen-oss/lux.git".parse().unwrap();
+            "http://github.com/lumen-oss/lux.git".parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(
             url_shorthand.to_string(),
             "github:lumen-oss/lux".to_string()
         );
+    }
+
+    #[tokio::test]
+    async fn regular_ftp_url() {
+        let url_shorthand: RemoteGitUrlShorthand =
+            "ftp://github.com/lumen-oss/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo(), "lux");
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn illegal_scheme_url() {
+        RemoteGitUrlShorthand::from_str("git+https://github.com/lumen-oss/lux.git")
+            .expect_err("git+ handling should be done in an outer layer.");
+        RemoteGitUrlShorthand::from_str("file:///lumen-oss/lux.git")
+            .expect_err("local filesystems are not supported as a Remote URL.");
+        RemoteGitUrlShorthand::from_str("xyz:///lumen-oss/lux.git")
+            .expect_err("Unknown schemes are rejected");
     }
 
     #[tokio::test]
@@ -288,7 +311,7 @@ mod tests {
             "git://git@github.com/lumen-oss/lux.git".parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(
             url_shorthand.to_string(),
             "github:lumen-oss/lux".to_string()
@@ -301,21 +324,7 @@ mod tests {
             "ssh://git@github.com/lumen-oss/lux.git".parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
-        assert_eq!(
-            url_shorthand.to_string(),
-            "github:lumen-oss/lux".to_string()
-        );
-    }
-
-    #[tokio::test]
-    async fn git_plus_ssh_url() {
-        let url_shorthand: RemoteGitUrlShorthand = "git+ssh://git@github.com/lumen-oss/lux.git"
-            .parse()
-            .unwrap();
-        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
-        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
         assert_eq!(
             url_shorthand.to_string(),
             "github:lumen-oss/lux".to_string()
@@ -328,7 +337,7 @@ mod tests {
         let url_shorthand: RemoteGitUrlShorthand = url_str.parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo().to_owned(), "lux".to_string());
+        assert_eq!(url_shorthand.0.repo(), "lux");
     }
 
     #[tokio::test]

--- a/lux-lib/src/git/shorthand.rs
+++ b/lux-lib/src/git/shorthand.rs
@@ -283,9 +283,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn regular_ssh_url() {
+        let url_shorthand: RemoteGitUrlShorthand =
+            "ssh://git@github.com/lumen-oss/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo(), "lux");
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
     async fn regular_ftp_url() {
         let url_shorthand: RemoteGitUrlShorthand =
             "ftp://github.com/lumen-oss/lux.git".parse().unwrap();
+        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
+        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
+        assert_eq!(url_shorthand.0.repo(), "lux");
+        assert_eq!(
+            url_shorthand.to_string(),
+            "github:lumen-oss/lux".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn regular_ftps_url() {
+        let url_shorthand: RemoteGitUrlShorthand =
+            "ftps://github.com/lumen-oss/lux.git".parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
         assert_eq!(url_shorthand.0.repo(), "lux");
@@ -309,19 +335,6 @@ mod tests {
     async fn git_scheme_url() {
         let url_shorthand: RemoteGitUrlShorthand =
             "git://git@github.com/lumen-oss/lux.git".parse().unwrap();
-        assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
-        assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
-        assert_eq!(url_shorthand.0.repo(), "lux");
-        assert_eq!(
-            url_shorthand.to_string(),
-            "github:lumen-oss/lux".to_string()
-        );
-    }
-
-    #[tokio::test]
-    async fn ssh_url() {
-        let url_shorthand: RemoteGitUrlShorthand =
-            "ssh://git@github.com/lumen-oss/lux.git".parse().unwrap();
         assert_eq!(url_shorthand.0.url.host_str(), Some("github.com"));
         assert_eq!(url_shorthand.0.owner(), Some("lumen-oss"));
         assert_eq!(url_shorthand.0.repo(), "lux");

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -20,8 +20,8 @@ pub enum RemoteGitUrlParseError {
     NotARemoteGitUrl(String),
     #[error("Unsupported git remote scheme {scheme:?} in url {url}")]
     UnsupportedRemoteScheme { scheme: String, url: Url },
-    #[error("Url {url} missing host name")]
-    MissingHostName(String),
+    #[error("Url {0} missing host name")]
+    MissingHostName(Url),
 }
 
 impl RemoteGitUrl {

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -1,10 +1,5 @@
 use serde::{de, Deserialize, Deserializer, Serialize};
-use std::{
-    borrow::Cow,
-    fmt::Display,
-    hash::{DefaultHasher, Hash, Hasher as _},
-    str::FromStr,
-};
+use std::{fmt::Display, hash::Hash, str::FromStr};
 use thiserror::Error;
 use url::Url;
 
@@ -12,6 +7,7 @@ use url::Url;
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct RemoteGitUrl {
     pub(crate) url: Url,
+    host_str: String,
     /// The raw URL string
     url_str: String,
 }
@@ -28,7 +24,7 @@ impl RemoteGitUrl {
     /// Get the repo name, as the final component of the path, with any .git
     /// suffix removed, or as the hostname, if there is no final path component,
     /// or as a hash of the whole URL otherwise.
-    pub fn repo(&self) -> Cow<'_, str> {
+    pub fn repo(&self) -> &str {
         let url = &self.url;
         url.path_segments()
             .into_iter()
@@ -36,14 +32,7 @@ impl RemoteGitUrl {
             .rev()
             .next()
             .map(|part| part.strip_suffix(".git").unwrap_or(part))
-            .or_else(|| url.host_str())
-            .map(Cow::Borrowed)
-            .unwrap_or_else(|| {
-                let mut hasher = DefaultHasher::new();
-                url.hash(&mut hasher);
-                let hash = hasher.finish();
-                Cow::Owned(format!("lua-{hash}"))
-            })
+            .unwrap_or(&self.host_str)
     }
     /// Get the repo owner, as second-final component of the path.
     pub fn owner(&self) -> Option<&str> {
@@ -62,7 +51,19 @@ impl FromStr for RemoteGitUrl {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let url: Url = s.parse()?;
+        let scheme = url.scheme();
+        if !matches!(scheme, "ssh" | "git" | "http" | "https" | "ftp") {
+            return Err(RemoteGitUrlParseError::NotARemoteGitUrl(format!(
+                "Illegal git remote scheme: {scheme}"
+            )));
+        }
+        let Some(host_str) = url.host_str() else {
+            return Err(RemoteGitUrlParseError::NotARemoteGitUrl(
+                "Missing hostname".into(),
+            ));
+        };
         Ok(RemoteGitUrl {
+            host_str: String::from(host_str),
             url,
             url_str: String::from(s),
         })

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -1,20 +1,17 @@
 use serde::{de, Deserialize, Deserializer, Serialize};
-use std::{fmt::Display, str::FromStr};
+use std::{
+    borrow::Cow,
+    fmt::Display,
+    hash::{DefaultHasher, Hash, Hasher as _},
+    str::FromStr,
+};
 use thiserror::Error;
-
-// NOTE: This module implements a basic `GitUrl` struct with only what we need.
-// This is so that we don't have to expose `git_url_parse::GitUrl`, which is  highly unstable,
-// via our API.
+use url::Url;
 
 /// GitUrl represents an input url that is a url used by git
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct RemoteGitUrl {
-    /// The fully qualified domain name (FQDN) or IP of the repo
-    pub(crate) host: String,
-    /// The name of the repo
-    pub(crate) repo: String,
-    /// The owner/account/project name
-    pub(crate) owner: String,
+    pub(crate) url: Url,
     /// The raw URL string
     url_str: String,
 }
@@ -22,31 +19,52 @@ pub struct RemoteGitUrl {
 #[derive(Debug, Error)]
 pub enum RemoteGitUrlParseError {
     #[error("error parsing git URL:\n{0}")]
-    GitUrlParse(String),
+    GitUrlParse(#[from] url::ParseError),
     #[error("not a remote git URL: {0}")]
     NotARemoteGitUrl(String),
+}
+
+impl RemoteGitUrl {
+    /// Get the repo name, as the final component of the path, with any .git
+    /// suffix removed, or as the hostname, if there is no final path component,
+    /// or as a hash of the whole URL otherwise.
+    pub fn repo(&self) -> Cow<'_, str> {
+        let url = &self.url;
+        url.path_segments()
+            .into_iter()
+            .flatten()
+            .rev()
+            .next()
+            .map(|part| part.strip_suffix(".git").unwrap_or(part))
+            .or_else(|| url.host_str())
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| {
+                let mut hasher = DefaultHasher::new();
+                url.hash(&mut hasher);
+                let hash = hasher.finish();
+                Cow::Owned(format!("lua-{hash}"))
+            })
+    }
+    /// Get the repo owner, as second-final component of the path.
+    pub fn owner(&self) -> Option<&str> {
+        self.url
+            .path_segments()
+            .into_iter()
+            .flatten()
+            .rev()
+            .skip(1)
+            .next()
+    }
 }
 
 impl FromStr for RemoteGitUrl {
     type Err = RemoteGitUrlParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = git_url_parse::GitUrl::parse(s)
-            .map_err(|err| RemoteGitUrlParseError::GitUrlParse(err.to_string()))?;
-        let host = url
-            .host()
-            .ok_or_else(|| RemoteGitUrlParseError::NotARemoteGitUrl(url.to_string()))?;
-        let provider: Result<
-            git_url_parse::types::provider::GenericProvider,
-            git_url_parse::GitUrlParseError,
-        > = url.provider_info();
-        let provider =
-            provider.map_err(|_err| RemoteGitUrlParseError::NotARemoteGitUrl(s.to_string()))?;
+        let url: Url = s.parse()?;
         Ok(RemoteGitUrl {
-            host: host.to_string(),
-            repo: provider.repo().to_string(),
-            owner: provider.owner().to_string(),
-            url_str: url.to_string(),
+            url,
+            url_str: String::from(s),
         })
     }
 }

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -18,6 +18,8 @@ pub enum RemoteGitUrlParseError {
     GitUrlParse(#[from] url::ParseError),
     #[error("not a remote git URL: {0}")]
     NotARemoteGitUrl(String),
+    #[error("Unsupported git remote scheme {scheme:?} in url {url}")]
+    UnsupportedRemoteScheme { scheme: String, url: Url },
 }
 
 impl RemoteGitUrl {
@@ -53,14 +55,15 @@ impl FromStr for RemoteGitUrl {
         let url: Url = s.parse()?;
         let scheme = url.scheme();
         if !matches!(scheme, "ssh" | "git" | "http" | "https" | "ftp" | "ftps") {
-            return Err(RemoteGitUrlParseError::NotARemoteGitUrl(format!(
-                "Illegal git remote scheme: {scheme}"
-            )));
+            return Err(RemoteGitUrlParseError::UnsupportedRemoteScheme {
+                scheme: scheme.into(),
+                url,
+            });
         }
         let Some(host_str) = url.host_str() else {
-            return Err(RemoteGitUrlParseError::NotARemoteGitUrl(
-                "Missing hostname".into(),
-            ));
+            return Err(RemoteGitUrlParseError::NotARemoteGitUrl(format!(
+                "Missing hostname in url: {url}"
+            )));
         };
         Ok(RemoteGitUrl {
             host_str: String::from(host_str),

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -20,6 +20,8 @@ pub enum RemoteGitUrlParseError {
     NotARemoteGitUrl(String),
     #[error("Unsupported git remote scheme {scheme:?} in url {url}")]
     UnsupportedRemoteScheme { scheme: String, url: Url },
+    #[error("Url {url} missing host name")]
+    MissingHostName(String),
 }
 
 impl RemoteGitUrl {
@@ -61,9 +63,7 @@ impl FromStr for RemoteGitUrl {
             });
         }
         let Some(host_str) = url.host_str() else {
-            return Err(RemoteGitUrlParseError::NotARemoteGitUrl(format!(
-                "Missing hostname in url: {url}"
-            )));
+            return Err(RemoteGitUrlParseError::MissingHostName(url));
         };
         Ok(RemoteGitUrl {
             host_str: String::from(host_str),

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -33,20 +33,13 @@ impl RemoteGitUrl {
         url.path_segments()
             .into_iter()
             .flatten()
-            .rev()
-            .next()
+            .next_back()
             .map(|part| part.strip_suffix(".git").unwrap_or(part))
             .unwrap_or(&self.host_str)
     }
     /// Get the repo owner, as second-final component of the path.
     pub fn owner(&self) -> Option<&str> {
-        self.url
-            .path_segments()
-            .into_iter()
-            .flatten()
-            .rev()
-            .skip(1)
-            .next()
+        self.url.path_segments().into_iter().flatten().rev().nth(1)
     }
 }
 

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -52,7 +52,7 @@ impl FromStr for RemoteGitUrl {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let url: Url = s.parse()?;
         let scheme = url.scheme();
-        if !matches!(scheme, "ssh" | "git" | "http" | "https" | "ftp") {
+        if !matches!(scheme, "ssh" | "git" | "http" | "https" | "ftp" | "ftps") {
             return Err(RemoteGitUrlParseError::NotARemoteGitUrl(format!(
                 "Illegal git remote scheme: {scheme}"
             )));

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -354,8 +354,8 @@ mod tests {
         assert!(matches!(url, SourceUrl::Url { .. }));
         let url: SourceUrl = "git://example.com/foo/bar".parse().unwrap();
         assert!(matches!(url, SourceUrl::Git { .. }));
-        let url: SourceUrl = "git+file:///path/to/repo.git".parse().unwrap();
-        assert!(matches!(url, SourceUrl::Git { .. }));
+        // We don't support file-like URLs, as they are not remote.
+        SourceUrl::from_str("git+file:///path/to/repo.git").unwrap_err();
         let url: SourceUrl = "git+http://example.com/foo/bar".parse().unwrap();
         assert!(matches!(url, SourceUrl::Git { .. }));
         let url: SourceUrl = "git+https://example.com/foo/bar".parse().unwrap();

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -354,8 +354,8 @@ mod tests {
         assert!(matches!(url, SourceUrl::Url { .. }));
         let url: SourceUrl = "git://example.com/foo/bar".parse().unwrap();
         assert!(matches!(url, SourceUrl::Git { .. }));
-        // We don't support file-like URLs, as they are not remote.
-        SourceUrl::from_str("git+file:///path/to/repo.git").unwrap_err();
+        let url: SourceUrl = "git+file:///path/to/repo.git".parse().unwrap();
+        assert!(matches!(url, SourceUrl::Git { .. }));
         let url: SourceUrl = "git+http://example.com/foo/bar".parse().unwrap();
         assert!(matches!(url, SourceUrl::Git { .. }));
         let url: SourceUrl = "git+https://example.com/foo/bar".parse().unwrap();

--- a/lux-lib/src/operations/vendor.rs
+++ b/lux-lib/src/operations/vendor.rs
@@ -32,9 +32,11 @@ use crate::{
     workspace::{Workspace, WorkspaceError},
 };
 
+#[allow(clippy::large_enum_variant)]
 pub enum VendorTarget {
     /// Vendor dependencies of a Lux workspace
     Workspace(Workspace),
+
     /// Vendor dependencies of a Lua RockSpec
     Rockspec(RemoteLuaRockspec),
 }

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -300,7 +300,7 @@ impl Project {
                             dep_entry["version"] = Item::Value(sha.into());
                         }
                     }
-                    table[git_url.repo.clone()] = dep_entry;
+                    table[git_url.repo().as_ref()] = dep_entry;
                 }
             }
         }

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -300,7 +300,7 @@ impl Project {
                             dep_entry["version"] = Item::Value(sha.into());
                         }
                     }
-                    table[git_url.repo().as_ref()] = dep_entry;
+                    table[git_url.repo()] = dep_entry;
                 }
             }
         }


### PR DESCRIPTION
git-url-parse had a lot of limitations that prevented it from working
on many common git URL types. There's no real good reason to use it when
all the URL types that we want to use are either:

* A shorthand URL, which we have to handle ourselves anyway.
* A shorthand URL without the prefix, which we have to handle ourselves.
* SCP-style URL, which wasn't being handled correctly by git-url-parse.
* Proper URLs, which were also not being handled correctly by
  git-url-parse.

We already have `url` as a dependency, which parses URLs perfectly well
itself. We may as well use it instead.

closes #1594 

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
