### PR TITLE
fix(lux-lua): build rock with `vendored-module` feature

### DIFF
--- a/lux.toml
+++ b/lux.toml
@@ -16,7 +16,7 @@ dev = "git+https://github.com/lumen-oss/lux.git"
 [build]
 type = "rust-mlua"
 cargo_extra_args = ["--package", "lux-lua", "--locked"]
-features = ["vendored", "module"]
+features = ["vendored-module"]
 
 [build.modules]
 lux = "lux_lua"


### PR DESCRIPTION
Fixes #1627.