### PR TITLE
feat(lua): build as a DLL on windows

### DIFF
--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -697,7 +697,7 @@ async fn do_build_lua_msvc(
             .output()
             .await,
         config,
-        &format!("install {}", lua_c_bin_path.display()),
+        &format!("link {}", lua_c_bin_path.display()),
     )?;
 
     copy_includes(&src_dir, &include_dir).await?;

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -492,9 +492,9 @@ stderr:
                 .arg("generic")
                 .output()
                 .await;
-            guard_success(fallback_output, config)?;
+            guard_success(fallback_output, config, "build (generic)".to_string())?;
         }
-        output => guard_success(output, config)?,
+        output => guard_success(output, config, format!("build ({build_target})"))?,
     };
 
     progress.map(|p| p.set_message(format!("💻 Installing Lua {}", pkg_version)));
@@ -527,29 +527,6 @@ stderr:
     };
 
     Ok(())
-}
-
-fn guard_success(
-    output: io::Result<std::process::Output>,
-    config: &Config,
-) -> Result<(), BuildLuaError> {
-    match output {
-        Ok(output) if output.status.success() => {
-            utils::log_command_output(&output, config);
-            Ok(())
-        }
-        Ok(output) => Err(BuildLuaError::CommandFailure {
-            name: "build".into(),
-            status: output.status,
-            stdout: String::from_utf8_lossy(&output.stdout).into(),
-            stderr: String::from_utf8_lossy(&output.stderr).into(),
-        }),
-        Err(err) => Err(BuildLuaError::Io(io::Error::other(format!(
-            "Failed to run `{} build`:\n{}",
-            config.make_cmd(),
-            err,
-        )))),
-    }
 }
 
 async fn do_build_lua_msvc(
@@ -591,6 +568,18 @@ async fn do_build_lua_msvc(
 
     let src_dir = build_dir.join("src");
 
+    let lua_bin_name = "lua";
+    let lua_c_bin_name = "luac";
+
+    let dll_name = match lua_version {
+        LuaVersion::Lua51 => "lua51",
+        LuaVersion::Lua52 => "lua52",
+        LuaVersion::Lua53 => "lua53",
+        LuaVersion::Lua54 => "lua54",
+        LuaVersion::Lua55 => "lua55",
+        LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => unreachable!(),
+    };
+
     let lib_name = match lua_version {
         LuaVersion::Lua51 => "lua5.1",
         LuaVersion::Lua52 => "lua5.2",
@@ -599,6 +588,7 @@ async fn do_build_lua_msvc(
         LuaVersion::Lua55 => "lua5.5",
         LuaVersion::LuaJIT | LuaVersion::LuaJIT52 => unreachable!(),
     };
+
     let host = Triple::host();
     let mut cc = cc::Build::new();
     cc.cargo_output(false)
@@ -610,6 +600,7 @@ async fn do_build_lua_msvc(
         .target(&host.to_string());
 
     cc.define("LUA_USE_WINDOWS", None);
+    cc.define("LUA_BUILD_AS_DLL", None);
 
     let mut lib_c_files = Vec::new();
     let mut read_dir = fs::read_dir(&src_dir).await.map_err(|err| {
@@ -630,17 +621,35 @@ async fn do_build_lua_msvc(
             lib_c_files.push(path);
         }
     }
-    cc.include(&src_dir)
+
+    let lib_objects = cc
+        .include(&src_dir)
         .files(lib_c_files)
         .out_dir(&lib_dir)
-        .try_compile(lib_name)?;
+        .try_compile_intermediates()?;
 
     let bin_objects = cc
         .include(&src_dir)
-        .file(src_dir.join("lua.c"))
-        .file(src_dir.join("luac.c"))
+        .file(src_dir.join(format!("{lua_bin_name}.c")))
+        .file(src_dir.join(format!("{lua_c_bin_name}.c")))
         .out_dir(&src_dir)
         .try_compile_intermediates()?;
+
+    let lua_bin_objects = bin_objects.iter().filter(|file| {
+        file.file_stem().is_some_and(|fname| {
+            fname
+                .to_string_lossy()
+                .ends_with(&format!("-{lua_bin_name}"))
+        })
+    });
+
+    let lua_c_bin_objects = bin_objects.iter().filter(|file| {
+        file.file_stem().is_some_and(|fname| {
+            fname
+                .to_string_lossy()
+                .ends_with(&format!("-{lua_c_bin_name}"))
+        })
+    });
 
     progress.map(|p| p.set_message(format!("💻 Installing Lua {}", pkg_version)));
 
@@ -648,39 +657,76 @@ async fn do_build_lua_msvc(
     let link =
         cc::windows_registry::find_tool(&target, "link.exe").ok_or(BuildLuaError::LinkNotFound)?;
 
-    for name in ["lua", "luac"] {
-        let bin = bin_dir.join(format!("{name}.exe"));
-        let objects = bin_objects.iter().filter(|file| {
-            file.with_extension("").file_name().is_some_and(|fname| {
-                fname
-                    .to_string_lossy()
-                    .to_string()
-                    .ends_with(&format!("-{name}"))
-            })
-        });
-        match Command::new(link.path())
-            .arg(format!("/OUT:{}", bin.display()))
-            .args(objects)
-            .arg(format!("{}.lib", lib_dir.join(lib_name).display()))
+    let dll_path = bin_dir.join(format!("{dll_name}.dll"));
+    let lua_bin_path = bin_dir.join(format!("{lua_bin_name}.exe"));
+    let lua_c_bin_path = bin_dir.join(format!("{lua_c_bin_name}.exe"));
+
+    let implib_path = lib_dir.join(format!("{lib_name}.lib"));
+
+    // lua.dll
+    guard_success(
+        Command::new(link.path())
+            .arg("/DLL")
+            .arg(format!("/OUT:{}", dll_path.display()))
+            .arg(format!("/IMPLIB:{}", implib_path.display()))
+            .args(&lib_objects)
             .output()
-            .await
-        {
-            Ok(output) if output.status.success() => utils::log_command_output(&output, config),
-            Ok(output) => {
-                return Err(BuildLuaError::CommandFailure {
-                    name: format!("install {name}.exe"),
-                    status: output.status,
-                    stdout: String::from_utf8_lossy(&output.stdout).into(),
-                    stderr: String::from_utf8_lossy(&output.stderr).into(),
-                });
-            }
-            Err(err) => return Err(BuildLuaError::Io(err)),
-        };
-    }
+            .await,
+        config,
+        format!("install {dll_name}.dll"),
+    )?;
+
+    // lua.exe
+    guard_success(
+        Command::new(link.path())
+            .arg(format!("/OUT:{}", lua_bin_path.display()))
+            .arg(&implib_path)
+            .args(lua_bin_objects)
+            .output()
+            .await,
+        config,
+        format!("install {}", lua_bin_path.display()),
+    )?;
+
+    // luac.exe
+    guard_success(
+        Command::new(link.path())
+            .arg(format!("/OUT:{}", lua_c_bin_path.display()))
+            .args(&lib_objects)
+            .args(lua_c_bin_objects)
+            .output()
+            .await,
+        config,
+        format!("install {}", lua_c_bin_path.display()),
+    )?;
 
     copy_includes(&src_dir, &include_dir).await?;
 
     Ok(())
+}
+
+fn guard_success(
+    output: io::Result<std::process::Output>,
+    config: &Config,
+    message: String,
+) -> Result<(), BuildLuaError> {
+    match output {
+        Ok(output) if output.status.success() => {
+            utils::log_command_output(&output, config);
+            Ok(())
+        }
+        Ok(output) => Err(BuildLuaError::CommandFailure {
+            name: message,
+            status: output.status,
+            stdout: String::from_utf8_lossy(&output.stdout).into(),
+            stderr: String::from_utf8_lossy(&output.stderr).into(),
+        }),
+        Err(err) => Err(BuildLuaError::Io(io::Error::other(format!(
+            "Failed to run `{} build`:\n{}",
+            config.make_cmd(),
+            err,
+        )))),
+    }
 }
 
 async fn copy_includes(src_dir: &Path, include_dir: &Path) -> Result<(), io::Error> {

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -492,9 +492,9 @@ stderr:
                 .arg("generic")
                 .output()
                 .await;
-            guard_success(fallback_output, config, "build (generic)".to_string())?;
+            guard_success(fallback_output, config, "build (generic)")?;
         }
-        output => guard_success(output, config, format!("build ({build_target})"))?,
+        output => guard_success(output, config, &format!("build ({build_target})"))?,
     };
 
     progress.map(|p| p.set_message(format!("💻 Installing Lua {}", pkg_version)));
@@ -673,7 +673,7 @@ async fn do_build_lua_msvc(
             .output()
             .await,
         config,
-        format!("install {dll_name}.dll"),
+        &format!("link {dll_name}.dll"),
     )?;
 
     // lua.exe
@@ -685,7 +685,7 @@ async fn do_build_lua_msvc(
             .output()
             .await,
         config,
-        format!("install {}", lua_bin_path.display()),
+        &format!("install {}", lua_bin_path.display()),
     )?;
 
     // luac.exe
@@ -697,7 +697,7 @@ async fn do_build_lua_msvc(
             .output()
             .await,
         config,
-        format!("install {}", lua_c_bin_path.display()),
+        &format!("install {}", lua_c_bin_path.display()),
     )?;
 
     copy_includes(&src_dir, &include_dir).await?;
@@ -708,7 +708,7 @@ async fn do_build_lua_msvc(
 fn guard_success(
     output: io::Result<std::process::Output>,
     config: &Config,
-    message: String,
+    cmd_name: &str,
 ) -> Result<(), BuildLuaError> {
     match output {
         Ok(output) if output.status.success() => {
@@ -716,7 +716,7 @@ fn guard_success(
             Ok(())
         }
         Ok(output) => Err(BuildLuaError::CommandFailure {
-            name: message,
+            name: cmd_name.to_string(),
             status: output.status,
             stdout: String::from_utf8_lossy(&output.stdout).into(),
             stderr: String::from_utf8_lossy(&output.stderr).into(),

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -685,7 +685,7 @@ async fn do_build_lua_msvc(
             .output()
             .await,
         config,
-        &format!("install {}", lua_bin_path.display()),
+        &format!("link {}", lua_bin_path.display()),
     )?;
 
     // luac.exe


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

This PR enables support for loading external lua c modules on windows. I wanted to enable windows tests in my CI, but I was unable to do so since the windows builds would never load the module correctly. I did use the assistance of an LLM (chatGPT web) when first starting on this fix, but this PR includes no LLM generated code at this point. I am not sure if this is allowed under the LLM/AI policy. I also do not have a windows machine, so this was tested through github actions runs: https://github.com/benniekiss/rs-mod-lua/actions/workflows/window.yaml


The most significant change is that the `do_build_lua_msvc` function now compiles a `lua{version}.dll` alongside the `lua.exe` and `luac.exe` files. This is to support loading dynamic modules, as noted in the [Lua documentation](https://www.lua.org/manual/5.5/readme.html#other)

The `guard_success` function was refactored to accept a `message` arg, since the logic was essentially the same as the windows build result matching. I moved it to after `do_build_lua_msvc`  since it now is used in both the unix build and the msvc build.

I tested *several* permutations of the build args. I actually had a small typo which tripped me up for several attempts (using `.args` instead of the singular `.arg`), and this set compiles cleanly. I actually found this guide to be very helpful: https://www.saoe.net/blog/building-lua-5-4-7-on-windows-10-with-visual-studio-2022/

The build is passing in my CI, while other versions have failed: https://github.com/benniekiss/lux/actions

<!-- Please check what applies. -->

- [ X ] Fits [CONTRIBUTING.md].
- [ ] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
