### PR TITLE
feat(lint): support specifying files & directories

### DIFF
--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -10,6 +10,8 @@ use lux_lib::{
 use path_slash::PathExt;
 use walkdir::WalkDir;
 
+use crate::utils::path::{classify_path, PathTarget};
+
 #[derive(Args)]
 pub struct Fmt {
     /// Path to a workspace, directory, or Lua file to format. Defaults to the current workspace.
@@ -34,28 +36,6 @@ enum FmtBackend {
     Luafmt,
     /// The default formatter used by [lua-language-server](https://luals.github.io/).
     EmmyluaCodestyle,
-}
-
-// TODO: For `lx check` #1407 and `lx lint` #1409, move `PathTarget` + `classify_path` into a shared module.
-enum PathTarget {
-    Workspace(Box<Workspace>),
-    Directory(PathBuf),
-    File(PathBuf),
-}
-
-fn classify_path(path: &Path) -> Result<PathTarget> {
-    if !path.exists() {
-        bail!("path does not exist: {}", path.display());
-    }
-    if let Some(workspace) = Workspace::from_exact(path)? {
-        return Ok(PathTarget::Workspace(Box::new(workspace)));
-    }
-    let path = std::path::absolute(path)?;
-    if path.is_file() {
-        Ok(PathTarget::File(path))
-    } else {
-        Ok(PathTarget::Directory(path))
-    }
 }
 
 pub fn format(args: Fmt, config: Config) -> Result<()> {

--- a/lux-cli/src/lint.rs
+++ b/lux-cli/src/lint.rs
@@ -1,13 +1,18 @@
+use std::path::PathBuf;
+
 use clap::Args;
 use eyre::Result;
 use itertools::Itertools;
 use lux_lib::{config::Config, operations::Exec, workspace::Workspace};
-use path_slash::PathBufExt;
+use path_slash::PathExt;
 
+use crate::utils::path::{classify_path, PathTarget};
 use crate::workspace::top_level_ignored_files;
 
 #[derive(Args)]
 pub struct Lint {
+    /// Path to a workspace, directory, or Lua file to lint. Defaults to the current workspace.
+    path: Option<PathBuf>,
     /// Arguments to pass to the luacheck command.{n}
     /// If you pass arguments to luacheck, Lux will not pass any default arguments.
     args: Option<Vec<String>>,
@@ -19,10 +24,27 @@ pub struct Lint {
 }
 
 pub async fn lint(lint_args: Lint, config: Config) -> Result<()> {
-    let workspace = Workspace::current()?;
-    let root_dir = match &workspace {
-        Some(workspace) => workspace.root().to_slash_lossy().to_string(),
-        None => std::env::current_dir()?.to_slash_lossy().to_string(),
+    let target = match lint_args.path.as_deref() {
+        Some(path) => classify_path(path)?,
+        None => match Workspace::current()? {
+            Some(workspace) => PathTarget::Workspace(Box::new(workspace)),
+            None => PathTarget::Directory(std::env::current_dir()?),
+        },
+    };
+
+    let (target_path, workspace) = match target {
+        PathTarget::Workspace(ws) => (ws.root().to_slash_lossy().to_string(), Some(*ws)),
+        PathTarget::Directory(dir) => {
+            let ws = Workspace::from(&dir)?;
+            (dir.to_slash_lossy().to_string(), ws)
+        }
+        PathTarget::File(file) => {
+            let ws = match file.parent() {
+                Some(parent) => Workspace::from(parent)?,
+                None => None,
+            };
+            (file.to_slash_lossy().to_string(), ws)
+        }
     };
 
     let check_args: Vec<String> = match lint_args.args {
@@ -41,7 +63,7 @@ pub async fn lint(lint_args: Lint, config: Config) -> Result<()> {
     };
 
     Exec::new("luacheck", None, &config)
-        .arg(root_dir)
+        .arg(target_path)
         .args(check_args)
         .disable_loader(true)
         .exec()

--- a/lux-cli/src/utils/mod.rs
+++ b/lux-cli/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod file_tree;
 pub(crate) mod github_metadata;
 pub(crate) mod install;
+pub(crate) mod path;

--- a/lux-cli/src/utils/path.rs
+++ b/lux-cli/src/utils/path.rs
@@ -1,0 +1,24 @@
+use eyre::{bail, Result};
+use lux_lib::workspace::Workspace;
+use std::path::{Path, PathBuf};
+
+pub enum PathTarget {
+    Workspace(Box<Workspace>),
+    Directory(PathBuf),
+    File(PathBuf),
+}
+
+pub fn classify_path(path: &Path) -> Result<PathTarget> {
+    if !path.exists() {
+        bail!("path does not exist: {}", path.display());
+    }
+    if let Some(workspace) = Workspace::from_exact(path)? {
+        return Ok(PathTarget::Workspace(Box::new(workspace)));
+    }
+    let path = std::path::absolute(path)?;
+    if path.is_file() {
+        Ok(PathTarget::File(path))
+    } else {
+        Ok(PathTarget::Directory(path))
+    }
+}


### PR DESCRIPTION
## Description

Close #1409 

Here, I try to implement specifying directories for the `lx-lint` command. 
Happy to receive any feedback about the implementation :pray: 

Changes:
- move `PathTarget` and `classify_path` into a shared module in `lux-cli/src/utils/path.rs`
- added an optional `path: Option<PathBuf>` parameter as the very first argument
- implemented "up-tree" lookup via `Workspace::from()` for loose files and directories

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
