### PR TITLE
feat(check): support specifying directories

### DIFF
--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -15,6 +15,7 @@ use crate::{
 #[derive(Args)]
 pub struct Check {
     /// Path to a workspace, directory, or Lua file to check. Defaults to the current workspace.
+    #[arg(short, long)]
     path: Option<PathBuf>,
     /// Comma-separated list of ignore patterns.
     /// Patterns must follow glob syntax.
@@ -86,13 +87,18 @@ pub async fn check(args: Check, config: Config) -> Result<()> {
 
             (dirs, rc)
         }
-        PathTarget::Directory(dir) => (vec![dir], None),
+        PathTarget::Directory(dir) => {
+            let rc = resolve_rc_files(&dir, &config)?;
+            (vec![dir], rc)
+        }
         PathTarget::File(file) => {
             let root = file
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
                 .to_path_buf();
-            (vec![root], None)
+
+            let rc = resolve_rc_files(&root, &config)?;
+            (vec![root], rc)
         }
     };
 
@@ -115,4 +121,17 @@ pub async fn check(args: Check, config: Config) -> Result<()> {
         .await
         .map_err(|err| eyre!(err.to_string()))?;
     Ok(())
+}
+
+fn resolve_rc_files(root: &Path, config: &Config) -> Result<Option<Vec<PathBuf>>> {
+    let rc_path = match Workspace::from(root)? {
+        Some(workspace) => workspace.luarc_path(config),
+        None => root.join(".luarc.json"),
+    };
+
+    if rc_path.is_file() {
+        Ok(Some(vec![rc_path]))
+    } else {
+        Ok(None)
+    }
 }

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Args)]
 pub struct Check {
     /// Path to a workspace, directory, or Lua file to check. Defaults to the current workspace.
-    #[arg(short, long)]
+    #[arg(long)]
     path: Option<PathBuf>,
     /// Comma-separated list of ignore patterns.
     /// Patterns must follow glob syntax.

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use clap::Args;
 use emmylua_check::OutputDestination;
 use eyre::{eyre, Result};
@@ -6,11 +8,14 @@ use lux_lib::{config::Config, progress::MultiProgress, workspace::Workspace};
 
 use crate::{
     args::OutputFormat,
+    utils::path::{classify_path, PathTarget},
     workspace::{sync_dependencies_if_locked, sync_test_dependencies_if_locked},
 };
 
 #[derive(Args)]
 pub struct Check {
+    /// Path to a workspace, directory, or Lua file to check. Defaults to the current workspace.
+    path: Option<PathBuf>,
     /// Comma-separated list of ignore patterns.
     /// Patterns must follow glob syntax.
     /// Lux will automatically add top-level ignored project files.
@@ -41,42 +46,61 @@ impl From<OutputFormat> for emmylua_check::OutputFormat {
 }
 
 pub async fn check(args: Check, config: Config) -> Result<()> {
-    let workspace = Workspace::current_or_err()?;
+    let target = match args.path.as_deref() {
+        None => PathTarget::Workspace(Box::new(Workspace::current_or_err()?)),
+        Some(path) => classify_path(path)?,
+    };
 
-    let progress = MultiProgress::new_arc(&config);
-    sync_dependencies_if_locked(&workspace, progress.clone(), &config).await?;
-    sync_test_dependencies_if_locked(&workspace, progress, &config).await?;
+    let (workspace_dirs, rc_files) = match target {
+        PathTarget::Workspace(workspace) => {
+            let progress = MultiProgress::new_arc(&config);
+            sync_dependencies_if_locked(&workspace, progress.clone(), &config).await?;
+            sync_test_dependencies_if_locked(&workspace, progress, &config).await?;
 
-    let workspace_dirs = workspace
-        .members()
-        .iter()
-        .map(|project| project.root())
-        .flat_map(|project_root| {
-            vec![
-                project_root.join("src"),
-                project_root.join("lua"),
-                // For now, we don't include tests
-                // because they require LLS_Addons definitions for busted
+            let dirs = workspace
+                .members()
+                .iter()
+                .map(|project| project.root())
+                .flat_map(|project_root| {
+                    vec![
+                        project_root.join("src"),
+                        project_root.join("lua"),
+                        // For now, we don't include tests
+                        // because they require LLS_Addons definitions for busted
 
-                // project_root.join("test"),
-                // project_root.join("tests"),
-                // project_root.join("spec"),
-            ]
-        })
-        .filter(|dir| dir.is_dir())
-        .collect_vec();
+                        // project_root.join("test"),
+                        // project_root.join("tests"),
+                        // project_root.join("spec"),
+                    ]
+                })
+                .filter(|dir| dir.is_dir())
+                .collect_vec();
+
+            let luarc_path = workspace.luarc_path(&config);
+
+            let rc = if luarc_path.is_file() {
+                Some(vec![luarc_path])
+            } else {
+                None
+            };
+
+            (dirs, rc)
+        }
+        PathTarget::Directory(dir) => (vec![dir], None),
+        PathTarget::File(file) => {
+            let root = file
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf();
+            (vec![root], None)
+        }
+    };
 
     if workspace_dirs.is_empty() {
         println!("Nothing to check!");
         return Ok(());
     }
 
-    let luarc_path = workspace.luarc_path(&config);
-    let rc_files = if luarc_path.is_file() {
-        Some(vec![luarc_path])
-    } else {
-        None
-    };
     let emmylua_check_args = emmylua_check::CmdArgs {
         config: rc_files,
         workspace: workspace_dirs,


### PR DESCRIPTION
## Description

Close #1407 

Add support for specifying dir for `lx check`.
Happy to receive any feedback about the implementation 🙏

Changes:
- Modified argument parsing for the `check` command to accept path target
- Reused `PathTarget` and `classify_path`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
