### PR TITLE
feat(config)!: add `luarc_file_name` option

### DIFF
--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -74,7 +74,7 @@ pub async fn check(args: Check, config: Config) -> Result<()> {
         return Ok(());
     }
 
-    let luarc_path = workspace.luarc_path();
+    let luarc_path = workspace.luarc_path(&config);
     let rc_files = if luarc_path.is_file() {
         Some(vec![luarc_path])
     } else {

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -53,7 +53,7 @@ pub struct Config {
     user_agent: String,
 
     generate_luarc: bool,
-    ls_config_file: Option<String>,
+    luarc_file_name: String,
     wrap_bin_scripts: bool,
 }
 
@@ -221,9 +221,9 @@ impl Config {
         self.generate_luarc
     }
 
-    /// The custom language server configuration file name, if specified
-    pub fn ls_config_file(&self) -> Option<&String> {
-        self.ls_config_file.as_ref()
+    // Lua runtime configuration file name
+    pub fn luarc_file_name(&self) -> &str {
+        &self.luarc_file_name
     }
 
     /// Whether to wrap installed Lua bin scripts to be executed with
@@ -294,7 +294,7 @@ pub struct ConfigBuilder {
     entrypoint_layout: RockLayoutConfig,
     user_agent: Option<String>,
     generate_luarc: Option<bool>,
-    ls_config_file: Option<String>,
+    luarc_file_name: Option<String>,
     wrap_bin_scripts: Option<bool>,
 }
 
@@ -487,9 +487,11 @@ impl ConfigBuilder {
         }
     }
 
-    pub fn ls_config_file(self, file: Option<String>) -> Self {
+    /// Lua runtime configuration file name
+    /// Default: `.luarc.json`
+    pub fn luarc_file_name(self, file: Option<String>) -> Self {
         Self {
-            ls_config_file: file.or(self.ls_config_file),
+            luarc_file_name: file.or(self.luarc_file_name),
             ..self
         }
     }
@@ -543,7 +545,9 @@ impl ConfigBuilder {
             vendor_dir: self.vendor_dir,
             user_agent: self.user_agent.unwrap_or(DEFAULT_USER_AGENT.into()),
             generate_luarc: self.generate_luarc.unwrap_or(true),
-            ls_config_file: self.ls_config_file,
+            luarc_file_name: self
+                .luarc_file_name
+                .unwrap_or_else(|| ".luarc.json".to_string()),
             wrap_bin_scripts: self.wrap_bin_scripts.unwrap_or(true),
         })
     }
@@ -577,7 +581,7 @@ impl From<Config> for ConfigBuilder {
             entrypoint_layout: value.entrypoint_layout,
             user_agent: Some(value.user_agent),
             generate_luarc: Some(value.generate_luarc),
-            ls_config_file: value.ls_config_file,
+            luarc_file_name: Some(value.luarc_file_name),
             wrap_bin_scripts: Some(value.wrap_bin_scripts),
         }
     }

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -53,6 +53,7 @@ pub struct Config {
     user_agent: String,
 
     generate_luarc: bool,
+    ls_config_file: Option<String>,
     wrap_bin_scripts: bool,
 }
 
@@ -220,6 +221,11 @@ impl Config {
         self.generate_luarc
     }
 
+    /// The custom language server configuration file name, if specified
+    pub fn ls_config_file(&self) -> Option<&String> {
+        self.ls_config_file.as_ref()
+    }
+
     /// Whether to wrap installed Lua bin scripts to be executed with
     /// the detected or configured Lua installation.
     /// If `true`, individual rocks can still disable wrapping of their own bin scripts.
@@ -288,6 +294,7 @@ pub struct ConfigBuilder {
     entrypoint_layout: RockLayoutConfig,
     user_agent: Option<String>,
     generate_luarc: Option<bool>,
+    ls_config_file: Option<String>,
     wrap_bin_scripts: Option<bool>,
 }
 
@@ -480,6 +487,13 @@ impl ConfigBuilder {
         }
     }
 
+    pub fn ls_config_file(self, file: Option<String>) -> Self {
+        Self {
+            ls_config_file: file.or(self.ls_config_file),
+            ..self
+        }
+    }
+
     /// Whether to wrap installed Lua bin scripts to be executed with
     /// the detected or configured Lua installation.
     /// Setting this to `false` disables wrapping globally.
@@ -529,6 +543,7 @@ impl ConfigBuilder {
             vendor_dir: self.vendor_dir,
             user_agent: self.user_agent.unwrap_or(DEFAULT_USER_AGENT.into()),
             generate_luarc: self.generate_luarc.unwrap_or(true),
+            ls_config_file: self.ls_config_file,
             wrap_bin_scripts: self.wrap_bin_scripts.unwrap_or(true),
         })
     }
@@ -562,6 +577,7 @@ impl From<Config> for ConfigBuilder {
             entrypoint_layout: value.entrypoint_layout,
             user_agent: Some(value.user_agent),
             generate_luarc: Some(value.generate_luarc),
+            ls_config_file: value.ls_config_file,
             wrap_bin_scripts: Some(value.wrap_bin_scripts),
         }
     }

--- a/lux-lib/src/operations/gen_luarc.rs
+++ b/lux-lib/src/operations/gen_luarc.rs
@@ -72,7 +72,7 @@ async fn do_generate_luarc(args: GenLuaRc<'_>) -> Result<(), GenLuaRcError> {
     }
     let workspace = args.workspace;
     let lockfile = workspace.lockfile()?;
-    let luarc_path = workspace.luarc_path();
+    let luarc_path = workspace.luarc_path(config);
 
     // read the existing .luarc file or initialise a new one if it doesn't exist
     let luarc_content = fs::read_to_string(&luarc_path)

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -454,4 +454,54 @@ members = [ "glob:projects/*" ]
         let work_dir = assert_fs::TempDir::new().unwrap();
         assert!(Workspace::from(&work_dir).unwrap().is_none())
     }
+
+    #[tokio::test]
+    async fn test_luarc_path_custom_config() {
+        let sample_project: PathBuf = "resources/test/sample-projects/init/".into();
+        let project_root = assert_fs::TempDir::new().unwrap();
+        project_root.copy_from(&sample_project, &["**"]).unwrap();
+
+        let workspace = Workspace::from(&project_root).unwrap().unwrap();
+
+        let mut builder = crate::config::ConfigBuilder::default();
+        builder = builder.ls_config_file(Some("custom_config.json".to_string()));
+        let config = builder.build().unwrap();
+
+        let path = workspace.luarc_path(&config);
+        assert_eq!(path, workspace.root().join("custom_config.json"));
+    }
+
+    #[tokio::test]
+    async fn test_luarc_path_fallback_luarc() {
+        use assert_fs::prelude::*;
+
+        let sample_project: PathBuf = "resources/test/sample-projects/init/".into();
+        let project_root = assert_fs::TempDir::new().unwrap();
+        project_root.copy_from(&sample_project, &["**"]).unwrap();
+
+        project_root.child(".luarc.json").touch().unwrap();
+
+        let workspace = Workspace::from(&project_root).unwrap().unwrap();
+        let config = crate::config::ConfigBuilder::default().build().unwrap();
+
+        let path = workspace.luarc_path(&config);
+        assert_eq!(path, workspace.root().join(".luarc.json"));
+    }
+
+    #[tokio::test]
+    async fn test_luarc_path_fallback_emmyrc() {
+        use assert_fs::prelude::*;
+
+        let sample_project: PathBuf = "resources/test/sample-projects/init/".into();
+        let project_root = assert_fs::TempDir::new().unwrap();
+        project_root.copy_from(&sample_project, &["**"]).unwrap();
+
+        project_root.child(".emmyrc.json").touch().unwrap();
+
+        let workspace = Workspace::from(&project_root).unwrap().unwrap();
+        let config = crate::config::ConfigBuilder::default().build().unwrap();
+
+        let path = workspace.luarc_path(&config);
+        assert_eq!(path, workspace.root().join(".emmyrc.json"));
+    }
 }

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -245,7 +245,11 @@ impl Workspace {
     }
 
     /// Get the `.luarc.json` or `.emmyrc.json` path.
-    pub fn luarc_path(&self) -> PathBuf {
+    pub fn luarc_path(&self, config: &Config) -> PathBuf {
+        if let Some(custom_ls_file) = config.ls_config_file() {
+            return self.root.join(custom_ls_file);
+        }
+
         let luarc_path = self.root.join(LUARC);
         if luarc_path.is_file() {
             luarc_path

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -377,9 +377,10 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ConfigBuilder;
     use std::path::PathBuf;
 
-    use assert_fs::prelude::PathCopy;
+    use assert_fs::prelude::*;
 
     #[tokio::test]
     async fn find_single_project_workspace() {
@@ -460,7 +461,7 @@ members = [ "glob:projects/*" ]
 
         let workspace = Workspace::from(&project_root).unwrap().unwrap();
 
-        let config = crate::config::ConfigBuilder::default()
+        let config = ConfigBuilder::default()
             .luarc_file_name(Some("custom_config.json".to_string()))
             .build()
             .unwrap();
@@ -471,35 +472,33 @@ members = [ "glob:projects/*" ]
 
     #[tokio::test]
     async fn test_luarc_path_fallback_luarc() {
-        use assert_fs::prelude::*;
-
         let sample_project: PathBuf = "resources/test/sample-projects/init/".into();
         let project_root = assert_fs::TempDir::new().unwrap();
         project_root.copy_from(&sample_project, &["**"]).unwrap();
 
-        project_root.child(".luarc.json").touch().unwrap();
+        let luarc_file = project_root.child(".luarc.json");
+        luarc_file.touch().unwrap();
 
         let workspace = Workspace::from(&project_root).unwrap().unwrap();
-        let config = crate::config::ConfigBuilder::default().build().unwrap();
+        let config = ConfigBuilder::default().build().unwrap();
 
         let path = workspace.luarc_path(&config);
-        assert_eq!(path, workspace.root().join(".luarc.json"));
+        assert_eq!(path, luarc_file.path().to_path_buf());
     }
 
     #[tokio::test]
     async fn test_luarc_path_fallback_emmyrc() {
-        use assert_fs::prelude::*;
-
         let sample_project: PathBuf = "resources/test/sample-projects/init/".into();
         let project_root = assert_fs::TempDir::new().unwrap();
         project_root.copy_from(&sample_project, &["**"]).unwrap();
 
-        project_root.child(".emmyrc.json").touch().unwrap();
+        let emmyrc_file = project_root.child(".emmyrc.json");
+        emmyrc_file.touch().unwrap();
 
         let workspace = Workspace::from(&project_root).unwrap().unwrap();
-        let config = crate::config::ConfigBuilder::default().build().unwrap();
+        let config = ConfigBuilder::default().build().unwrap();
 
         let path = workspace.luarc_path(&config);
-        assert_eq!(path, workspace.root().join(".emmyrc.json"));
+        assert_eq!(path, emmyrc_file.path().to_path_buf());
     }
 }

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -26,7 +26,6 @@ pub mod workspace_toml;
 
 pub const WORKSPACE_TOML: &str = PROJECT_TOML;
 pub(crate) const LUX_DIR_NAME: &str = ".lux";
-const LUARC: &str = ".luarc.json";
 const EMMYRC: &str = ".emmyrc.json";
 
 /// A newtype for the workspace root directory.
@@ -246,19 +245,17 @@ impl Workspace {
 
     /// Get the `.luarc.json` or `.emmyrc.json` path.
     pub fn luarc_path(&self, config: &Config) -> PathBuf {
-        if let Some(custom_ls_file) = config.ls_config_file() {
-            return self.root.join(custom_ls_file);
-        }
+        let configured_name = config.luarc_file_name();
+        let file_path = self.root.join(configured_name);
 
-        let luarc_path = self.root.join(LUARC);
-        if luarc_path.is_file() {
-            luarc_path
+        if file_path.is_file() {
+            file_path
         } else {
             let emmy_path = self.root.join(EMMYRC);
             if emmy_path.is_file() {
                 emmy_path
             } else {
-                luarc_path
+                file_path
             }
         }
     }
@@ -463,9 +460,10 @@ members = [ "glob:projects/*" ]
 
         let workspace = Workspace::from(&project_root).unwrap().unwrap();
 
-        let mut builder = crate::config::ConfigBuilder::default();
-        builder = builder.ls_config_file(Some("custom_config.json".to_string()));
-        let config = builder.build().unwrap();
+        let config = crate::config::ConfigBuilder::default()
+            .luarc_file_name(Some("custom_config.json".to_string()))
+            .build()
+            .unwrap();
 
         let path = workspace.luarc_path(&config);
         assert_eq!(path, workspace.root().join("custom_config.json"));

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -2638,7 +2638,7 @@ impl TypedUserData for WorkspaceLua {
         });
 
         methods.add_method("luarc_path", |_, this, ()| {
-            Ok(this.0.luarc_path().to_slash_lossy().into_owned())
+            Ok(this.0.luarc_path(config).to_slash_lossy().into_owned())
         });
     }
     fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -2637,7 +2637,7 @@ impl TypedUserData for WorkspaceLua {
             this.0.test_tree(&config.0).map(TreeLua).into_lua_err()
         });
 
-        methods.add_method("luarc_path", |_, this, ()| {
+        methods.add_method("luarc_path", |_, this, config: ConfigLua| {
             Ok(this.0.luarc_path(&config.0).to_slash_lossy().into_owned())
         });
     }

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -2638,7 +2638,7 @@ impl TypedUserData for WorkspaceLua {
         });
 
         methods.add_method("luarc_path", |_, this, ()| {
-            Ok(this.0.luarc_path(config).to_slash_lossy().into_owned())
+            Ok(this.0.luarc_path(&config.0).to_slash_lossy().into_owned())
         });
     }
     fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {


### PR DESCRIPTION
# Summary

Closes #1233

Adds an `ls_config_file` option so users can choose their preferred LSP config filename (like `.emmyrc.json`). Right now, Lux defaults to creating a `.luarc.json` on fresh projects even if the user prefers EmmyLua.

Please let me know if I missed anything, messed up the logic or existing feature, or if there's a better way to approach this!

# Changes
- Added `ls_config_file: Option<String>` to `Config` and `ConfigBuilder`.
- Updated `luarc_path(&self, config: &Config)` to immediately return the custom path if defined, bypassing filesystem checks.
- Fed `&config` / `config` into various `workspace.luarc_path()` calls across the codebase.
- Added unit tests.

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
