### PR TITLE
feat(git): enable authentication like git CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-git2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec364a6ee335b23a7e77703100f5103965810f91a9ef6319a004a7e7b8e2b66"
+dependencies = [
+ "dirs",
+ "git2",
+ "terminal-prompt",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3350,7 @@ version = "0.42.0"
 dependencies = [
  "assert_fs",
  "async-recursion",
+ "auth-git2",
  "bon",
  "bytes",
  "cc",
@@ -6160,6 +6172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-prompt"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572818b3472910acbd5dff46a3413715c18e934b071ab2ba464a7b2c2af16376"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -98,6 +98,7 @@ gpgme = { version = "0.11", optional = true }
 ottavino = "0.4.0"
 ottavino-util = "0.4.0"
 serde-value = "0.7.0"
+auth-git2 = "0.6.0"
 
 [dev-dependencies]
 httptest = { version = "0.16" }

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -1,6 +1,7 @@
+use auth_git2::GitAuthenticator;
 use bon::Builder;
 use git2::build::RepoBuilder;
-use git2::{Cred, FetchOptions, RemoteCallbacks};
+use git2::{FetchOptions, RemoteCallbacks};
 use remove_dir_all::remove_dir_all;
 use ssri::Integrity;
 use std::fs::File;
@@ -201,10 +202,10 @@ async fn do_fetch_src<R: Rockspec>(
             let url = git.url.to_string();
             progress.map(|p| p.set_message(format!("🦠 Cloning {url}")));
 
+            let auth = GitAuthenticator::default();
+            let git_config = git2::Config::open_default()?;
             let mut callbacks = RemoteCallbacks::new();
-            callbacks.credentials(|_url, username_from_url, _allowed_types| {
-                Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"))
-            });
+            callbacks.credentials(auth.credentials(&git_config));
             let mut fetch_options = FetchOptions::new();
             fetch_options.update_fetchhead(false);
             fetch_options.remote_callbacks(callbacks);

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -1,4 +1,4 @@
-use auth_git2::GitAuthenticator;
+use auth_git2::{GitAuthenticator, Prompter};
 use bon::Builder;
 use git2::build::RepoBuilder;
 use git2::{FetchOptions, RemoteCallbacks};
@@ -165,6 +165,24 @@ pub enum FetchSrcRockError {
     Io(#[from] io::Error),
 }
 
+/// A no-prompt implementer for auth_git2's prompter
+#[derive(Copy, Clone, Debug)]
+struct NullPrompter;
+
+impl Prompter for NullPrompter {
+    fn prompt_username_password(&mut self, _: &str, _: &git2::Config) -> Option<(String, String)> {
+        None
+    }
+
+    fn prompt_password(&mut self, _: &str, _: &str, _: &git2::Config) -> Option<String> {
+        None
+    }
+
+    fn prompt_ssh_key_passphrase(&mut self, _: &Path, _: &git2::Config) -> Option<String> {
+        None
+    }
+}
+
 async fn do_fetch_src<R: Rockspec>(
     fetch: &FetchSrc<'_, R>,
 ) -> Result<RemotePackageSourceMetadata, FetchSrcError> {
@@ -202,7 +220,14 @@ async fn do_fetch_src<R: Rockspec>(
             let url = git.url.to_string();
             progress.map(|p| p.set_message(format!("🦠 Cloning {url}")));
 
-            let auth = GitAuthenticator::default();
+            let auth = if config.no_prompt() {
+                GitAuthenticator::default()
+                    .try_password_prompt(0)
+                    .prompt_ssh_key_password(false)
+                    .set_prompter(NullPrompter)
+            } else {
+                GitAuthenticator::default()
+            };
             let git_config = git2::Config::open_default()?;
             let mut callbacks = RemoteCallbacks::new();
             callbacks.credentials(auth.credentials(&git_config));


### PR DESCRIPTION
git auth was not fully featured, only allowing SSH agent authentication. auth-git2 is a fairly minimal crate that for the most part allows git2 to authenticate like CLI git.

With this change, private auth ssh://, git+ssh://, and https:// now work.

closes #1594 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
