### PR TITLE
feat!: improved error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,33 +865,6 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
 
 [[package]]
 name = "colorchoice"
@@ -1864,16 +1846,6 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -2868,12 +2840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +2996,12 @@ dependencies = [
  "is-docker",
  "once_cell",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_executable"
@@ -3404,12 +3376,10 @@ dependencies = [
  "base32",
  "clap 4.6.1",
  "clap_complete",
- "color-eyre",
  "edit",
  "emmylua_check",
  "emmylua_codestyle",
  "emmylua_formatter",
- "eyre",
  "git2",
  "ignore",
  "indicatif",
@@ -3417,6 +3387,7 @@ dependencies = [
  "itertools 0.15.0",
  "lux-lib",
  "lux-workspace-hack",
+ "miette 7.6.0",
  "nucleo",
  "octocrab",
  "open",
@@ -3425,6 +3396,7 @@ dependencies = [
  "pathdiff",
  "serde_json",
  "serial_test",
+ "shlex",
  "spdx",
  "spinners",
  "strum 0.28.0",
@@ -3489,6 +3461,7 @@ dependencies = [
  "lux-macros",
  "lux-workspace-hack",
  "md5 0.8.0",
+ "miette 7.6.0",
  "nix-nar",
  "nonempty",
  "openssl",
@@ -3596,6 +3569,7 @@ dependencies = [
  "lock_api",
  "log",
  "memchr",
+ "miette 7.6.0",
  "miniz_oxide",
  "num-traits",
  "parking_lot",
@@ -3612,6 +3586,7 @@ dependencies = [
  "smallvec",
  "subtle",
  "syn 2.0.118",
+ "textwrap",
  "time",
  "tokio",
  "tokio-util",
@@ -3621,7 +3596,6 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "tracing",
- "tracing-core",
  "typenum",
  "url",
  "winnow 0.7.15",
@@ -3687,9 +3661,28 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
 dependencies = [
- "miette-derive",
+ "miette-derive 5.10.0",
  "once_cell",
  "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive 7.6.0",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
  "unicode-width 0.1.14",
 ]
 
@@ -3698,6 +3691,17 @@ name = "miette-derive"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5825,15 +5829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6039,7 +6034,7 @@ dependencies = [
  "base64 0.21.7",
  "digest 0.10.7",
  "hex",
- "miette",
+ "miette 5.10.0",
  "serde",
  "sha-1",
  "sha2 0.10.9",
@@ -6214,6 +6209,27 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "symlink"
@@ -6401,6 +6417,10 @@ name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -6802,28 +6822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -6991,6 +6989,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7100,12 +7104,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ indicatif = "0.18"
 itertools = "0.15"
 lux-workspace-hack = { version = "0.1", path = "./lux-workspace-hack" }
 lux-macros = { version = "0.1", path = "./lux-macros" }
+miette = { version = "7.6", features = ["derive"] }
 path-absolutize = "4.0"
 path-slash = "0.2"
 pathdiff = "0.2"

--- a/lux-cli/Cargo.toml
+++ b/lux-cli/Cargo.toml
@@ -25,14 +25,14 @@ edit = { version = "0.1", features = ["quoted-env"] }
 emmylua_check = { version = "0.23", features = [] }
 emmylua_formatter = { version = "0.24", features = [] }
 emmylua_codestyle = "0.6.0"
-eyre = "0.6"
-color-eyre = "0.6"
 inquire = "0.9"
+miette = { workspace = true, features = ["fancy"] }
 nucleo = "0.5"
 octocrab = "0.54"
 open = "5.3"
 spdx = "0.13"
 spinners = { version = "4.2", features = ["osc-progress"] }
+shlex = "2.0"
 termcolor = "1.4"
 termtree = "1.0"
 text_trees = "0.1"
@@ -79,6 +79,6 @@ panic = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 
-# Improve color-eyre performance in debug mode
+# Improve miette backtrace performance in debug mode
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/lux-cli/src/add.rs
+++ b/lux-cli/src/add.rs
@@ -1,4 +1,3 @@
-use eyre::Result;
 use itertools::{Either, Itertools};
 use lux_lib::{
     config::Config,
@@ -8,6 +7,7 @@ use lux_lib::{
     rockspec::lua_dependency::{self},
     workspace::Workspace,
 };
+use miette::Result;
 
 use crate::workspace::{
     sync_build_dependencies_if_locked, sync_dependencies_if_locked,

--- a/lux-cli/src/args.rs
+++ b/lux-cli/src/args.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
-use eyre::{eyre, Result};
 use lux_lib::package::PackageReq;
+use miette::{miette, Result};
 use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Clone)]
@@ -16,7 +16,7 @@ pub enum OutputFormat {
 }
 
 impl FromStr for PackageOrRockspec {
-    type Err = eyre::Error;
+    type Err = miette::Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let path = PathBuf::from(s);
@@ -24,7 +24,7 @@ impl FromStr for PackageOrRockspec {
             Ok(Self::RockSpec(path))
         } else {
             let pkg = PackageReq::from_str(s).map_err(|err| {
-                eyre!(
+                miette!(
                     "No file {0} found and cannot parse package query: {1}",
                     s,
                     err

--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use clap::Parser;
-use eyre::Result;
 use lux_cli::{
     add, build, check, completion, config,
     debug::{self, Debug},
@@ -17,13 +16,35 @@ use lux_lib::{
     lockfile::PinnedState::{Pinned, Unpinned},
     lua_version::LuaVersion,
 };
+use miette::{MietteHandlerOpts, Result};
+
+use lux_cli::utils::error::clap_to_miette;
 
 const DEFAULT_USER_AGENT: &str = concat!("lux/", env!("CARGO_PKG_VERSION"));
-
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
-    color_eyre::install()?;
-    let cli = Cli::parse();
+    miette::set_hook(Box::new(|_| {
+        Box::new(
+            MietteHandlerOpts::new()
+                .terminal_links(true)
+                .unicode(true)
+                .context_lines(3)
+                .tab_width(4)
+                .break_words(true)
+                .with_cause_chain()
+                .build(),
+        )
+    }))?;
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(err) => match clap_to_miette(err) {
+            Ok(report) => return Err(report),
+            Err(text) => {
+                print!("{text}");
+                return Err(miette::miette!("not enough arguments supplied"));
+            }
+        },
+    };
 
     let lua_version = cli.lua_version.or({
         if cli.nvim {

--- a/lux-cli/src/build.rs
+++ b/lux-cli/src/build.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::Config,
     lockfile::LocalPackage,
@@ -7,6 +6,7 @@ use lux_lib::{
     package::PackageName,
     workspace::Workspace,
 };
+use miette::Result;
 
 #[derive(Args, Default)]
 pub struct Build {

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -2,9 +2,9 @@ use std::path::{Path, PathBuf};
 
 use clap::Args;
 use emmylua_check::OutputDestination;
-use eyre::{eyre, Result};
 use itertools::Itertools;
 use lux_lib::{config::Config, progress::MultiProgress, workspace::Workspace};
+use miette::{miette, Result};
 
 use crate::{
     args::OutputFormat,
@@ -119,7 +119,7 @@ pub async fn check(args: Check, config: Config) -> Result<()> {
 
     emmylua_check::run_check(emmylua_check_args)
         .await
-        .map_err(|err| eyre!(err.to_string()))?;
+        .map_err(|err| miette!("{err}"))?;
     Ok(())
 }
 

--- a/lux-cli/src/completion.rs
+++ b/lux-cli/src/completion.rs
@@ -6,8 +6,8 @@ use clap::Args;
 use clap::CommandFactory;
 use clap_complete::generate as clap_generate;
 use clap_complete::Shell;
-use eyre::eyre;
-use eyre::Result;
+use miette::miette;
+use miette::Result;
 
 use crate::Cli;
 
@@ -26,7 +26,7 @@ pub async fn completion(args: Completion) -> Result<()> {
         None => {
             let shell_var: PathBuf = env::var("SHELL")
                 .map_err(|_| {
-                    eyre!(
+                    miette!(
                         r#"could not auto-detect the shell
 Please make sure the SHELL environment variable is set
 or specify the shell for which to generate completions.
@@ -43,7 +43,7 @@ Supported shells: "bash", "elvish", "fish", "powershell", "zsh"
                 .unwrap_or_else(|| shell_var.as_os_str())
                 .to_string_lossy();
             Shell::from_str(&shell_name).map_err(|_| {
-                eyre!(
+                miette!(
                     r#"unsupported shell: {}.
 Please specify the shell for which to generate completions.
 

--- a/lux-cli/src/config.rs
+++ b/lux-cli/src/config.rs
@@ -1,6 +1,6 @@
-use eyre::{eyre, Context, OptionExt, Result};
 use inquire::Confirm;
 use lux_lib::config::{Config, ConfigBuilder};
+use miette::{miette, Context, IntoDiagnostic, Result};
 
 #[derive(clap::Subcommand)]
 pub enum ConfigCmd {
@@ -34,30 +34,32 @@ pub fn config(cmd: ConfigCmd, config: Config) -> Result<()> {
                 || Confirm::new("Config already exists. Overwrite?")
                     .with_default(false)
                     .prompt()
+                    .into_diagnostic()
                     .wrap_err("error prompting to overwrite config")?
             {
                 std::fs::create_dir_all(
                     config_file
                         .parent()
-                        .ok_or_eyre("error getting lux config parent directory")?,
-                )?;
+                        .ok_or_else(|| miette!("error getting lux config parent directory"))?,
+                )
+                .into_diagnostic()?;
                 let content = if init.default {
                     let cfg: ConfigBuilder = ConfigBuilder::default().build()?.into();
-                    toml::to_string(&cfg)?
+                    toml::to_string(&cfg).into_diagnostic()?
                 } else if init.current {
                     let cfg: ConfigBuilder = config.into();
-                    toml::to_string(&cfg)?
+                    toml::to_string(&cfg).into_diagnostic()?
                 } else {
                     String::default()
                 };
-                std::fs::write(&config_file, content)?;
+                std::fs::write(&config_file, content).into_diagnostic()?;
                 print!("Config initialised at {}", config_file.display());
             }
         }
         ConfigCmd::Edit => {
             let config_file = ConfigBuilder::config_file()?;
             if !config_file.is_file() {
-                return Err(eyre!(
+                return Err(miette!(
                     "
 No config file found.
 Use 'lux config init', 'lux config init --default', or 'lux config init --current'
@@ -65,11 +67,11 @@ to initialise a config file.
 "
                 ));
             }
-            edit::edit_file(config_file)?;
+            edit::edit_file(config_file).into_diagnostic()?;
         }
         ConfigCmd::Show => {
             let cfg: ConfigBuilder = config.into();
-            print!("{}", toml::to_string(&cfg)?);
+            print!("{}", toml::to_string(&cfg).into_diagnostic()?);
         }
     }
     Ok(())

--- a/lux-cli/src/debug/toolchains.rs
+++ b/lux-cli/src/debug/toolchains.rs
@@ -1,7 +1,7 @@
 use crate::args::OutputFormat;
 use clap::Args;
-use eyre::Result;
 use lux_lib::toolchains::{Tool, ToolchainReport};
+use miette::{IntoDiagnostic, Result};
 
 #[derive(Args)]
 pub struct Toolchains {
@@ -69,7 +69,7 @@ fn print_toolchains(dep: &Tool) {
 }
 
 fn print_json(report: &ToolchainReport) -> Result<()> {
-    let json = serde_json::to_string_pretty(report)?;
+    let json = serde_json::to_string_pretty(report).into_diagnostic()?;
     println!("{}", json);
     Ok(())
 }

--- a/lux-cli/src/dist/bin.rs
+++ b/lux-cli/src/dist/bin.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::{Config, ConfigBuilder},
     operations::DistProjectBin,
@@ -9,6 +8,7 @@ use lux_lib::{
     tree::FlatDistTree,
     workspace::Workspace,
 };
+use miette::{IntoDiagnostic, Result};
 use tempfile::tempdir;
 
 use crate::args::OutputFormat;
@@ -32,7 +32,7 @@ pub struct Bin {
 }
 
 pub async fn bin(data: Bin, config: Config) -> Result<()> {
-    let staging_dir = tempdir()?;
+    let staging_dir = tempdir().into_diagnostic()?;
     let config = ConfigBuilder::from(config)
         .wrap_bin_scripts(Some(false))
         .user_tree(Some(staging_dir.path().to_path_buf()))
@@ -53,10 +53,11 @@ pub async fn bin(data: Bin, config: Config) -> Result<()> {
         .tree(&tree)
         .maybe_output(data.output)
         .compile()
-        .await?;
+        .await
+        .into_diagnostic()?;
 
     match data.output_format {
-        OutputFormat::Json => println!("{}", serde_json::to_string(&out)?),
+        OutputFormat::Json => println!("{}", serde_json::to_string(&out).into_diagnostic()?),
         OutputFormat::Text => println!("Binary written to {}", out.display()),
     }
 

--- a/lux-cli/src/dist/flat_archive.rs
+++ b/lux-cli/src/dist/flat_archive.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use clap::Args;
-use eyre::{eyre, Context as _, OptionExt, Result};
 use lux_lib::{
     build::{Build, BuildBehaviour},
     config::{Config, ConfigBuilder},
@@ -18,6 +17,7 @@ use lux_lib::{
     tree::{self, FlatDistTree, InstallTree},
     workspace::Workspace,
 };
+use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use path_slash::PathExt;
 use tempfile::{tempdir, TempDir};
 use tokio::fs::{self, File};
@@ -78,7 +78,7 @@ enum CompressionMethod {
 }
 
 pub async fn dist_archive(args: FlatArchive, config: Config) -> Result<()> {
-    let staging_dir = tempdir()?;
+    let staging_dir = tempdir().into_diagnostic()?;
     let config = ConfigBuilder::from(config)
         // Wrapping bin scripts does not make sense for distributed packages.
         .wrap_bin_scripts(Some(false))
@@ -119,7 +119,9 @@ pub async fn dist_archive(args: FlatArchive, config: Config) -> Result<()> {
     zip_dir(&install_root, &destination, &args.compression_method).await?;
 
     match args.output_format {
-        OutputFormat::Json => println!("{}", serde_json::to_string(&destination)?),
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string(&destination).into_diagnostic()?)
+        }
         OutputFormat::Text => println!("Wrote archive to {}", destination.display()),
     }
 
@@ -168,7 +170,7 @@ async fn install_package(
     let package = packages
         .into_iter()
         .find(|pkg| pkg.name() == package.name())
-        .ok_or_eyre("package was not installed")?;
+        .ok_or_else(|| miette!("package was not installed"))?;
     Ok((package, tree.root()))
 }
 
@@ -177,7 +179,9 @@ async fn install_rockspec(
     staging_dir: &TempDir,
     config: &Config,
 ) -> Result<(LocalPackage, PathBuf)> {
-    let content = tokio::fs::read_to_string(&rockspec_path).await?;
+    let content = tokio::fs::read_to_string(&rockspec_path)
+        .await
+        .into_diagnostic()?;
     let lua_version = LuaVersion::from(config)?.clone();
     let rockspec = match rockspec_path
         .extension()
@@ -186,7 +190,7 @@ async fn install_rockspec(
         .as_str()
     {
         "rockspec" => Ok(RemoteLuaRockspec::new(&content)?),
-        _ => Err(eyre!(
+        _ => Err(miette!(
             "expected a path to a .rockspec or a package requirement."
         )),
     }?;
@@ -213,10 +217,14 @@ async fn install_rockspec(
 
 async fn zip_dir(src_dir: &Path, dest_file: &Path, method: &CompressionMethod) -> Result<()> {
     if dest_file.exists() {
-        return Err(eyre!("File {} already exists!", dest_file.display()));
+        return Err(miette!("File {} already exists!", dest_file.display()));
     }
     let temp_archive = PathBuf::from(format!("{}.part", dest_file.display()));
-    let archive = File::create(&temp_archive).await?.into_std().await;
+    let archive = File::create(&temp_archive)
+        .await
+        .into_diagnostic()?
+        .into_std()
+        .await;
     let walkdir = WalkDir::new(src_dir);
     let mut zip = ZipWriter::new(archive);
 
@@ -239,28 +247,31 @@ async fn zip_dir(src_dir: &Path, dest_file: &Path, method: &CompressionMethod) -
 
     for entry_result in walkdir.into_iter() {
         let entry = entry_result.map_err(|err| {
-            eyre!(
+            miette!(
                 "Error while traversing directory {}: {}.",
                 src_dir.display(),
                 err,
             )
         })?;
         let path = entry.path();
-        let relative_path = path.strip_prefix(src_dir)?;
+        let relative_path = path.strip_prefix(src_dir).into_diagnostic()?;
         let relative_path_str = relative_path.to_slash_lossy().to_string();
         if path.is_file() {
-            zip.start_file(relative_path_str, options)?;
-            let mut f = File::open(path).await?.into_std().await;
-            io::copy(&mut f, &mut zip)?;
+            zip.start_file(relative_path_str, options)
+                .into_diagnostic()?;
+            let mut f = File::open(path).await.into_diagnostic()?.into_std().await;
+            io::copy(&mut f, &mut zip).into_diagnostic()?;
         } else if !relative_path.as_os_str().is_empty() {
-            zip.add_directory(relative_path_str, options)?;
+            zip.add_directory(relative_path_str, options)
+                .into_diagnostic()?;
         }
     }
-    zip.finish()?;
+    zip.finish().into_diagnostic()?;
     fs::rename(&temp_archive, &dest_file)
         .await
-        .context(format!(
-            "Error renaming {} to {}.",
+        .into_diagnostic()
+        .wrap_err(format!(
+            "Error renaming {} to {}",
             temp_archive.display(),
             dest_file.display()
         ))?;

--- a/lux-cli/src/doc.rs
+++ b/lux-cli/src/doc.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use eyre::{eyre, Context, OptionExt, Result};
 use inquire::{Confirm, Select};
 use itertools::Itertools;
 use lux_lib::{
@@ -11,6 +10,7 @@ use lux_lib::{
     rockspec::Rockspec,
     tree::{InstallTree, RockMatches, Tree},
 };
+use miette::{miette, Context, IntoDiagnostic, Result};
 use url::Url;
 use walkdir::WalkDir;
 
@@ -27,9 +27,9 @@ pub async fn doc(args: Doc, config: Config) -> Result<()> {
     let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;
     let package_id = match tree.match_rocks(&args.package)? {
         RockMatches::NotFound(package_req) => {
-            Err(eyre!("No package matching {} found.", package_req))
+            Err(miette!("No package matching {} found.", package_req))
         }
-        RockMatches::Many(_package_ids) => Err(eyre!(
+        RockMatches::Many(_package_ids) => Err(miette!(
             "
 Found multiple packages matching {}.
 Please specify an exact package (<name>@<version>) or narrow the version requirement.
@@ -41,7 +41,7 @@ Please specify an exact package (<name>@<version>) or narrow the version require
     let lockfile = tree.lockfile()?;
     let pkg = lockfile
         .get(&package_id)
-        .ok_or_eyre("package is installed, but not found in the lockfile")?
+        .ok_or_else(|| miette!("package is installed, but not found in the lockfile"))?
         .clone();
     if args.online {
         open_homepage(pkg, &tree).await
@@ -53,18 +53,18 @@ Please specify an exact package (<name>@<version>) or narrow the version require
 async fn open_homepage(pkg: LocalPackage, tree: &Tree) -> Result<()> {
     let homepage = match get_homepage(&pkg, tree)? {
         Some(homepage) => Ok(homepage),
-        None => Err(eyre!(
+        None => Err(miette!(
             "Package {} does not have a homepage in its RockSpec.",
             pkg.into_package_spec()
         )),
     }?;
-    open::that(homepage.to_string())?;
+    open::that(homepage.to_string()).into_diagnostic()?;
     Ok(())
 }
 
 fn get_homepage(pkg: &LocalPackage, tree: &Tree) -> Result<Option<Url>> {
     let layout = tree.installed_rock_layout(pkg)?;
-    let rockspec_content = std::fs::read_to_string(layout.rockspec_path())?;
+    let rockspec_content = std::fs::read_to_string(layout.rockspec_path()).into_diagnostic()?;
     let rockspec = RemoteLuaRockspec::new(&rockspec_content)?;
     Ok(rockspec.description().homepage.clone())
 }
@@ -82,10 +82,11 @@ async fn open_local_docs(pkg: LocalPackage, tree: &Tree, config: &Config) -> Res
                 None
             }
         })
-        .try_collect()?;
+        .try_collect()
+        .into_diagnostic()?;
     match files.first() {
         Some(file) if files.len() == 1 => {
-            edit::edit_file(layout.doc.join(file))?;
+            edit::edit_file(layout.doc.join(file)).into_diagnostic()?;
             Ok(())
         }
         Some(_) => {
@@ -94,27 +95,29 @@ async fn open_local_docs(pkg: LocalPackage, tree: &Tree, config: &Config) -> Res
                 files,
             )
             .prompt()
+            .into_diagnostic()
             .wrap_err("error selecting from multiple files")?;
-            edit::edit_file(layout.doc.join(file))?;
+            edit::edit_file(layout.doc.join(file)).into_diagnostic()?;
             Ok(())
         }
         None => match get_homepage(&pkg, tree)? {
-            None => Err(eyre!(
+            None => Err(miette!(
                 "No documentation found for package {}",
                 pkg.into_package_spec()
             )),
             Some(homepage) => {
                 if config.no_prompt() {
-                    return Err(eyre!(
+                    return Err(miette!(
                         "No local documentation found for package {}",
                         pkg.into_package_spec()
                     ));
                 } else if Confirm::new("No local documentation found. Open homepage?")
                     .with_default(false)
                     .prompt()
+                    .into_diagnostic()
                     .wrap_err("error prompting to open homepage")?
                 {
-                    open::that(homepage.to_string())?;
+                    open::that(homepage.to_string()).into_diagnostic()?;
                 }
                 Ok(())
             }

--- a/lux-cli/src/download.rs
+++ b/lux-cli/src/download.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{config::Config, operations, package::PackageReq, progress::MultiProgress};
+use miette::Result;
 
 #[derive(Args)]
 pub struct Download {

--- a/lux-cli/src/exec.rs
+++ b/lux-cli/src/exec.rs
@@ -1,10 +1,10 @@
 use std::env;
 
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::Config, lua_version::LuaVersion, operations, path::Paths, workspace::Workspace,
 };
+use miette::Result;
 
 #[derive(Args)]
 pub struct Exec {

--- a/lux-cli/src/fetch.rs
+++ b/lux-cli/src/fetch.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use eyre::Result;
 use lux_lib::{config::Config, operations::Download, progress::MultiProgress, rockspec::Rockspec};
+use miette::Result;
 
 use crate::unpack::UnpackRemote;
 

--- a/lux-cli/src/format.rs
+++ b/lux-cli/src/format.rs
@@ -2,11 +2,11 @@ use std::path::{Path, PathBuf};
 
 use clap::Args;
 use emmylua_formatter as luafmt;
-use eyre::{bail, Context, Result};
 use lux_lib::{
     config::Config, lua_version::LuaVersion, package::PackageName, project::Project,
     workspace::Workspace,
 };
+use miette::{bail, Context, IntoDiagnostic, Result};
 use path_slash::PathExt;
 use walkdir::WalkDir;
 
@@ -117,6 +117,7 @@ impl FmtConfig {
                 None,
                 stylua_lib::OutputVerification::Full,
             )
+            .into_diagnostic()
             .context(format!("error formatting {} with stylua.", path.display()))?,
             FmtBackend::Luafmt => {
                 luafmt::check_text(code, self.luafmt_syntax_level.into(), &self.luafmt).formatted
@@ -142,9 +143,10 @@ fn format_files(
     backend: &FmtBackend,
 ) -> Result<()> {
     files.into_iter().try_for_each(|file| {
-        let unformatted_code = std::fs::read_to_string(&file)?;
+        let unformatted_code = std::fs::read_to_string(&file).into_diagnostic()?;
         let formatted_code = configs.format(backend, &file, &unformatted_code)?;
         std::fs::write(&file, formatted_code)
+            .into_diagnostic()
             .context(format!("error writing formatted file {}.", file.display()))
     })
 }

--- a/lux-cli/src/generate_rockspec.rs
+++ b/lux-cli/src/generate_rockspec.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{package::PackageName, project::Project, rockspec::Rockspec, workspace::Workspace};
+use miette::{IntoDiagnostic, Result};
 use std::path::PathBuf;
 
 use crate::args::OutputFormat;
@@ -36,7 +36,10 @@ pub async fn generate_rockspec(data: GenerateRockspec) -> Result<()> {
     }
 
     if data.output_format == OutputFormat::Json {
-        println!("{}", serde_json::to_string(&generated_paths)?);
+        println!(
+            "{}",
+            serde_json::to_string(&generated_paths).into_diagnostic()?
+        );
     }
 
     Ok(())
@@ -50,7 +53,7 @@ async fn generate_project_rockspec(project: &Project) -> Result<PathBuf> {
         .root()
         .join(format!("{}-{}.rockspec", toml.package(), toml.version()));
 
-    tokio::fs::write(&path, rockspec).await?;
+    tokio::fs::write(&path, rockspec).await.into_diagnostic()?;
 
     Ok(path)
 }

--- a/lux-cli/src/info.rs
+++ b/lux-cli/src/info.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::Config, operations::Download, package::PackageReq, progress::MultiProgress,
     rockspec::Rockspec, tree::InstallTree,
 };
+use miette::Result;
 
 use crate::workspace::current_workspace_or_user_tree;
 

--- a/lux-cli/src/install.rs
+++ b/lux-cli/src/install.rs
@@ -1,8 +1,8 @@
-use eyre::Result;
 use lux_lib::{
     config::Config, lockfile::PinnedState, lua_version::LuaVersion, operations,
     package::PackageReq, progress::MultiProgress,
 };
+use miette::Result;
 
 use crate::utils::install::apply_build_behaviour;
 

--- a/lux-cli/src/install_lua.rs
+++ b/lux-cli/src/install_lua.rs
@@ -1,10 +1,10 @@
-use eyre::{OptionExt, Result};
 use lux_lib::{
     config::Config,
     lua_installation::LuaInstallation,
     lua_version::LuaVersion,
     progress::{MultiProgress, ProgressBar},
 };
+use miette::{miette, Result};
 
 pub async fn install_lua(config: Config) -> Result<()> {
     let version_stringified = &LuaVersion::from(&config)?;
@@ -24,7 +24,7 @@ pub async fn install_lua(config: Config) -> Result<()> {
         .includes()
         .first()
         .and_then(|dir| dir.parent())
-        .ok_or_eyre("error getting lua include parent directory")?;
+        .ok_or_else(|| miette!("error getting lua include parent directory"))?;
 
     bar.map(|bar| {
         bar.finish_with_message(format!(

--- a/lux-cli/src/install_rockspec.rs
+++ b/lux-cli/src/install_rockspec.rs
@@ -1,8 +1,7 @@
-use eyre::eyre;
+use miette::miette;
 use std::{path::PathBuf, sync::Arc};
 
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     build::{self, BuildBehaviour},
     config::Config,
@@ -15,6 +14,7 @@ use lux_lib::{
     rockspec::{LuaVersionCompatibility, Rockspec},
     tree::{self, InstallTree},
 };
+use miette::{IntoDiagnostic, Result};
 
 #[derive(Args, Default)]
 pub struct InstallRockspec {
@@ -36,13 +36,13 @@ pub async fn install_rockspec(data: InstallRockspec, config: Config) -> Result<(
         .map(|ext| ext != "rockspec")
         .unwrap_or(true)
     {
-        return Err(eyre!("Provided path is not a valid rockspec!"));
+        return Err(miette!("Provided path is not a valid rockspec!"));
     }
 
     let progress_arc = MultiProgress::new_arc(&config);
     let progress = Arc::clone(&progress_arc);
 
-    let content = std::fs::read_to_string(path)?;
+    let content = std::fs::read_to_string(path).into_diagnostic()?;
     let rockspec = RemoteLuaRockspec::new(&content)?;
     let lua_version = rockspec.lua_version_matches(&config)?;
     let lua = LuaInstallation::new(

--- a/lux-cli/src/lint.rs
+++ b/lux-cli/src/lint.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use eyre::Result;
 use itertools::Itertools;
 use lux_lib::{config::Config, operations::Exec, workspace::Workspace};
-use path_slash::PathExt;
+use path_slash::PathBufExt;
 
 use crate::utils::path::{classify_path, PathTarget};
 use crate::workspace::top_level_ignored_files;
+use miette::{IntoDiagnostic, Result};
 
 #[derive(Args)]
 pub struct Lint {
@@ -29,7 +29,7 @@ pub async fn lint(lint_args: Lint, config: Config) -> Result<()> {
         Some(path) => classify_path(path)?,
         None => match Workspace::current()? {
             Some(workspace) => PathTarget::Workspace(Box::new(workspace)),
-            None => PathTarget::Directory(std::env::current_dir()?),
+            None => PathTarget::Directory(std::env::current_dir().into_diagnostic()?),
         },
     };
 

--- a/lux-cli/src/list.rs
+++ b/lux-cli/src/list.rs
@@ -1,7 +1,7 @@
 use clap::Args;
-use eyre::Result;
 use itertools::Itertools as _;
 use lux_lib::{config::Config, lockfile::PinnedState, lua_version::LuaVersion, tree::InstallTree};
+use miette::{IntoDiagnostic, Result};
 use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
 
 use crate::args::OutputFormat;
@@ -19,7 +19,10 @@ pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
 
     match list_data.output_format {
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string(&available_rocks)?);
+            println!(
+                "{}",
+                serde_json::to_string(&available_rocks).into_diagnostic()?
+            );
         }
         OutputFormat::Text => {
             let formatting = TreeFormatting::dir_tree(FormatCharacters::box_chars());
@@ -38,7 +41,10 @@ pub fn list_installed(list_data: ListCmd, config: Config) -> Result<()> {
                     ));
                 }
 
-                println!("{}", tree.to_string_with_format(&formatting)?);
+                println!(
+                    "{}",
+                    tree.to_string_with_format(&formatting).into_diagnostic()?
+                );
             }
         }
     }

--- a/lux-cli/src/outdated.rs
+++ b/lux-cli/src/outdated.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
 use clap::Args;
-use eyre::Result;
 use itertools::Itertools;
 use lux_lib::{
     config::Config, lockfile::LocalPackage, lua_version::LuaVersion, package::PackageVersion,
     progress::MultiProgress, remote_package_db::RemotePackageDB, workspace::Workspace,
 };
+use miette::{IntoDiagnostic, Result};
 use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
 
 use crate::{args::OutputFormat, workspace::sync_dependencies_if_locked};
@@ -76,7 +76,10 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
                 })
                 .collect::<HashMap<_, _>>();
 
-            println!("{}", serde_json::to_string(&jsonified_rock_list)?);
+            println!(
+                "{}",
+                serde_json::to_string(&jsonified_rock_list).into_diagnostic()?
+            );
         }
         OutputFormat::Text => {
             let formatting = TreeFormatting::dir_tree(FormatCharacters::box_chars());
@@ -88,7 +91,10 @@ pub async fn outdated(outdated_data: Outdated, config: Config) -> Result<()> {
                     tree.push(format!("{} => {}", rock.version(), latest_version));
                 }
 
-                println!("{}", tree.to_string_with_format(&formatting)?);
+                println!(
+                    "{}",
+                    tree.to_string_with_format(&formatting).into_diagnostic()?
+                );
             }
         }
     }

--- a/lux-cli/src/pack.rs
+++ b/lux-cli/src/pack.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 
 use crate::{args::PackageOrRockspec, build, workspace::exists_matching_workspace_member};
 use clap::Args;
-use eyre::{eyre, OptionExt, Result};
 use itertools::Itertools;
 use lux_lib::{
     build::{Build, BuildBehaviour},
@@ -17,6 +16,7 @@ use lux_lib::{
     tree::{self, InstallTree},
     workspace::Workspace,
 };
+use miette::{miette, IntoDiagnostic, Result};
 use path_slash::PathBufExt;
 use tempfile::tempdir;
 
@@ -77,7 +77,7 @@ async fn pack_workspace(
     .await?;
 
     if packages.is_empty() {
-        return Err(eyre!("build did not produce a package"));
+        return Err(miette!("build did not produce a package"));
     }
 
     let mut rock_paths = Vec::new();
@@ -94,7 +94,7 @@ async fn pack_workspace(
 
 pub async fn pack(args: Pack, config: Config) -> Result<()> {
     let lua_version = LuaVersion::from(&config)?.clone();
-    let dest_dir = std::env::current_dir()?;
+    let dest_dir = std::env::current_dir().into_diagnostic()?;
     let progress = MultiProgress::new_arc(&config);
     let rock_paths: Vec<PathBuf> = match args.package_or_rockspec {
         Some(PackageOrRockspec::Package(package_req))
@@ -106,7 +106,7 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             let user_tree = config.user_tree(lua_version.clone())?;
             match user_tree.match_rocks(&package_req)? {
                 lux_lib::tree::RockMatches::NotFound(_) => {
-                    let temp_dir = tempdir()?;
+                    let temp_dir = tempdir().into_diagnostic()?;
                     let temp_config = config.with_tree(temp_dir.path().to_path_buf());
                     let tree = temp_config.user_tree(lua_version.clone())?;
                     let packages = Install::new(&temp_config)
@@ -119,7 +119,9 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                         .progress(progress)
                         .install()
                         .await?;
-                    let package = packages.first().ok_or_eyre("no packages installed")?;
+                    let package = packages
+                        .first()
+                        .ok_or_else(|| miette!("no packages installed"))?;
                     let rock_path = operations::Pack::new(dest_dir, tree, package.clone())
                         .pack()
                         .await?;
@@ -127,9 +129,9 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                 }
                 lux_lib::tree::RockMatches::Single(local_package_id) => {
                     let lockfile = user_tree.lockfile()?;
-                    let package = lockfile
-                        .get(&local_package_id)
-                        .ok_or_eyre("package is installed, but was not found in the lockfile")?;
+                    let package = lockfile.get(&local_package_id).ok_or_else(|| {
+                        miette!("package is installed, but was not found in the lockfile")
+                    })?;
                     let rock_path = operations::Pack::new(dest_dir, user_tree, package.clone())
                         .pack()
                         .await?;
@@ -138,9 +140,11 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                 lux_lib::tree::RockMatches::Many(vec) => {
                     let local_package_id = vec.first();
                     let lockfile = user_tree.lockfile()?;
-                    let package = lockfile.get(local_package_id).ok_or_eyre(
-                        "multiple package installations found, but not found in the lockfile",
-                    )?;
+                    let package = lockfile.get(local_package_id).ok_or_else(|| {
+                        miette!(
+                            "multiple package installations found, but not found in the lockfile"
+                        )
+                    })?;
                     let rock_path = operations::Pack::new(dest_dir, user_tree, package.clone())
                         .pack()
                         .await?;
@@ -149,7 +153,9 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
             }
         }
         Some(PackageOrRockspec::RockSpec(rockspec_path)) => {
-            let content = tokio::fs::read_to_string(&rockspec_path).await?;
+            let content = tokio::fs::read_to_string(&rockspec_path)
+                .await
+                .into_diagnostic()?;
             let rockspec = match rockspec_path
                 .extension()
                 .map(|ext| ext.to_string_lossy().to_string())
@@ -157,11 +163,11 @@ pub async fn pack(args: Pack, config: Config) -> Result<()> {
                 .as_str()
             {
                 "rockspec" => Ok(RemoteLuaRockspec::new(&content)?),
-                _ => Err(eyre!(
+                _ => Err(miette!(
                     "expected a path to a .rockspec or a package requirement."
                 )),
             }?;
-            let temp_dir = tempdir()?;
+            let temp_dir = tempdir().into_diagnostic()?;
             let bar = progress.map(|p| p.new_bar());
             let config = config.with_tree(temp_dir.path().to_path_buf());
             let lua = LuaInstallation::new(

--- a/lux-cli/src/path.rs
+++ b/lux-cli/src/path.rs
@@ -1,10 +1,10 @@
 use clap::Subcommand;
-use eyre::Result;
 use lux_lib::{
     config::Config,
     path::{BinPath, PackagePath, Paths},
     tree::InstallTree,
 };
+use miette::Result;
 use strum_macros::{Display, EnumString, VariantNames};
 
 use clap::{Args, ValueEnum};

--- a/lux-cli/src/pin.rs
+++ b/lux-cli/src/pin.rs
@@ -1,7 +1,4 @@
 use clap::Args;
-use eyre::eyre;
-use eyre::Context;
-use eyre::Result;
 use itertools::Itertools;
 use lux_lib::config::Config;
 use lux_lib::lockfile::PinnedState;
@@ -13,6 +10,9 @@ use lux_lib::progress::MultiProgress;
 use lux_lib::rockspec::lua_dependency;
 use lux_lib::tree::RockMatches;
 use lux_lib::workspace::Workspace;
+use miette::miette;
+use miette::Context;
+use miette::Result;
 
 #[derive(Args)]
 pub struct ChangePin {
@@ -46,7 +46,7 @@ pub async fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState)
                 .iter()
                 .any(|pkg| !pkg.version_req().is_any())
             {
-                return Err(eyre!(
+                return Err(miette!(
                     "Cannot pin project dependencies using version constraints."
                 ));
             }
@@ -115,7 +115,7 @@ pub async fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState)
                     RockMatches::Many(_) => {
                         todo!("Add an error here about many conflicting types and to use `all:`")
                     }
-                    RockMatches::NotFound(_) => return Err(eyre!("Rock {} not found!", package)),
+                    RockMatches::NotFound(_) => return Err(miette!("Rock {} not found!", package)),
                 }
             }
         }

--- a/lux-cli/src/project/debug.rs
+++ b/lux-cli/src/project/debug.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::workspace::Workspace;
+use miette::Result;
 
 use crate::utils::file_tree::term_tree_from_paths;
 

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -1,13 +1,13 @@
 use std::{error::Error, fmt::Display, path::PathBuf, str::FromStr};
 
 use clap::Args;
-use eyre::{eyre, Result};
 use inquire::{
     ui::{RenderConfig, Styled},
     validator::Validation,
     Confirm, Select, Text,
 };
 use itertools::Itertools;
+use miette::{miette, IntoDiagnostic, Result};
 use spdx::LicenseId;
 use spinners::{Spinner, Spinners};
 
@@ -157,9 +157,10 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
             .with_default(false)
             .with_help_message(&format!("This may overwrite your existing {PROJECT_TOML}",))
             .with_render_config(render_config)
-            .prompt()?
+            .prompt()
+            .into_diagnostic()?
     {
-        return Err(eyre!("cancelled creation of project (already exists)"));
+        return Err(miette!("cancelled creation of project (already exists)"));
     };
 
     let validated = match cli_flags {
@@ -173,7 +174,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
             name: Some(name),
             license,
             target,
-        } => Ok::<_, eyre::Report>(NewProjectValidated {
+        } => Ok::<_, miette::Report>(NewProjectValidated {
             description,
             labels,
             license,
@@ -206,40 +207,48 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
 
                     RepoMetadata::default(&target)
                 }
-            }?;
+            }
+            .into_diagnostic()?;
 
             spinner.stop_and_persist("✔", "Fetched remote repository metadata.".into());
 
-            let package_name = name.map_or_else(
-                || {
-                    Text::new("Package name:")
-                        .with_default(&repo_metadata.name)
-                        .with_help_message("A folder with the same name will be created for you.")
-                        .with_render_config(render_config)
-                        .prompt()
-                },
-                Ok,
-            )?;
+            let package_name = name
+                .map_or_else(
+                    || {
+                        Text::new("Package name:")
+                            .with_default(&repo_metadata.name)
+                            .with_help_message(
+                                "A folder with the same name will be created for you.",
+                            )
+                            .with_render_config(render_config)
+                            .prompt()
+                    },
+                    Ok,
+                )
+                .into_diagnostic()?;
 
-            let description = description.map_or_else(
-                || {
-                    Text::new("Description:")
-                        .with_default(&repo_metadata.description.unwrap_or_default())
-                        .with_render_config(render_config)
-                        .prompt()
-                },
-                Ok,
-            )?;
+            let description = description
+                .map_or_else(
+                    || {
+                        Text::new("Description:")
+                            .with_default(&repo_metadata.description.unwrap_or_default())
+                            .with_render_config(render_config)
+                            .prompt()
+                    },
+                    Ok,
+                )
+                .into_diagnostic()?;
 
             let license = license.map_or_else(
                 || {
-                    Ok::<_, eyre::Error>(
+                    Ok::<_, miette::Report>(
                         match Text::new("License:")
                             .with_default(&repo_metadata.license.unwrap_or("none".into()))
                             .with_help_message("Type 'none' for no license")
                             .with_validator(validate_license)
                             .with_render_config(render_config)
-                            .prompt()?
+                            .prompt()
+                            .into_diagnostic()?
                             .as_str()
                         {
                             "none" => None,
@@ -252,11 +261,12 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
 
             let labels = labels.or(repo_metadata.labels).map_or_else(
                 || {
-                    Ok::<_, eyre::Error>(
+                    Ok::<_, miette::Report>(
                         Text::new("Labels:")
                             .with_placeholder("web,filesystem")
                             .with_help_message("Labels are comma separated")
-                            .prompt()?
+                            .prompt()
+                            .into_diagnostic()?
                             .split(',')
                             .map(|label| label.trim().to_string())
                             .collect_vec(),
@@ -265,26 +275,28 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
                 Ok,
             )?;
 
-            let maintainer = maintainer.map_or_else(
-                || {
-                    let prompt = Text::new("Maintainer:");
-                    if let Some(default_maintainer) = repo_metadata
-                        .contributors
-                        .first()
-                        .cloned()
-                        .or_else(|| whoami::realname().ok())
-                    {
-                        prompt.with_default(&default_maintainer).prompt()
-                    } else {
-                        prompt.prompt()
-                    }
-                },
-                Ok,
-            )?;
+            let maintainer = maintainer
+                .map_or_else(
+                    || {
+                        let prompt = Text::new("Maintainer:");
+                        if let Some(default_maintainer) = repo_metadata
+                            .contributors
+                            .first()
+                            .cloned()
+                            .or_else(|| whoami::realname().ok())
+                        {
+                            prompt.with_default(&default_maintainer).prompt()
+                        } else {
+                            prompt.prompt()
+                        }
+                    },
+                    Ok,
+                )
+                .into_diagnostic()?;
 
             let lua_versions = lua_versions.map_or_else(
                 || {
-                    Ok::<_, eyre::Report>(
+                    Ok::<_, miette::Report>(
                         format!(
                             "lua >= {}",
                             Select::new(
@@ -296,7 +308,8 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
                             .with_help_message(
                                 "This is equivalent to the 'lua >= {version}' constraint."
                             )
-                            .prompt()?
+                            .prompt()
+                            .into_diagnostic()?
                         )
                         .parse()?,
                     )
@@ -317,7 +330,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
         }
     }?;
 
-    let _ = std::fs::create_dir_all(&validated.target);
+    let _ = std::fs::create_dir_all(&validated.target).into_diagnostic();
 
     let rocks_path = validated.target.join(PROJECT_TOML);
 
@@ -361,7 +374,8 @@ type = "builtin"
             main = validated.main,
         )
         .trim(),
-    )?;
+    )
+    .into_diagnostic()?;
 
     let main_dir = validated.target.join(validated.main.to_string());
     if main_dir.exists() {
@@ -370,8 +384,8 @@ type = "builtin"
             main_dir.display()
         );
     } else {
-        std::fs::create_dir(&main_dir)?;
-        std::fs::write(main_dir.join("main.lua"), r#"print("Hello world!")"#)?;
+        std::fs::create_dir(&main_dir).into_diagnostic()?;
+        std::fs::write(main_dir.join("main.lua"), r#"print("Hello world!")"#).into_diagnostic()?;
     }
 
     println!("All done!");

--- a/lux-cli/src/purge.rs
+++ b/lux-cli/src/purge.rs
@@ -1,4 +1,3 @@
-use eyre::Result;
 use inquire::Confirm;
 use lux_lib::{
     config::Config,
@@ -6,6 +5,7 @@ use lux_lib::{
     progress::{MultiProgress, ProgressBar},
     tree::InstallTree,
 };
+use miette::{IntoDiagnostic, Result};
 
 /// Purge the user tree
 pub async fn purge(config: Config) -> Result<()> {
@@ -16,7 +16,8 @@ pub async fn purge(config: Config) -> Result<()> {
     if !config.no_prompt()
         && Confirm::new(&format!("Are you sure you want to purge all {len} rocks?"))
             .with_default(false)
-            .prompt()?
+            .prompt()
+            .into_diagnostic()?
     {
         let root_dir = tree.root();
 
@@ -27,7 +28,9 @@ pub async fn purge(config: Config) -> Result<()> {
                 root_dir.display()
             )))
         });
-        tokio::fs::remove_dir_all(tree.root()).await?;
+        tokio::fs::remove_dir_all(tree.root())
+            .await
+            .into_diagnostic()?;
     }
 
     Ok(())

--- a/lux-cli/src/remove.rs
+++ b/lux-cli/src/remove.rs
@@ -1,10 +1,10 @@
 use clap::Args;
-use eyre::{OptionExt, Result};
 use itertools::Itertools;
 use lux_lib::{
     config::Config, package::PackageName, progress::MultiProgress, rockspec::lua_dependency,
     workspace::Workspace,
 };
+use miette::{miette, Result};
 
 use crate::workspace::{
     sync_build_dependencies_if_locked, sync_dependencies_if_locked,
@@ -31,7 +31,7 @@ pub struct Remove {
 }
 
 pub async fn remove(data: Remove, config: Config) -> Result<()> {
-    let mut workspace = Workspace::current()?.ok_or_eyre("No project found")?;
+    let mut workspace = Workspace::current()?.ok_or_else(|| miette!("No project found"))?;
     let progress = MultiProgress::new_arc(&config);
 
     let project = workspace.single_member_or_select_mut(&data.package)?;

--- a/lux-cli/src/run.rs
+++ b/lux-cli/src/run.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use eyre::Result;
 use lux_lib::{config::Config, operations, workspace::Workspace};
+use miette::Result;
 
 use crate::build::{self, Build};
 

--- a/lux-cli/src/run_lua.rs
+++ b/lux-cli/src/run_lua.rs
@@ -4,7 +4,6 @@ use path_slash::PathExt;
 use tokio::process::Command;
 
 use clap::Args;
-use eyre::{eyre, Result};
 use itertools::Itertools;
 use lux_lib::{
     config::Config,
@@ -14,6 +13,7 @@ use lux_lib::{
     progress::MultiProgress,
     workspace::Workspace,
 };
+use miette::{IntoDiagnostic, Result, WrapErr};
 
 use crate::build::{self, Build};
 
@@ -70,7 +70,7 @@ pub async fn run_lua(run_lua: RunLua, config: Config) -> Result<()> {
             let version = LuaVersion::from(&config)?.clone();
             (
                 version.clone(),
-                std::env::current_dir()?,
+                std::env::current_dir().into_diagnostic()?,
                 config.user_tree(version)?,
                 "Welcome to the lux Lua repl.".into(),
             )
@@ -129,15 +129,13 @@ To exit type 'exit()' or <C-d>.
 
 async fn print_lua_help(lua_cmd: &LuaBinary) -> Result<()> {
     let lua_cmd_path: PathBuf = lua_cmd.clone().try_into()?;
-    let output = match Command::new(lua_cmd_path.to_string_lossy().to_string())
+    let output = Command::new(lua_cmd_path.to_string_lossy().to_string())
         // HACK: This fails with exit 1, because lua doesn't actually have a help flag (╯°□°)╯︵ ┻━┻
         .arg("-h")
         .output()
         .await
-    {
-        Ok(output) => Ok(output),
-        Err(err) => Err(eyre!("Failed to run {}: {}", lua_cmd, err)),
-    }?;
+        .into_diagnostic()
+        .wrap_err(format!("Failed to run {lua_cmd}"))?;
     let lua_help = String::from_utf8_lossy(&output.stderr)
         .lines()
         .skip(2)

--- a/lux-cli/src/search.rs
+++ b/lux-cli/src/search.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use clap::Args;
-use eyre::Result;
 use itertools::Itertools;
+use miette::{IntoDiagnostic, Result};
 use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
 
 use lux_lib::{
@@ -41,7 +41,10 @@ pub async fn search(data: Search, config: Config) -> Result<()> {
         OutputFormat::Json => {
             let rock_to_version_map: HashMap<&PackageName, Vec<&PackageVersion>> =
                 HashMap::from_iter(result);
-            println!("{}", serde_json::to_string(&rock_to_version_map)?);
+            println!(
+                "{}",
+                serde_json::to_string(&rock_to_version_map).into_diagnostic()?
+            );
         }
         OutputFormat::Text => {
             for (key, versions) in result.into_iter().sorted() {
@@ -51,7 +54,10 @@ pub async fn search(data: Search, config: Config) -> Result<()> {
                     tree.push(version.to_string());
                 }
 
-                println!("{}", tree.to_string_with_format(&formatting)?);
+                println!(
+                    "{}",
+                    tree.to_string_with_format(&formatting).into_diagnostic()?
+                );
             }
         }
     }

--- a/lux-cli/src/shell.rs
+++ b/lux-cli/src/shell.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use eyre::{eyre, Result, WrapErr};
 use lux_lib::{
     config::Config, lua_installation::LuaInstallation, path::Paths, progress::MultiProgress,
     tree::InstallTree,
 };
+use miette::{miette, IntoDiagnostic, Result};
 use which::which;
 
 use std::{env, path::PathBuf};
@@ -31,7 +31,7 @@ pub struct Shell {
 
 pub async fn shell(data: Shell, config: Config) -> Result<()> {
     if env::var("LUX_SHELL").is_ok_and(|lx_shell_var| lx_shell_var == "1") {
-        return Err(eyre!("Already in a Lux shell."));
+        return Err(miette!("Already in a Lux shell."));
     }
 
     let tree = current_workspace_or_user_tree(&config)?;
@@ -53,13 +53,19 @@ pub async fn shell(data: Shell, config: Config) -> Result<()> {
         Ok(val) => PathBuf::from(val),
         Err(_) => {
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            let fallback = which("bash").wrap_err("Cannot find `bash` on your system!")?;
+            let fallback = which("bash")
+                .into_diagnostic()
+                .map_err(|_| miette!("Cannot find `bash` on your system!"))?;
 
             #[cfg(target_os = "windows")]
-            let fallback = which("cmd.exe").wrap_err("Cannot find `cmd.exe` on your system!")?;
+            let fallback = which("cmd.exe")
+                .into_diagnostic()
+                .map_err(|_| miette!("Cannot find `cmd.exe` on your system!"))?;
 
             #[cfg(target_os = "macos")]
-            let fallback = which("zsh").wrap_err("Cannot find `zsh` on your system!")?;
+            let fallback = which("zsh")
+                .into_diagnostic()
+                .map_err(|_| miette!("Cannot find `zsh` on your system!"))?;
 
             fallback
         }
@@ -100,9 +106,11 @@ pub async fn shell(data: Shell, config: Config) -> Result<()> {
         .env("LUA_CPATH", lua_cpath.joined())
         .env("LUA_INIT", lua_init.unwrap_or_default())
         .env("LUX_SHELL", "1")
-        .spawn()?
+        .spawn()
+        .into_diagnostic()?
         .wait()
-        .await?;
+        .await
+        .into_diagnostic()?;
 
     Ok(())
 }

--- a/lux-cli/src/sync.rs
+++ b/lux-cli/src/sync.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::Config, lockfile::LocalPackage, operations::Sync, progress::MultiProgress,
     workspace::Workspace,
 };
+use miette::Result;
 
 #[derive(Args)]
 pub struct SyncProject {

--- a/lux-cli/src/test.rs
+++ b/lux-cli/src/test.rs
@@ -1,11 +1,11 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::Config,
     operations::{self, TestEnv},
     package::PackageName,
     workspace::Workspace,
 };
+use miette::Result;
 
 #[derive(Args)]
 pub struct Test {

--- a/lux-cli/src/uninstall.rs
+++ b/lux-cli/src/uninstall.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use eyre::{eyre, Context, Result};
 use inquire::Confirm;
 use itertools::Itertools;
 use lux_lib::{
@@ -12,6 +11,7 @@ use lux_lib::{
     progress::MultiProgress,
     tree::{self, InstallTree, RockMatches, TreeError},
 };
+use miette::{miette, IntoDiagnostic, Result};
 
 #[derive(Args)]
 pub struct Uninstall {
@@ -44,14 +44,14 @@ pub async fn uninstall(uninstall_args: Uninstall, config: Config) -> Result<()> 
 
     if !nonexistent_packages.is_empty() {
         // TODO(vhyrro): Render this in the form of a tree.
-        return Err(eyre!(
+        return Err(miette!(
             "The following packages were not found: {:#?}",
             nonexistent_packages
         ));
     }
 
     if !duplicate_packages.is_empty() {
-        return Err(eyre!(
+        return Err(miette!(
             "
 Multiple packages satisfying your version requirements were found:
 {:#?}
@@ -75,7 +75,7 @@ Please specify the exact package to uninstall:
         })
         .collect_vec();
     if !non_entrypoints.is_empty() {
-        return Err(eyre!(
+        return Err(miette!(
             "
 Cannot uninstall dependencies:
 {:#?}
@@ -125,7 +125,8 @@ Reinstall?
             && Confirm::new(&prompt)
                 .with_default(false)
                 .prompt()
-                .wrap_err("Error prompting for reinstall")?
+                .into_diagnostic()
+                .map_err(|_| miette!("Error prompting for reinstall"))?
         {
             operations::Uninstall::new()
                 .config(&config)
@@ -162,7 +163,7 @@ Reinstall?
                 .install()
                 .await?;
         } else {
-            return Err(eyre!("Operation cancelled."));
+            return Err(miette!("Operation cancelled."));
         }
     };
 

--- a/lux-cli/src/unpack.rs
+++ b/lux-cli/src/unpack.rs
@@ -1,8 +1,8 @@
 use std::{fs::File, io::Cursor, path::PathBuf};
 
 use clap::Args;
-use eyre::Result;
 use lux_lib::{config::Config, operations, package::PackageReq, progress::MultiProgress};
+use miette::{IntoDiagnostic, Result};
 
 #[derive(Args)]
 pub struct Unpack {
@@ -23,7 +23,7 @@ pub async fn unpack(data: Unpack, config: Config) -> Result<()> {
     let destination = data.destination.unwrap_or_else(|| {
         PathBuf::from(data.path.to_string_lossy().trim_end_matches(".src.rock"))
     });
-    let src_file = File::open(data.path)?;
+    let src_file = File::open(data.path).into_diagnostic()?;
     let progress = MultiProgress::new(&config);
     let bar = progress.map(MultiProgress::new_bar);
 

--- a/lux-cli/src/update.rs
+++ b/lux-cli/src/update.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use eyre::{eyre, Context, Result};
 use itertools::Itertools;
 use lux_lib::package::{PackageName, PackageReq};
 use lux_lib::progress::{MultiProgress, ProgressBar};
@@ -7,6 +6,7 @@ use lux_lib::remote_package_db::RemotePackageDB;
 use lux_lib::rockspec::lua_dependency::LuaDependencyType;
 use lux_lib::workspace::Workspace;
 use lux_lib::{config::Config, operations};
+use miette::{miette, Context, Result};
 
 #[derive(Args)]
 pub struct Update {
@@ -129,7 +129,7 @@ pub async fn update(args: Update, config: Config) -> Result<()> {
 
 fn to_package_names(packages: Option<&Vec<PackageReq>>) -> Result<Option<Vec<PackageName>>> {
     if packages.is_some_and(|pkgs| !pkgs.iter().any(|pkg| pkg.version_req().is_any())) {
-        return Err(eyre!(
+        return Err(miette!(
             "Cannot use version constraints to upgrade dependencies in lux.toml."
         ));
     }

--- a/lux-cli/src/upload.rs
+++ b/lux-cli/src/upload.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{
     config::Config, package::PackageName, progress::MultiProgress,
     remote_package_db::RemotePackageDB, upload::ProjectUpload, workspace::Workspace,
 };
+use miette::{IntoDiagnostic, Result};
 
 #[cfg(feature = "gpgme")]
 use lux_lib::upload::SignatureProtocol;
@@ -101,9 +101,11 @@ fn tfa_code_from_args_or_secret(data: &Upload) -> Result<Option<String>> {
         None => match std::env::var("LUAROCKS_2FA_SECRET") {
             Ok(secret) => {
                 let secret = base32::decode(base32::Alphabet::Crockford, &secret)
-                    .ok_or(totp_rs::SecretParseError::ParseBase32)?;
-                let totp = totp_rs::TOTP::new(totp_rs::Algorithm::SHA1, 6, 1, 30, secret)?;
-                Ok(Some(totp.generate_current()?))
+                    .ok_or(totp_rs::SecretParseError::ParseBase32)
+                    .into_diagnostic()?;
+                let totp = totp_rs::TOTP::new(totp_rs::Algorithm::SHA1, 6, 1, 30, secret)
+                    .into_diagnostic()?;
+                Ok(Some(totp.generate_current().into_diagnostic()?))
             }
             Err(_) => Ok(None),
         },

--- a/lux-cli/src/utils/error.rs
+++ b/lux-cli/src/utils/error.rs
@@ -1,0 +1,624 @@
+//! Utility module for converting clap parsing errors into good-looking [`miette`] errors
+use std::{error::Error, ffi::OsStr, path::Path};
+
+use clap::error::{ContextKind, ContextValue, ErrorKind};
+use miette::{LabeledSpan, MietteDiagnostic, NamedSource, SourceSpan};
+
+/// All the [`ContextKind`] data exposed by a [`clap::Error`], extracted into a
+/// struct so we can pattern-match on it freely.
+enum ErrorContext {
+    InvalidValue {
+        arg: Option<String>,
+        value: Option<String>,
+        valid_values: Vec<String>,
+        custom: Option<String>,
+    },
+    ValueValidation {
+        arg: Option<String>,
+        value: Option<String>,
+        custom: Option<String>,
+    },
+    UnknownArgument {
+        arg: Option<String>,
+        suggested_arg: Option<String>,
+    },
+    InvalidSubcommand {
+        subcommand: Option<String>,
+        suggested_subcommand: Option<String>,
+        valid_subcommands: Vec<String>,
+    },
+    MissingRequiredArgument {
+        arg: Option<String>,
+    },
+    MissingSubcommand,
+    NoEquals {
+        arg: Option<String>,
+    },
+    TooManyValues {
+        arg: Option<String>,
+        actual: Option<isize>,
+        expected: Option<isize>,
+        custom: Option<String>,
+    },
+    TooFewValues {
+        arg: Option<String>,
+        actual: Option<isize>,
+        expected: Option<isize>,
+        custom: Option<String>,
+    },
+    WrongNumberOfValues {
+        arg: Option<String>,
+        actual: Option<isize>,
+        expected: Option<isize>,
+        custom: Option<String>,
+    },
+    ArgumentConflict {
+        arg: Option<String>,
+        prior: Vec<String>,
+    },
+    InvalidUtf8,
+    Other(String),
+}
+
+impl ErrorContext {
+    fn extract(error: &clap::Error) -> Self {
+        let kind = error.kind();
+        let mut custom = error.source().map(|s| s.to_string());
+
+        // Capture all the possibilities upfront so we can package it in structs later
+        let mut invalid_arg: Option<String> = None;
+        let mut invalid_value: Option<String> = None;
+        let mut invalid_subcommand: Option<String> = None;
+        let mut suggested_arg: Option<String> = None;
+        let mut suggested_subcommand: Option<String> = None;
+        let mut valid_values: Vec<String> = Vec::new();
+        let mut valid_subcommands: Vec<String> = Vec::new();
+        let mut prior_arg: Vec<String> = Vec::new();
+        let mut actual_num: Option<isize> = None;
+        let mut expected_num: Option<isize> = None;
+        let mut min_values: Option<isize> = None;
+
+        for (ctx_kind, value) in error.context() {
+            match (ctx_kind, value) {
+                (ContextKind::InvalidArg, ContextValue::String(s)) => {
+                    invalid_arg = Some(flag_of(s));
+                }
+                (ContextKind::InvalidArg, ContextValue::Strings(ss)) => {
+                    if let Some(s) = ss.first() {
+                        invalid_arg = Some(flag_of(s));
+                    }
+                }
+                (ContextKind::InvalidValue, ContextValue::String(s)) => {
+                    invalid_value = Some(s.clone());
+                }
+                (ContextKind::InvalidSubcommand, ContextValue::String(s)) => {
+                    invalid_subcommand = Some(s.clone());
+                }
+                (ContextKind::SuggestedArg, ContextValue::String(s)) => {
+                    suggested_arg = Some(s.clone());
+                }
+                (ContextKind::SuggestedSubcommand, ContextValue::Strings(ss)) => {
+                    if let Some(first) = ss.first() {
+                        suggested_subcommand = Some(first.clone());
+                    }
+                }
+                (ContextKind::ValidValue, ContextValue::Strings(ss)) => {
+                    valid_values = ss.clone();
+                }
+                (ContextKind::ValidSubcommand, ContextValue::Strings(ss)) => {
+                    valid_subcommands = ss.clone();
+                }
+                (ContextKind::PriorArg, ContextValue::String(s)) => prior_arg.push(s.clone()),
+                (ContextKind::PriorArg, ContextValue::Strings(ss)) => {
+                    prior_arg.extend(ss.iter().cloned());
+                }
+                (ContextKind::ActualNumValues, ContextValue::Number(n)) => {
+                    actual_num = Some(*n);
+                }
+                (ContextKind::ExpectedNumValues, ContextValue::Number(n)) => {
+                    expected_num = Some(*n);
+                }
+                (ContextKind::MinValues, ContextValue::Number(n)) => min_values = Some(*n),
+                (ContextKind::Custom, ContextValue::String(s)) => {
+                    custom.get_or_insert_with(|| s.clone());
+                }
+                _ => {}
+            }
+        }
+
+        match kind {
+            ErrorKind::InvalidValue => Self::InvalidValue {
+                arg: invalid_arg,
+                value: invalid_value,
+                valid_values,
+                custom,
+            },
+            ErrorKind::ValueValidation => Self::ValueValidation {
+                arg: invalid_arg,
+                value: invalid_value,
+                custom,
+            },
+            ErrorKind::UnknownArgument => Self::UnknownArgument {
+                arg: invalid_arg,
+                suggested_arg,
+            },
+            ErrorKind::InvalidSubcommand => Self::InvalidSubcommand {
+                subcommand: invalid_subcommand,
+                suggested_subcommand,
+                valid_subcommands,
+            },
+            ErrorKind::MissingRequiredArgument => {
+                Self::MissingRequiredArgument { arg: invalid_arg }
+            }
+            ErrorKind::MissingSubcommand => Self::MissingSubcommand,
+            ErrorKind::NoEquals => Self::NoEquals { arg: invalid_arg },
+            ErrorKind::TooManyValues => Self::TooManyValues {
+                arg: invalid_arg,
+                actual: actual_num,
+                expected: expected_num,
+                custom,
+            },
+            ErrorKind::TooFewValues => Self::TooFewValues {
+                arg: invalid_arg,
+                actual: actual_num,
+                expected: expected_num.or(min_values),
+                custom,
+            },
+            ErrorKind::WrongNumberOfValues => Self::WrongNumberOfValues {
+                arg: invalid_arg,
+                actual: actual_num,
+                expected: expected_num,
+                custom,
+            },
+            ErrorKind::ArgumentConflict => Self::ArgumentConflict {
+                arg: invalid_arg,
+                prior: prior_arg,
+            },
+            ErrorKind::InvalidUtf8 => Self::InvalidUtf8,
+            _ => Self::Other(error.to_string()),
+        }
+    }
+
+    fn arg_extract(&self) -> Option<&str> {
+        match self {
+            Self::InvalidValue { arg, .. }
+            | Self::ValueValidation { arg, .. }
+            | Self::UnknownArgument { arg, .. }
+            | Self::MissingRequiredArgument { arg }
+            | Self::NoEquals { arg }
+            | Self::TooManyValues { arg, .. }
+            | Self::TooFewValues { arg, .. }
+            | Self::WrongNumberOfValues { arg, .. }
+            | Self::ArgumentConflict { arg, .. } => arg.as_deref(),
+            _ => None,
+        }
+    }
+
+    fn message(&self) -> String {
+        let a = || self.arg_extract().unwrap_or("?");
+        match self {
+            Self::InvalidValue { value, .. } | Self::ValueValidation { value, .. } => {
+                format!(
+                    "invalid value `{}` for `{}`",
+                    value.as_deref().unwrap_or("?"),
+                    a()
+                )
+            }
+            Self::UnknownArgument { .. } => format!("unexpected argument `{}`", a()),
+            Self::InvalidSubcommand { subcommand, .. } => {
+                format!(
+                    "unknown subcommand `{}`",
+                    subcommand.as_deref().unwrap_or("?")
+                )
+            }
+            Self::MissingRequiredArgument { .. } => format!("missing required argument `{}`", a()),
+            Self::MissingSubcommand => "missing required subcommand".to_string(),
+            Self::NoEquals { .. } => format!("argument `{}` requires a value with `=`", a()),
+            Self::TooManyValues { .. } => format!("too many values for `{}`", a()),
+            Self::TooFewValues { .. } => format!("too few values for `{}`", a()),
+            Self::WrongNumberOfValues { .. } => format!("wrong number of values for `{}`", a()),
+            Self::ArgumentConflict { .. } => {
+                format!("argument `{}` conflicts with a previous argument", a())
+            }
+            Self::InvalidUtf8 => "invalid UTF-8 in command-line arguments".to_string(),
+            Self::Other(msg) => msg.clone(),
+        }
+    }
+
+    fn help(&self) -> Option<String> {
+        let hint = match self {
+            Self::InvalidValue { valid_values, .. } if !valid_values.is_empty() => {
+                Some(format!("possible values: {}", valid_values.join(", ")))
+            }
+            Self::InvalidSubcommand {
+                suggested_subcommand,
+                valid_subcommands,
+                ..
+            } => suggested_subcommand
+                .as_ref()
+                .map(|sug| format!("did you mean `{sug}`?"))
+                .or_else(|| {
+                    (!valid_subcommands.is_empty())
+                        .then(|| format!("available subcommands: {}", valid_subcommands.join(", ")))
+                }),
+            Self::UnknownArgument { suggested_arg, .. } => suggested_arg
+                .as_ref()
+                .map(|sug| format!("did you mean `{sug}`?")),
+            Self::ArgumentConflict { prior, .. } if !prior.is_empty() => {
+                Some(format!("cannot be used with `{}`", prior.join("`, `")))
+            }
+            Self::TooManyValues {
+                actual, expected, ..
+            }
+            | Self::TooFewValues {
+                actual, expected, ..
+            }
+            | Self::WrongNumberOfValues {
+                actual, expected, ..
+            } => expected.and_then(|e| {
+                let value_str = if e == 1 { "value" } else { "values" };
+                actual.map(|a| format!("expected {e} {}, got {a}", value_str))
+            }),
+            Self::NoEquals { arg } => Some(format!(
+                "use `{}=<value>` syntax",
+                arg.as_deref().unwrap_or("...")
+            )),
+            _ => None,
+        };
+        let parts: Vec<_> = [hint, self.custom()].into_iter().flatten().collect();
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("\n"))
+        }
+    }
+
+    fn custom(&self) -> Option<String> {
+        match self {
+            Self::InvalidValue { custom, .. }
+            | Self::ValueValidation { custom, .. }
+            | Self::TooManyValues { custom, .. }
+            | Self::TooFewValues { custom, .. }
+            | Self::WrongNumberOfValues { custom, .. } => custom.clone(),
+            _ => None,
+        }
+    }
+
+    fn primary_label(&self, source: &str) -> Option<LabeledSpan> {
+        match self {
+            Self::InvalidValue { value, arg, .. } | Self::ValueValidation { value, arg, .. } => {
+                value.as_deref().and_then(|value| {
+                    let start = arg
+                        .as_deref()
+                        .and_then(|anchor| source.find(anchor).map(|p| p + anchor.len()))
+                        .unwrap_or(0);
+                    source[start..].find(value).map(|offset| {
+                        LabeledSpan::new_primary_with_span(
+                            Some("this value is invalid".into()),
+                            SourceSpan::from((start + offset, value.len())),
+                        )
+                    })
+                })
+            }
+            Self::UnknownArgument { .. } => {
+                arg_span(source, self.arg_extract(), "unknown argument")
+            }
+            Self::InvalidSubcommand { subcommand, .. } => span_of(source, subcommand.as_deref()?)
+                .map(|span| {
+                    LabeledSpan::new_primary_with_span(Some("unknown subcommand".into()), span)
+                }),
+            Self::MissingRequiredArgument { .. }
+            | Self::TooManyValues { .. }
+            | Self::TooFewValues { .. }
+            | Self::WrongNumberOfValues { .. } => {
+                arg_span(source, self.arg_extract(), "this argument")
+            }
+            Self::MissingSubcommand => Some(LabeledSpan::new_primary_with_span(
+                Some("expected a subcommand here".into()),
+                SourceSpan::from((source.len(), 0)),
+            )),
+            Self::NoEquals { .. } => arg_span(source, self.arg_extract(), "missing `=`"),
+            Self::ArgumentConflict { .. } => {
+                arg_span(source, self.arg_extract(), "conflicting argument")
+            }
+            _ => None,
+        }
+    }
+
+    fn secondary_label(&self, source: &str) -> Option<LabeledSpan> {
+        match self {
+            Self::InvalidValue { .. } | Self::ValueValidation { .. } => {
+                self.arg_extract().and_then(|arg| {
+                    span_of(source, arg).map(|span| {
+                        LabeledSpan::new_with_span(Some("for this argument".into()), span)
+                    })
+                })
+            }
+            Self::UnknownArgument { suggested_arg, .. } => {
+                suggested_arg.as_deref().and_then(|sug| {
+                    span_of(source, sug).map(|span| {
+                        LabeledSpan::new_with_span(Some(format!("did you mean `{sug}`?")), span)
+                    })
+                })
+            }
+            Self::InvalidSubcommand {
+                suggested_subcommand,
+                ..
+            } => suggested_subcommand.as_deref().and_then(|sug| {
+                span_of(source, sug).map(|span| {
+                    LabeledSpan::new_with_span(Some(format!("did you mean `{sug}`?")), span)
+                })
+            }),
+            _ => None,
+        }
+    }
+}
+
+fn span_of(source: &str, needle: &str) -> Option<SourceSpan> {
+    source
+        .find(needle)
+        .map(|start| SourceSpan::from((start, needle.len())))
+}
+
+fn arg_span(source: &str, arg: Option<&str>, label: &str) -> Option<LabeledSpan> {
+    arg.and_then(|a| {
+        span_of(source, a).map(|span| LabeledSpan::new_primary_with_span(Some(label.into()), span))
+    })
+}
+
+/// Strips value from key-value pair: `--lua-version <VER>` -> `--lua-version`
+fn flag_of(s: &str) -> String {
+    match s.find(' ') {
+        Some(idx) => s[..idx].to_string(),
+        None => s.to_string(),
+    }
+}
+
+/// Reconstruct the user's command-line invocation as a single string suitable
+/// for use as a miette source. Example: `lx --lua-version 5.4 build`. This lets
+/// us generate beautiful diagnostics.
+fn build_source() -> String {
+    let mut args = std::env::args_os();
+
+    args.next()
+        .map(|exe_path| {
+            Path::new(&exe_path)
+                .file_name()
+                .map(|n| n.to_os_string())
+                .unwrap_or(exe_path)
+        })
+        .into_iter()
+        .chain(args)
+        .map(|a| shell_escape(&a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_escape(arg: &OsStr) -> String {
+    shlex::try_quote(&arg.to_string_lossy())
+        .unwrap_or_else(|err| {
+            unreachable!(
+                "Empty value during quoting. This is a bug. Error: {:?}",
+                err
+            )
+        })
+        .into_owned()
+}
+
+pub fn clap_to_miette(error: clap::Error) -> Result<miette::Report, String> {
+    if matches!(
+        error.kind(),
+        ErrorKind::DisplayHelp
+            | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            | ErrorKind::DisplayVersion
+    ) {
+        // pass through the error so it gets rendered normally
+        return Err(error.to_string());
+    }
+    Ok(clap_to_miette_with_source(error, &build_source()))
+}
+
+fn clap_to_miette_with_source(error: clap::Error, source: &str) -> miette::Report {
+    let source = source.to_string();
+    let ctx = ErrorContext::extract(&error);
+    let message = ctx.message();
+    let labels: Vec<_> = [ctx.primary_label(&source), ctx.secondary_label(&source)]
+        .into_iter()
+        .flatten()
+        .collect();
+    let mut diag = MietteDiagnostic::new(message);
+    if let Some(h) = ctx.help() {
+        diag = diag.with_help(h);
+    }
+    if !labels.is_empty() {
+        diag = diag.with_labels(labels);
+    }
+    miette::Report::new(diag).with_source_code(NamedSource::new("command", source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Parser, Subcommand};
+    use miette::SourceSpan;
+
+    #[derive(Parser, Debug)]
+    #[allow(dead_code)]
+    struct TestCli {
+        #[arg(long, value_parser = ["text", "json"])]
+        format: Option<String>,
+        #[arg(long, value_parser = parse_int)]
+        timeout: Option<u32>,
+        #[arg(long, num_args = 2..)]
+        names: Vec<String>,
+        #[arg(long, conflicts_with = "format")]
+        server: Option<String>,
+    }
+
+    fn parse_int(s: &str) -> Result<u32, String> {
+        s.parse().map_err(|_| format!("`{s}` is not a number"))
+    }
+
+    fn convert(args: &[&str], source: &str) -> miette::Report {
+        let err = TestCli::try_parse_from(args).expect_err("expected parse error");
+        clap_to_miette_with_source(err, source)
+    }
+
+    fn get_label<'a>(span: &SourceSpan, source: &'a str) -> &'a str {
+        &source[span.offset()..span.offset() + span.len()]
+    }
+
+    #[test]
+    fn unknown_argument_with_suggestion() {
+        let report = convert(&["prog", "--forma"], "lx build --forma");
+        let s = report.to_string();
+        assert!(s.contains("unexpected argument"), "got: {s}");
+        assert!(s.contains("--forma"), "got: {s}");
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        assert!(labels[0].primary(), "first label should be primary");
+        assert_eq!(get_label(labels[0].inner(), "lx build --forma"), "--forma");
+        assert_eq!(
+            report.help().map(|h| h.to_string()),
+            Some("did you mean `--format`?".into())
+        );
+    }
+
+    #[test]
+    fn invalid_value_with_possible_values() {
+        let report = convert(&["prog", "--format", "yaml"], "lx --format yaml");
+        let s = report.to_string();
+        assert!(s.contains("invalid value `yaml`"));
+        assert!(s.contains("--format"));
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        assert!(labels[0].primary());
+        assert_eq!(get_label(labels[0].inner(), "lx --format yaml"), "yaml");
+        assert_eq!(get_label(labels[1].inner(), "lx --format yaml"), "--format");
+        assert_eq!(
+            report.help().map(|h| h.to_string()),
+            Some("possible values: text, json".into())
+        );
+    }
+
+    #[test]
+    fn invalid_value_with_custom_validation() {
+        let report = convert(&["prog", "--timeout", "abc"], "lx --timeout abc");
+        let s = report.to_string();
+        assert!(s.contains("invalid value `abc`"));
+        assert!(s.contains("--timeout"));
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        assert_eq!(get_label(labels[0].inner(), "lx --timeout abc"), "abc");
+        // The value_parser's custom error becomes a help note.
+        assert!(report
+            .help()
+            .unwrap()
+            .to_string()
+            .contains("`abc` is not a number"));
+    }
+
+    #[test]
+    fn invalid_subcommand_with_suggestion() {
+        #[derive(Parser, Debug)]
+        struct SubCli {
+            #[command(subcommand)]
+            cmd: SubCmd,
+        }
+        #[derive(Subcommand, Debug)]
+        enum SubCmd {
+            Install,
+            Build,
+        }
+
+        let err =
+            SubCli::try_parse_from(["prog", "instlal"]).expect_err("expected invalid subcommand");
+        let report = clap_to_miette_with_source(err, "lx instlal");
+        let s = report.to_string();
+        assert!(s.contains("unknown subcommand `instlal`"), "got: {s}");
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        assert!(labels[0].primary());
+        assert_eq!(get_label(labels[0].inner(), "lx instlal"), "instlal");
+        assert_eq!(
+            report.help().map(|h| h.to_string()),
+            Some("did you mean `install`?".into())
+        );
+    }
+
+    #[test]
+    fn too_few_values() {
+        let report = convert(&["prog", "--names", "only-one"], "lx --names only-one");
+        let s = report.to_string();
+        assert!(s.contains("too few values for `--names`"));
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        assert!(labels[0].primary());
+        assert_eq!(
+            get_label(labels[0].inner(), "lx --names only-one"),
+            "--names"
+        );
+        assert!(report
+            .help()
+            .unwrap()
+            .to_string()
+            .contains("expected 2 values"));
+    }
+
+    #[test]
+    fn missing_required_argument() {
+        #[derive(Parser, Debug)]
+        struct NeedArg {
+            #[command(subcommand)]
+            cmd: NeedArgCmd,
+        }
+        #[derive(Subcommand, Debug)]
+        enum NeedArgCmd {
+            Run {
+                #[arg(long, required = true)]
+                target: String,
+            },
+        }
+
+        let err = NeedArg::try_parse_from(["prog", "run"]).expect_err("expected missing arg error");
+        let report = clap_to_miette_with_source(err, "lx run");
+        let s = report.to_string();
+        assert!(s.contains("missing required argument"));
+        assert!(s.contains("--target"));
+    }
+
+    #[test]
+    fn argument_conflict() {
+        let report = convert(
+            &["prog", "--format", "text", "--server", "x"],
+            "lx --format text --server x",
+        );
+        let s = report.to_string();
+        assert!(s.contains("conflicts with"));
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        assert!(labels[0].primary());
+        assert_eq!(
+            get_label(labels[0].inner(), "lx --format text --server x"),
+            "--format"
+        );
+    }
+
+    #[test]
+    fn display_help_passes_through() {
+        for kind in [
+            ErrorKind::DisplayHelp,
+            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+            ErrorKind::DisplayVersion,
+        ] {
+            let err = clap::Error::new(kind);
+            assert!(
+                clap_to_miette(err).is_err(),
+                "{kind:?} should bypass miette"
+            );
+        }
+    }
+
+    #[test]
+    fn label_finds_value_after_flag() {
+        let report = convert(&["prog", "--format", "yaml"], "yaml lx --format yaml");
+        let labels: Vec<_> = report.labels().unwrap().collect();
+        let primary_text = get_label(labels[0].inner(), "yaml lx --format yaml");
+        assert_eq!(primary_text, "yaml");
+        assert!(labels[0].offset() >= "yaml lx --format ".len());
+    }
+}

--- a/lux-cli/src/utils/github_metadata.rs
+++ b/lux-cli/src/utils/github_metadata.rs
@@ -1,6 +1,6 @@
-use eyre::Result;
 use git2::Repository;
 use lux_lib::git::url::RemoteGitUrl;
+use miette::{IntoDiagnostic, Result};
 use path_absolutize::Absolutize as _;
 use std::io;
 use std::path::Path;
@@ -37,13 +37,13 @@ impl RepoMetadata {
 /// Retrieves metadata for a given directory
 pub async fn get_metadata_for(directory: Option<&PathBuf>) -> Result<Option<RepoMetadata>> {
     let repo = match directory {
-        Some(path) => Repository::open(path)?,
-        None => Repository::open_from_env()?,
+        Some(path) => Repository::open(path).into_diagnostic()?,
+        None => Repository::open_from_env().into_diagnostic()?,
     };
 
     // NOTE(vhyrro): Temporary value is required. Thank the borrow checker.
-    let ret = if let Ok(remote) = repo.find_remote("origin")?.url() {
-        let parsed_url: RemoteGitUrl = remote.parse()?;
+    let ret = if let Ok(remote) = repo.find_remote("origin").into_diagnostic()?.url() {
+        let parsed_url: RemoteGitUrl = remote.parse().into_diagnostic()?;
 
         let owner = match parsed_url.owner() {
             Some(owner) => owner.to_owned(),
@@ -55,8 +55,12 @@ pub async fn get_metadata_for(directory: Option<&PathBuf>) -> Result<Option<Repo
         let octocrab = octocrab::instance();
         let repo_handler = octocrab.repos(owner, repo);
 
-        let contributors = repo_handler.list_contributors().send().await?;
-        let repo_data = repo_handler.get().await?;
+        let contributors = repo_handler
+            .list_contributors()
+            .send()
+            .await
+            .into_diagnostic()?;
+        let repo_data = repo_handler.get().await.into_diagnostic()?;
 
         Ok(Some(RepoMetadata {
             name: repo_data.name,

--- a/lux-cli/src/utils/install.rs
+++ b/lux-cli/src/utils/install.rs
@@ -1,6 +1,5 @@
 //! Utilities for converting a list of packages into a list with the correct build behaviour.
 
-use eyre::Result;
 use inquire::Confirm;
 use itertools::Itertools;
 use lux_lib::{
@@ -11,6 +10,7 @@ use lux_lib::{
     package::PackageReq,
     tree::{self, InstallTree, RockMatches, Tree},
 };
+use miette::Result;
 
 pub fn apply_build_behaviour(
     package_reqs: Vec<PackageReq>,

--- a/lux-cli/src/utils/mod.rs
+++ b/lux-cli/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub(crate) mod file_tree;
 pub(crate) mod github_metadata;
 pub(crate) mod install;

--- a/lux-cli/src/utils/path.rs
+++ b/lux-cli/src/utils/path.rs
@@ -1,5 +1,5 @@
-use eyre::{bail, Result};
 use lux_lib::workspace::Workspace;
+use miette::{bail, IntoDiagnostic, Result};
 use std::path::{Path, PathBuf};
 
 pub enum PathTarget {
@@ -15,7 +15,7 @@ pub fn classify_path(path: &Path) -> Result<PathTarget> {
     if let Some(workspace) = Workspace::from_exact(path)? {
         return Ok(PathTarget::Workspace(Box::new(workspace)));
     }
-    let path = std::path::absolute(path)?;
+    let path = std::path::absolute(path).into_diagnostic()?;
     if path.is_file() {
         Ok(PathTarget::File(path))
     } else {

--- a/lux-cli/src/vendor.rs
+++ b/lux-cli/src/vendor.rs
@@ -1,11 +1,11 @@
 use clap::Args;
-use eyre::{eyre, Context, OptionExt, Result};
 use lux_lib::{
     config::Config,
     lua_rockspec::RemoteLuaRockspec,
     operations::{self, VendorTarget},
     workspace::Workspace,
 };
+use miette::{miette, IntoDiagnostic, Result};
 use std::path::PathBuf;
 
 #[derive(Args)]
@@ -30,37 +30,45 @@ pub struct Vendor {
 }
 
 pub async fn vendor(data: Vendor, config: Config) -> Result<()> {
-    let target =
-        match data.rockspec {
-            Some(rockspec_path) => {
-                let content = tokio::fs::read_to_string(&rockspec_path).await?;
-                let rockspec = match rockspec_path
-                    .extension()
-                    .map(|ext| ext.to_string_lossy().to_string())
-                    .unwrap_or("".into())
-                    .as_str()
-                {
-                    "rockspec" => Ok(RemoteLuaRockspec::new(&content)?),
-                    _ => Err(eyre!(
-                        "expected a path to a .rockspec file, but got:\n{}",
-                        rockspec_path.display()
-                    )),
-                }?;
-                VendorTarget::Rockspec(rockspec)
+    let target = match data.rockspec {
+        Some(rockspec_path) => {
+            let content = tokio::fs::read_to_string(&rockspec_path)
+                .await
+                .into_diagnostic()?;
+            let rockspec = match rockspec_path
+                .extension()
+                .map(|ext| ext.to_string_lossy().to_string())
+                .unwrap_or("".into())
+                .as_str()
+            {
+                "rockspec" => Ok(RemoteLuaRockspec::new(&content)?),
+                _ => Err(miette!(
+                    "expected a path to a .rockspec file, but got:\n{}",
+                    rockspec_path.display()
+                )),
+            }?;
+            VendorTarget::Rockspec(rockspec)
+        }
+        None => match Workspace::current_or_err() {
+            Ok(ws) => VendorTarget::Workspace(ws),
+            Err(_) => {
+                return Err(miette!(
+                    "`lx vendor` must be run in a workspace root or with a rockspec argument."
+                ));
             }
-            None => VendorTarget::Workspace(Workspace::current_or_err().context(
-                "`lx vendor` must be run in a workspace root or with a rockspec argument.",
-            )?),
-        };
+        },
+    };
 
     let vendor_dir = data
         .vendor_dir
         .or_else(|| config.vendor_dir().cloned())
-        .ok_or_eyre(
-            r#"<vendor-dir> not set.
+        .ok_or_else(|| {
+            miette!(
+                r#"<vendor-dir> not set.
         It must either be specified via `--vendor-dir` or passed to this command.
-        "#,
-        )?;
+        "#
+            )
+        })?;
 
     operations::Vendor::new()
         .vendor_dir(vendor_dir)

--- a/lux-cli/src/which.rs
+++ b/lux-cli/src/which.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use eyre::Result;
 use lux_lib::{config::Config, lua_rockspec::LuaModule, package::PackageReq, which};
+use miette::Result;
 
 #[derive(Args)]
 pub struct Which {

--- a/lux-cli/src/workspace.rs
+++ b/lux-cli/src/workspace.rs
@@ -2,7 +2,6 @@ use std::{collections::HashSet, path::PathBuf};
 
 use std::{str::FromStr, sync::Arc};
 
-use eyre::{Context, Result};
 use itertools::Itertools;
 use lux_lib::{
     config::Config,
@@ -14,6 +13,7 @@ use lux_lib::{
     tree::Tree,
     workspace::Workspace,
 };
+use miette::{Context, Result};
 use walkdir::WalkDir;
 
 pub fn top_level_ignored_files(project: &Workspace) -> Vec<PathBuf> {
@@ -61,7 +61,7 @@ pub enum PackageReqOrGitShorthand {
 }
 
 impl FromStr for PackageReqOrGitShorthand {
-    type Err = eyre::Error;
+    type Err = miette::Report;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match RemoteGitUrlShorthand::parse_with_prefix(s) {

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -78,6 +78,7 @@ indicatif = { workspace = true }
 itertools = { workspace = true }
 lux-macros = { workspace = true }
 lux-workspace-hack = { workspace = true }
+miette = { workspace = true }
 path-slash = { workspace = true }
 pathdiff = { workspace = true }
 serde_json = { workspace = true }

--- a/lux-lib/src/build/builtin.rs
+++ b/lux-lib/src/build/builtin.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use miette::Diagnostic;
 use std::{
     collections::{HashMap, HashSet},
     io,
@@ -19,19 +20,23 @@ use crate::{
 
 use super::utils::{CompileCFilesError, CompileCModulesError, InstallBinaryError};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum BuiltinBuildError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     CompileCFiles(#[from] CompileCFilesError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     CompileCModules(#[from] CompileCModulesError),
     #[error("failed to install binary {0}: {1}")]
     InstallBinary(String, InstallBinaryError),
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ParseLuaModule(#[from] ParseLuaModuleError),
 }
 

--- a/lux-lib/src/build/cmake.rs
+++ b/lux-lib/src/build/cmake.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use miette::Diagnostic;
 use std::{
     env, io,
     process::{ExitStatus, Stdio},
@@ -20,11 +21,13 @@ use crate::{
 
 const CMAKE_BUILD_FILE: &str = "build.lux";
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum CMakeError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error("{name} step failed.\n\n{status}\n\nstdout:\n{stdout}\n\nstderr:\n{stderr}")]
     CommandFailure {
@@ -40,6 +43,7 @@ pub enum CMakeError {
     #[error("failed to run `cmake` step: '{0}' command not found!")]
     CommandNotFound(String),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     VariableSubstitutionError(#[from] VariableSubstitutionError),
 }
 

--- a/lux-lib/src/build/command.rs
+++ b/lux-lib/src/build/command.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 use std::{
     collections::HashMap,
     io,
@@ -21,11 +22,13 @@ use crate::{
 use super::external_dependency::ExternalDependencyInfo;
 use super::utils;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum CommandError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error("'build_command' and 'install_command' cannot be empty.")]
     EmptyCommand,
@@ -46,6 +49,7 @@ pub enum CommandError {
         stderr: String,
     },
     #[error(transparent)]
+    #[diagnostic(transparent)]
     VariableSubstitutionError(#[from] VariableSubstitutionError),
 }
 

--- a/lux-lib/src/build/external_dependency.rs
+++ b/lux-lib/src/build/external_dependency.rs
@@ -1,4 +1,10 @@
+use crate::{
+    config::external_deps::ExternalDependencySearchConfig,
+    lua_rockspec::ExternalDependencySpec,
+    variables::{GetVariableError, HasVariables},
+};
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::{PathBufExt, PathExt};
 use pkg_config::{Config as PkgConfig, Library};
 use std::{
@@ -7,15 +13,9 @@ use std::{
 };
 use thiserror::Error;
 
-use crate::{
-    config::external_deps::ExternalDependencySearchConfig,
-    lua_rockspec::ExternalDependencySpec,
-    variables::{GetVariableError, HasVariables},
-};
-
 use super::utils::{c_lib_extension, format_path};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ExternalDependencyError {
     #[error("{}", not_found_error_msg(.0))]
     NotFound(String),

--- a/lux-lib/src/build/luarocks.rs
+++ b/lux-lib/src/build/luarocks.rs
@@ -13,24 +13,28 @@ use crate::{
     tree::RockLayout,
 };
 
+use super::utils::recursive_copy_dir;
+use miette::Diagnostic;
 use tempfile::tempdir;
 use thiserror::Error;
 
-use super::utils::recursive_copy_dir;
-
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuarocksBuildError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error("error instantiating luarocks compatibility layer:\n{0}")]
+    #[diagnostic(forward(0))]
     LuaRocksError(#[from] LuaRocksError),
     #[error("error running 'luarocks make':\n{0}")]
+    #[diagnostic(forward(0))]
     ExecLuaRocksError(#[from] ExecLuaRocksError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error("{0}")] // We don't know the concrete error type
     Rockspec(String),
     #[error("error installing luarocks compatibility layer:\n{0}")]
+    #[diagnostic(forward(0))]
     LuaVersion(#[from] LuaVersionError),
 }
 

--- a/lux-lib/src/build/make.rs
+++ b/lux-lib/src/build/make.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathBufExt;
 use std::{
     io,
@@ -19,11 +20,13 @@ use crate::{
     variables::VariableSubstitutionError,
 };
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum MakeError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error("{name} step failed.\n\n{status}\n\nstdout:\n{stdout}\n\nstderr:\n{stderr}")]
     CommandFailure {
@@ -37,6 +40,7 @@ pub enum MakeError {
     #[error("failed to run `make` step: '{0}' command not found!")]
     CommandNotFound(String),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     VariableSubstitutionError(#[from] VariableSubstitutionError),
     #[error("{0} not found")]
     MakefileNotFound(PathBuf),

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -35,6 +35,7 @@ use itertools::Itertools;
 use luarocks::LuarocksBuildError;
 use make::MakeError;
 
+use miette::Diagnostic;
 use patch::{Patch, PatchError};
 use rust_mlua::RustError;
 use source::SourceBuildError;
@@ -110,39 +111,53 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum BuildError {
     #[error("builtin build failed: {0}")]
+    #[diagnostic(forward(0))]
     Builtin(#[from] BuiltinBuildError),
     #[error("cmake build failed: {0}")]
+    #[diagnostic(forward(0))]
     CMake(#[from] CMakeError),
     #[error("make build failed: {0}")]
+    #[diagnostic(forward(0))]
     Make(#[from] MakeError),
     #[error("command build failed: {0}")]
+    #[diagnostic(forward(0))]
     Command(#[from] CommandError),
     #[error("rust-mlua build failed: {0}")]
+    #[diagnostic(forward(0))]
     Rust(#[from] RustError),
     #[error("treesitter-parser build failed: {0}")]
+    #[diagnostic(forward(0))]
     TreesitterBuild(#[from] TreesitterBuildError),
     #[error("luarocks build failed: {0}")]
+    #[diagnostic(forward(0))]
     LuarocksBuild(#[from] LuarocksBuildError),
     #[error("building from rock source failed: {0}")]
+    #[diagnostic(forward(0))]
     SourceBuild(#[from] SourceBuildError),
     #[error("IO operation failed: {0}")]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error("failed to create spinner: {0}")]
     SpinnerFailure(#[from] TemplateError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ExternalDependencyError(#[from] ExternalDependencyError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     PatchError(#[from] PatchError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     CompileCFiles(#[from] CompileCFilesError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersion(#[from] LuaVersionError),
     #[error("source integrity mismatch.\nExpected: {expected},\nbut got: {actual}")]
     SourceIntegrityMismatch {
@@ -150,12 +165,15 @@ pub enum BuildError {
         actual: Integrity,
     },
     #[error("failed to unpack src.rock:\n{0}")]
+    #[diagnostic(forward(0))]
     UnpackSrcRock(UnpackError),
     #[error("failed to fetch rock source:\n{0}")]
+    #[diagnostic(forward(0))]
     FetchSrcError(#[from] FetchSrcError),
     #[error("failed to install binary {0}:\n{1}")]
     InstallBinary(String, InstallBinaryError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaInstallation(#[from] LuaInstallationError),
 }
 

--- a/lux-lib/src/build/patch.rs
+++ b/lux-lib/src/build/patch.rs
@@ -1,10 +1,10 @@
 use crate::progress::{Progress, ProgressBar};
 use bon::Builder;
 use diffy::{self, ApplyError, ParsePatchError};
+use miette::Diagnostic;
 use std::io;
 use std::{collections::HashMap, path::PathBuf};
 use thiserror::Error;
-
 #[derive(Builder)]
 #[builder(start_fn = new, finish_fn(name = _build, vis = ""))]
 pub(crate) struct Patch<'a> {
@@ -25,7 +25,7 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum PatchError {
     #[error("error parsing patch {0}: {1}")]
     Parse(PathBuf, ParsePatchError),

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -5,6 +5,7 @@ use crate::progress::{Progress, ProgressBar};
 use crate::tree::InstallTree;
 use crate::{lua_rockspec::RustMluaBuildSpec, tree::RockLayout};
 use itertools::Itertools;
+use miette::Diagnostic;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
@@ -12,7 +13,7 @@ use std::{fs, io};
 use thiserror::Error;
 use tokio::process::Command;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RustError {
     #[error("`cargo build` failed.\nstatus: {status}\nstdout: {stdout}\nstderr: {stderr}")]
     CargoBuild {
@@ -25,21 +26,24 @@ pub enum RustError {
     #[error("unable to create directory {0}:\n{1}")]
     CreateDir(String, io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     InstallRustLib(#[from] InstallRustLibError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     InstallLuaLib(#[from] InstallLuaLibError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("error installing rust library {lib}:\n{cause}")]
 pub struct InstallRustLibError {
     lib: String,
     cause: io::Error,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("error installing Lua library {lib}:\n{cause}")]
 pub struct InstallLuaLibError {
     lib: String,

--- a/lux-lib/src/build/source.rs
+++ b/lux-lib/src/build/source.rs
@@ -1,46 +1,55 @@
 use std::{io, string::FromUtf8Error};
 
-use thiserror::Error;
-
 use crate::{
     build::backend::{BuildBackend, BuildInfo, RunBuildArgs},
     lua_rockspec::{BuildBackendSpec, BuildSpec, LocalLuaRockspec, LuaRockspecError},
     project::{
         project_toml::{LocalProjectTomlValidationError, PartialProjectToml},
-        ProjectRoot, PROJECT_TOML,
+        ProjectRoot, TomlDeError, PROJECT_TOML,
     },
     rockspec::Rockspec,
     tree::InstallTree,
 };
+use miette::Diagnostic;
+use thiserror::Error;
 
 use super::{
     builtin::BuiltinBuildError, cmake::CMakeError, command::CommandError, make::MakeError,
     rust_mlua::RustError, treesitter_parser::TreesitterBuildError, utils::recursive_copy_dir,
 };
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum SourceBuildError {
     #[error("IO operation failed: {0}")]
     Io(#[from] io::Error),
     #[error(transparent)]
     FromUtf8(#[from] FromUtf8Error),
     #[error(transparent)]
-    Toml(#[from] toml::de::Error),
+    #[diagnostic(transparent)]
+    Toml(#[from] TomlDeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaRockspec(#[from] LuaRockspecError),
     #[error("builtin build failed: {0}")]
+    #[diagnostic(forward(0))]
     Builtin(#[from] BuiltinBuildError),
     #[error("cmake build failed: {0}")]
+    #[diagnostic(forward(0))]
     CMake(#[from] CMakeError),
     #[error("make build failed: {0}")]
+    #[diagnostic(forward(0))]
     Make(#[from] MakeError),
     #[error("command build failed: {0}")]
+    #[diagnostic(forward(0))]
     Command(#[from] CommandError),
     #[error("rust-mlua build failed: {0}")]
+    #[diagnostic(forward(0))]
     Rust(#[from] RustError),
     #[error("treesitter-parser build failed: {0}")]
+    #[diagnostic(forward(0))]
     TreesitterBuild(#[from] TreesitterBuildError),
     #[error("cannot build from a project source that requires a luarocks build backend: {0}")]
     UnsupporedLuarocksBuildBackend(String),
@@ -62,7 +71,8 @@ where
         if path.file_name().is_some_and(|name| name == PROJECT_TOML) {
             let toml_content = String::from_utf8(tokio::fs::read(path).await?)?;
             let project_toml =
-                PartialProjectToml::new(&toml_content, ProjectRoot::new())?.into_local()?;
+                PartialProjectToml::new(PROJECT_TOML, &toml_content, ProjectRoot::new())?
+                    .into_local()?;
             build_spec = project_toml.build().current_platform().clone();
             copy_directories = Some(build_spec.copy_directories);
             break;

--- a/lux-lib/src/build/treesitter_parser.rs
+++ b/lux-lib/src/build/treesitter_parser.rs
@@ -2,6 +2,7 @@ use crate::build::backend::{BuildBackend, BuildInfo, RunBuildArgs};
 use crate::lua_rockspec::TreesitterParserBuildSpec;
 use crate::lua_version::LuaVersionUnset;
 use crate::tree::InstallTree;
+use miette::Diagnostic;
 use std::io;
 use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
@@ -10,9 +11,10 @@ use tree_sitter_generate::GenerateError;
 
 const DEFAULT_GENERATE_ABI_VERSION: usize = tree_sitter::LANGUAGE_VERSION;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum TreesitterBuildError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     #[error("failed to initialise the tree-sitter loader: {0}")]
     Loader(String),

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -8,6 +8,7 @@ use crate::{
     variables::{self, Environment, VariableSubstitutionError},
 };
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathExt;
 use shlex::try_quote;
 use std::{
@@ -81,7 +82,7 @@ pub(crate) async fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(),
     Ok(())
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum OutputValidationError {
     #[error("compilation failed.\nstatus: {status}\nstdout: {stdout}\nstderr: {stderr}")]
     CommandFailure {
@@ -102,7 +103,7 @@ fn validate_output(output: &Output) -> Result<(), OutputValidationError> {
     Ok(())
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum CompileCFilesError {
     #[error("IO operation while compiling C files:\n{0}")]
     Io(#[from] io::Error),
@@ -111,6 +112,7 @@ pub enum CompileCFilesError {
     #[error("error compiling C files (compilation failed):\n{0}")]
     Compilation(#[from] cc::Error),
     #[error("error compiling C files (linking failed):\n{0}")]
+    #[diagnostic(forward(0))]
     Link(#[from] LinkCModulesError),
 }
 
@@ -262,7 +264,7 @@ pub(crate) fn default_libflag() -> &'static str {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum CompileCModulesError {
     #[error("IO operation failed while compiling C modules:\n{0}")]
     Io(#[from] io::Error),
@@ -271,18 +273,21 @@ pub enum CompileCModulesError {
     #[error("error compiling C modules (compilation failed):\n{0}")]
     Compilation(#[from] cc::Error),
     #[error("error compiling C modules (linking failed):\n{0}")]
+    #[diagnostic(forward(0))]
     Link(#[from] LinkCModulesError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     VariableSubstitution(#[from] VariableSubstitutionError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LinkCModulesError {
     #[error("IO operation failed while linking C modules:\n{0}")]
     Io(#[from] io::Error),
     #[error(transparent)]
     CC(#[from] cc::Error),
     #[error("error compiling C modules (output validation failed): {0}")]
+    #[diagnostic(forward(0))]
     OutputValidation(#[from] OutputValidationError),
     #[error("compiling C modules succeeded, but the expected library {0} was not created")]
     LibOutputNotCreated(String),
@@ -550,17 +555,19 @@ fn add_variable_if_set(config: &Config, name: &str, cmd: &mut Command) {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum InstallBinaryError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error("error wrapping binary: {0}")]
+    #[diagnostic(forward(0))]
     Wrap(#[from] WrapBinaryError),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum WrapBinaryError {
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -2,6 +2,7 @@ use directories::ProjectDirs;
 use external_deps::ExternalDependencySearchConfig;
 use itertools::Itertools;
 
+use miette::Diagnostic;
 use serde::{Deserialize, Serialize, Serializer};
 use std::{collections::HashMap, env, io, path::PathBuf, time::Duration};
 use thiserror::Error;
@@ -9,6 +10,7 @@ use tree::RockLayoutConfig;
 use url::Url;
 
 use crate::lua_version::LuaVersion;
+use crate::project::TomlDeError;
 use crate::tree::{Tree, TreeError};
 use crate::variables::GetVariableError;
 use crate::{build::utils, variables::HasVariables};
@@ -19,8 +21,12 @@ pub mod tree;
 const DEV_PATH: &str = "dev/";
 const DEFAULT_USER_AGENT: &str = concat!("lux-lib/", env!("CARGO_PKG_VERSION"));
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("could not find a valid home directory")]
+#[diagnostic(
+    code(lux_lib::no_home_directory),
+    help("this usually means you're running Lux in a managed environment like LDAP or a live session.")
+)]
 pub struct NoValidHomeDirectory;
 
 /// The resolved configuration for a Lux session.
@@ -240,18 +246,18 @@ impl HasVariables for Config {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ConfigError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     NoValidHomeDirectory(#[from] NoValidHomeDirectory),
-    #[error("error deserializing lux config: {0}")]
-    Deserialize(#[from] toml::de::Error),
+    #[error("error deserializing Lux config")]
+    #[diagnostic(forward(0))]
+    Deserialize(#[from] TomlDeError),
     #[error("error parsing URL: {0}")]
     UrlParseError(#[from] url::ParseError),
-    #[error("error initializing compiler toolchain: {0}")]
-    CompilerToolchain(#[from] cc::Error),
 }
 
 /// Incrementally builds a [`Config`] by layering configuration sources.
@@ -305,7 +311,11 @@ impl ConfigBuilder {
     pub fn new() -> Result<Self, ConfigError> {
         let config_file = Self::config_file()?;
         if config_file.is_file() {
-            Ok(toml::from_str(&std::fs::read_to_string(&config_file)?)?)
+            let content = std::fs::read_to_string(&config_file)?;
+            Ok(crate::project::parse_toml(
+                config_file.to_string_lossy().as_ref(),
+                &content,
+            )?)
         } else {
             Ok(Self::default())
         }

--- a/lux-lib/src/git/shorthand.rs
+++ b/lux-lib/src/git/shorthand.rs
@@ -1,17 +1,17 @@
 use std::{fmt::Display, str::FromStr};
 
+use crate::git::url::{RemoteGitUrl, RemoteGitUrlParseError};
 use chumsky::{prelude::*, Parser};
+use miette::Diagnostic;
 use serde::{de, Deserialize, Deserializer};
 use thiserror::Error;
-
-use crate::git::url::{RemoteGitUrl, RemoteGitUrlParseError};
 
 const GITHUB: &str = "github";
 const GITLAB: &str = "gitlab";
 const SOURCEHUT: &str = "sourcehut";
 const CODEBERG: &str = "codeberg";
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 #[error("error parsing git source: {0:#?}")]
 pub struct ParseError(Vec<String>);
 

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{fmt::Display, hash::Hash, str::FromStr};
 use thiserror::Error;
@@ -12,7 +13,7 @@ pub struct RemoteGitUrl {
     url_str: String,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum RemoteGitUrlParseError {
     #[error("error parsing git URL:\n{0}")]
     GitUrlParse(#[from] url::ParseError),

--- a/lux-lib/src/git/utils.rs
+++ b/lux-lib/src/git/utils.rs
@@ -1,13 +1,13 @@
 use std::io;
 
+use crate::git::url::RemoteGitUrl;
 use git2::{AutotagOption, Cred, FetchOptions, RemoteCallbacks, Repository};
 use itertools::Itertools;
+use miette::Diagnostic;
 use tempfile::tempdir;
 use thiserror::Error;
 
-use crate::git::url::RemoteGitUrl;
-
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum GitError {
     #[error("error creating temporary directory to checkout git repositotory: {0}")]
     CreateTempDir(io::Error),

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, fs::File, io::ErrorKind, path::PathBuf};
 
 use itertools::Itertools;
 
+use miette::Diagnostic;
 use serde::{de, Deserialize, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use ssri::Integrity;
@@ -534,9 +535,10 @@ impl From<PackageVersionReq> for LockConstraint {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LockConstraintParseError {
     #[error("Invalid constraint in LuaPackage: {0}")]
+    #[diagnostic(forward(0))]
     LockConstraintParseError(#[from] PackageVersionReqError),
 }
 
@@ -763,7 +765,7 @@ pub struct WorkspaceLockfile<P: LockfilePermissions> {
     build_dependencies: LocalPackageLock,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LockfileError {
     #[error("error loading lockfile: {0}")]
     Load(io::Error),
@@ -777,7 +779,7 @@ pub enum LockfileError {
     MismatchedRockLayout,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LockfileIntegrityError {
     #[error("rockspec integirty mismatch.\nExpected: {expected}\nBut got: {got}")]
     RockspecIntegrityMismatch { expected: Integrity, got: Integrity },
@@ -787,7 +789,7 @@ pub enum LockfileIntegrityError {
     PackageNotFound(PackageName, PackageVersion, PinnedState, String),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("error flushing the lockfile ({filepath}):\n{cause}")]
 pub struct FlushLockfileError {
     filepath: String,

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -1,5 +1,6 @@
 use is_executable::IsExecutable;
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathBufExt;
 use std::fmt;
 use std::fmt::Display;
@@ -40,11 +41,12 @@ pub struct LuaInstallation {
     pub(crate) bin: Option<PathBuf>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum LuaBinaryError {
     #[error("neither `lua` nor `luajit` found on the PATH")]
     LuaBinaryNotFound,
     #[error(transparent)]
+    #[diagnostic(transparent)]
     DetectLuaVersion(#[from] DetectLuaVersionError),
     #[error(
         r#"
@@ -72,23 +74,27 @@ in your config, or use `-v LUA=/path/to/lua_binary`.
     CustomBinaryNotFound(String),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum DetectLuaVersionError {
     #[error("failed to run {0}: {1}")]
     RunLuaCommand(String, io::Error),
     #[error("failed to parse Lua version from output: {0}")]
     ParseLuaVersion(String),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     PackageVersionParse(#[from] crate::package::PackageVersionParseError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersion(#[from] crate::lua_version::LuaVersionError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaInstallationError {
     #[error("could not find a Lua installation and failed to build Lua from source:\n{0}")]
+    #[diagnostic(forward(0))]
     Build(#[from] BuildLuaError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
 }
 

--- a/lux-lib/src/lua_rockspec/build/builtin.rs
+++ b/lux-lib/src/lua_rockspec/build/builtin.rs
@@ -1,9 +1,3 @@
-use itertools::Itertools;
-use path_slash::PathBufExt;
-use serde::{de, Deserialize, Deserializer};
-use std::{collections::HashMap, convert::Infallible, fmt::Display, path::PathBuf, str::FromStr};
-use thiserror::Error;
-
 use crate::{
     build::utils::c_dylib_extension,
     lua_rockspec::{
@@ -11,6 +5,12 @@ use crate::{
         PartialOverride, PerPlatform, PlatformOverridable,
     },
 };
+use itertools::Itertools;
+use miette::Diagnostic;
+use path_slash::PathBufExt;
+use serde::{de, Deserialize, Deserializer};
+use std::{collections::HashMap, convert::Infallible, fmt::Display, path::PathBuf, str::FromStr};
+use thiserror::Error;
 
 use super::{DisplayLuaKV, DisplayLuaValue};
 
@@ -73,7 +73,7 @@ impl LuaModule {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ParseLuaModuleError {
     #[error("could not parse Lua module from '{0}'.")]
     FromString(String),
@@ -229,7 +229,7 @@ where
         .try_collect()
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("cannot resolve ambiguous platform override for `build.modules`.")]
 pub struct ModuleSpecAmbiguousPlatformOverride;
 
@@ -252,7 +252,7 @@ impl PartialOverride for ModuleSpecInternal {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("could not resolve platform override for `build.modules`. THIS IS A BUG!")]
 pub struct BuildModulesPlatformOverride;
 
@@ -267,7 +267,7 @@ impl PlatformOverridable for ModuleSpecInternal {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("missing or empty field `sources`")]
 pub struct ModulePathsMissingSources;
 

--- a/lux-lib/src/lua_rockspec/build/mod.rs
+++ b/lux-lib/src/lua_rockspec/build/mod.rs
@@ -15,13 +15,13 @@ use builtin::{ModulePathsMissingSources, ModuleSpecAmbiguousPlatformOverride, Mo
 
 use itertools::Itertools;
 
+use miette::Diagnostic;
+use serde::{de, de::IntoDeserializer, Deserialize, Deserializer};
 use std::{
     collections::HashMap, convert::Infallible, env::consts::DLL_EXTENSION, env::consts::DLL_PREFIX,
     fmt::Display, path::PathBuf, str::FromStr,
 };
 use thiserror::Error;
-
-use serde::{de, de::IntoDeserializer, Deserialize, Deserializer};
 
 use crate::{
     lua_rockspec::per_platform_from_intermediate,
@@ -62,7 +62,7 @@ impl Default for BuildSpec {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum BuildSpecInternalError {
     #[error("'builtin' modules should not have list elements")]
     ModulesHaveListElements,
@@ -73,8 +73,10 @@ pub enum BuildSpecInternalError {
     #[error("invalid 'rust-mlua' modules format")]
     InvalidRustMLuaFormat,
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ModulePathsMissingSources(#[from] ModulePathsMissingSources),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ParseLuaModuleError(#[from] ParseLuaModuleError),
 }
 

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -18,6 +18,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use build::*;
 pub use dependency::*;
 pub use deploy::*;
+use miette::Diagnostic;
 pub use partial::*;
 pub use platform::*;
 pub use rock_source::*;
@@ -44,7 +45,7 @@ use crate::{
     ROCKSPEC_FUEL_LIMIT,
 };
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaRockspecError {
     #[error("manifest exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
     FuelLimitExceeded,
@@ -94,6 +95,7 @@ pub enum LuaRockspecError {
     #[error("cannot create Lua rockspec with off-spec test dependency: {0}")]
     OffSpecTestDependency(PackageName),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ProjectToml(#[from] ProjectTomlError),
 }
 
@@ -549,7 +551,7 @@ impl Rockspec for RemoteLuaRockspec {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaVersionError {
     #[error(
         r#"
@@ -562,6 +564,7 @@ HINT: If Lux has auto-detected an incompatible Lua installation,
     )]
     LuaVersionUnsupported(LuaVersion, PackageName, PackageVersion),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
 }
 
@@ -603,7 +606,7 @@ where
         .transpose()
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("invalid rockspec format: {0}")]
 pub struct InvalidRockspecFormat(String);
 
@@ -641,7 +644,7 @@ impl Display for RockspecFormat {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaTableError {
     #[error("could not parse '{variable}'. Expected list, but got {invalid_type}")]
     ParseError {

--- a/lux-lib/src/lua_rockspec/partial.rs
+++ b/lux-lib/src/lua_rockspec/partial.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use ottavino::{Closure, Executor, Fuel};
-use ottavino_util::serde::from_value;
-use thiserror::Error;
-
 use crate::{
     lua_rockspec::RockspecFormat, package::PackageName,
     rockspec::lua_dependency::LuaDependencySpec, ROCKSPEC_FUEL_LIMIT,
 };
+use miette::Diagnostic;
+use ottavino::{Closure, Executor, Fuel};
+use ottavino_util::serde::from_value;
+use thiserror::Error;
 
 use super::{
     parse_lua_tbl_or_default, BuildSpecInternal, DeploySpec, ExternalDependencySpec,
@@ -30,7 +30,7 @@ pub struct PartialLuaRockspec {
     pub(crate) test: Option<TestSpecInternal>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum PartialRockspecError {
     #[error("rockspec execution exceeded fuel limit of {ROCKSPEC_FUEL_LIMIT} steps")]
     FuelLimitExceeded,

--- a/lux-lib/src/lua_rockspec/platform.rs
+++ b/lux-lib/src/lua_rockspec/platform.rs
@@ -1,15 +1,15 @@
 use itertools::Itertools;
 
-use std::{cmp::Ordering, collections::HashMap};
-use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
-use thiserror::Error;
-
+use miette::Diagnostic;
 use serde::{
     de::{self, DeserializeOwned, IntoDeserializer, Visitor},
     Deserialize, Deserializer,
 };
 use serde_enum_str::{Deserialize_enum_str, Serialize_enum_str};
+use std::{cmp::Ordering, collections::HashMap};
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+use thiserror::Error;
 
 use super::{normalize_lua_value, DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue, LuaValueSeed};
 
@@ -155,7 +155,7 @@ impl DisplayAsLuaKV for PlatformSupport {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum PlatformValidationError {
     #[error("error when parsing platform identifier: {0}")]
     ParseError(String),

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -1,8 +1,3 @@
-use reqwest::Url;
-use serde::{de, Deserialize, Deserializer};
-use std::{convert::Infallible, fs, io, ops::Deref, path::PathBuf, str::FromStr};
-use thiserror::Error;
-
 use crate::{
     git::{
         url::{RemoteGitUrl, RemoteGitUrlParseError},
@@ -10,6 +5,11 @@ use crate::{
     },
     lua_rockspec::per_platform_from_intermediate,
 };
+use miette::Diagnostic;
+use reqwest::Url;
+use serde::{de, Deserialize, Deserializer};
+use std::{convert::Infallible, fs, io, ops::Deref, path::PathBuf, str::FromStr};
+use thiserror::Error;
 
 use super::{
     DisplayAsLuaKV, DisplayLuaKV, DisplayLuaValue, PartialOverride, PerPlatform,
@@ -47,11 +47,12 @@ impl Deref for RemoteRockSource {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RockSourceError {
     #[error("invalid rockspec source field combination")]
     InvalidCombination,
     #[error(transparent)]
+    #[diagnostic(transparent)]
     SourceUrl(#[from] SourceUrlError),
     #[error("source URL missing")]
     SourceUrlMissing,
@@ -198,7 +199,7 @@ impl PartialOverride for RockSourceInternal {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("missing source")]
 pub struct RockSourceMissingSource;
 
@@ -228,7 +229,7 @@ pub(crate) enum SourceUrl {
     Git(RemoteGitUrl),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("failed to parse source url: {0}")]
 pub enum SourceUrlError {
     Io(#[from] io::Error),

--- a/lux-lib/src/lua_rockspec/test_spec.rs
+++ b/lux-lib/src/lua_rockspec/test_spec.rs
@@ -1,11 +1,11 @@
 use itertools::Itertools;
 
+use miette::Diagnostic;
 use path_slash::PathExt;
+use serde::{Deserialize, Deserializer};
 use serde_enum_str::Serialize_enum_str;
 use std::{convert::Infallible, path::PathBuf};
 use thiserror::Error;
-
-use serde::{Deserialize, Deserializer};
 
 use crate::lua_version::LuaVersion;
 
@@ -24,7 +24,7 @@ const NLUA_EXE: &str = "nlua";
 #[cfg(target_family = "windows")]
 const NLUA_EXE: &str = "nlua.bat";
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum TestSpecDecodeError {
     #[error("the 'command' test type must specify either a 'command' or 'script' field")]
     NoCommandOrScript,
@@ -32,11 +32,12 @@ pub enum TestSpecDecodeError {
     CommandAndScript,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum TestSpecError {
     #[error("could not auto-detect the test spec. Please add one to your lux.toml")]
     NoTestSpecDetected,
     #[error("project validation failed:\n{0}")]
+    #[diagnostic(forward(0))]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
 }
 

--- a/lux-lib/src/lua_version/mod.rs
+++ b/lux-lib/src/lua_version/mod.rs
@@ -4,14 +4,14 @@ use std::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
-use strum_macros::EnumIter;
-use thiserror::Error;
-
 use crate::{
     config::Config,
     package::{PackageVersion, PackageVersionReq},
 };
+use miette::Diagnostic;
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
+use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, EnumIter)]
 pub enum LuaVersion {
@@ -33,7 +33,7 @@ pub enum LuaVersion {
     // LuaU,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum LuaVersionError {
     #[error("unsupported Lua version: {0}")]
     UnsupportedLuaVersion(PackageVersion),
@@ -114,7 +114,7 @@ impl LuaVersion {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(
     r#"lua version not set.
 Please provide a version through `lx --lua-version <ver> <cmd>`

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -4,10 +4,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bytes::Bytes;
-use tempfile::tempdir;
-use thiserror::Error;
-
 use crate::{
     build::{
         external_dependency::{ExternalDependencyError, ExternalDependencyInfo},
@@ -28,26 +24,35 @@ use crate::{
     tree::{self, InstallTree, TreeError},
 };
 use crate::{lockfile::RemotePackageSourceUrl, rockspec::LuaVersionCompatibility};
+use bytes::Bytes;
+use miette::Diagnostic;
+use tempfile::tempdir;
+use thiserror::Error;
 
 use super::rock_manifest::RockManifestError;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum InstallBinaryRockError {
     #[error("IO operation failed: {0}")]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ExternalDependencyError(#[from] ExternalDependencyError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionError(#[from] LuaVersionError),
     #[error("failed to unpack packed rock: {0}")]
     Zip(#[from] zip::result::ZipError),
     #[error("rock_manifest not found. Cannot install rock files that were packed using LuaRocks version 1")]
     RockManifestNotFound,
     #[error(transparent)]
+    #[diagnostic(transparent)]
     RockManifestError(#[from] RockManifestError),
     #[error(
         "the entry {0} listed in the `rock_manifest` is neither a file nor a directory: {1:?}"

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 use path_slash::{PathBufExt, PathExt};
 use ssri::Integrity;
 use std::{
@@ -50,43 +51,51 @@ build = {
 }
 ";
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaRocksError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     // #[error(transparent)]
     // Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaRocksInstallError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     BuildError(#[from] BuildError),
     #[error(transparent)]
     Request(#[from] reqwest::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     UnpackError(#[from] UnpackError),
     #[error("luarocks integrity mismatch.\nExpected: {expected}\nBut got: {got}")]
     IntegrityMismatch { expected: Integrity, got: Integrity },
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ExecLuaRocksError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     #[error("could not write luarocks config: {0}")]
     WriteLuarocksConfigError(io::Error),
     #[error("could not write luarocks config: {0}")]
+    #[diagnostic(forward(0))]
     VariableSubstitutionInConfig(#[from] VariableSubstitutionError),
     #[error("failed to run luarocks: {0}")]
     Io(#[from] io::Error),
     #[error("error setting up luarocks paths: {0}")]
+    #[diagnostic(forward(0))]
     Paths(#[from] PathsError),
     #[error("luarocks binary not found at {0}")]
     LuarocksBinNotFound(PathBuf),

--- a/lux-lib/src/luarocks/rock_manifest.rs
+++ b/lux-lib/src/luarocks/rock_manifest.rs
@@ -1,4 +1,9 @@
+use crate::{
+    lua_rockspec::{DisplayAsLuaKV, DisplayAsLuaValue, DisplayLuaKV, DisplayLuaValue},
+    ROCKSPEC_FUEL_LIMIT,
+};
 use itertools::Itertools;
+use miette::Diagnostic;
 use ottavino::{Closure, Executor, Fuel};
 use ottavino_util::serde::from_value;
 use path_slash::PathBufExt;
@@ -6,11 +11,6 @@ use serde::{Deserialize, Deserializer};
 /// Compatibility layer/adapter for the luarocks client
 use std::{collections::HashMap, path::PathBuf};
 use thiserror::Error;
-
-use crate::{
-    lua_rockspec::{DisplayAsLuaKV, DisplayAsLuaValue, DisplayLuaKV, DisplayLuaValue},
-    ROCKSPEC_FUEL_LIMIT,
-};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct RockManifest {
@@ -22,7 +22,7 @@ pub(crate) struct RockManifest {
     pub root: RockManifestRoot,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RockManifestError {
     #[error("could not parse rock_manifest: {0}")]
     Piccolo(#[from] ottavino::ExternError),

--- a/lux-lib/src/manifest/metadata.rs
+++ b/lux-lib/src/manifest/metadata.rs
@@ -1,12 +1,12 @@
+use crate::package::{PackageName, PackageReq, PackageSpec, PackageVersion};
+use crate::package::{RemotePackageType, RemotePackageTypeFilterSpec};
+use crate::ROCKSPEC_FUEL_LIMIT;
 use itertools::Itertools;
+use miette::Diagnostic;
 use ottavino::{Closure, Executor, Fuel, Lua};
 use ottavino_util::serde::from_value;
 use std::{cmp::Ordering, collections::HashMap};
 use thiserror::Error;
-
-use crate::package::{PackageName, PackageReq, PackageSpec, PackageVersion};
-use crate::package::{RemotePackageType, RemotePackageTypeFilterSpec};
-use crate::ROCKSPEC_FUEL_LIMIT;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ManifestMetadata {
@@ -23,7 +23,7 @@ impl<'de> serde::Deserialize<'de> for ManifestMetadata {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ManifestLuaError {
     #[error("failed to parse Lua manifest:\n{0}")]
     ExecutionError(#[from] ottavino::ExternError),

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 use reqwest::header::ToStrError;
 use reqwest::Client;
 use std::path::{Path, PathBuf};
@@ -14,7 +15,7 @@ use crate::config::Config;
 use crate::lua_version::{LuaVersion, LuaVersionUnset};
 use crate::progress::{Progress, ProgressBar};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ManifestFromServerError {
     #[error(transparent)]
     Io(#[from] io::Error),
@@ -33,6 +34,7 @@ pub enum ManifestFromServerError {
     #[error("failed to unzip manifest file {0}:\n{1}")]
     ZipExtract(Url, zip::result::ZipError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersion(#[from] LuaVersionUnset),
 }
 

--- a/lux-lib/src/manifest/mod.rs
+++ b/lux-lib/src/manifest/mod.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 use path_slash::PathExt;
 use thiserror::Error;
 use url::Url;
@@ -17,11 +18,13 @@ pub mod metadata;
 mod metadata_from_server;
 mod metadata_from_vendor_dir;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ManifestError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Lua(#[from] ManifestLuaError),
     #[error("failed to fetch manifest from server:\n{0}")]
+    #[diagnostic(forward(0))]
     Server(#[from] ManifestFromServerError),
     #[error("error parsing URL from `vendor-dir`: {0}:")]
     Vendor(String),

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use bon::Builder;
 use git2::{build::RepoBuilder, FetchOptions};
+use miette::Diagnostic;
 use path_slash::PathExt;
 use ssri::Integrity;
 use target_lexicon::Triple;
@@ -46,13 +47,14 @@ pub struct BuildLua<'a> {
     progress: &'a Progress<ProgressBar>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum BuildLuaError {
     #[error(transparent)]
     Request(#[from] reqwest::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Unpack(#[from] UnpackError),
     #[error(transparent)]
     Git(#[from] git2::Error),

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -1,8 +1,3 @@
-use bon::Builder;
-use itertools::Itertools;
-use std::sync::Arc;
-use thiserror::Error;
-
 use crate::{
     build::{Build, BuildBehaviour, BuildError},
     config::Config,
@@ -16,34 +11,51 @@ use crate::{
     tree::{self, InstallTree, TreeError},
     workspace::{Workspace, WorkspaceError, WorkspaceTreeError},
 };
+use bon::Builder;
+use itertools::Itertools;
+use miette::Diagnostic;
+use std::sync::Arc;
+use thiserror::Error;
 
 use super::{InstallError, Sync, SyncError};
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum BuildWorkspaceError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaInstallation(#[from] LuaInstallationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaRocks(#[from] LuaRocksError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaRocksInstall(#[from] LuaRocksInstallError),
     #[error("error installind dependencies:\n{0}")]
+    #[diagnostic(forward(0))]
     InstallDependencies(InstallError),
     #[error("error installind build dependencies:\n{0}")]
+    #[diagnostic(forward(0))]
     InstallBuildDependencies(InstallError),
     #[error("syncing dependencies with the project lockfile failed.\nUse --no-lock to force a new build.\n\n{0}")]
+    #[diagnostic(forward(0))]
     SyncDependencies(SyncError),
     #[error("syncing build dependencies with the project lockfile failed.\nUse --no-lock to force a new build.\n\n{0}")]
+    #[diagnostic(forward(0))]
     SyncBuildDependencies(SyncError),
     #[error("error building project:\n{0}")]
+    #[diagnostic(forward(0))]
     Build(#[from] BuildError),
 }
 

--- a/lux-lib/src/operations/dist_bin.rs
+++ b/lux-lib/src/operations/dist_bin.rs
@@ -47,13 +47,17 @@ where
     progress: Option<Arc<Progress<MultiProgress>>>,
 }
 
-#[derive(Error, Debug)]
+use miette::Diagnostic;
+#[derive(Error, Debug, Diagnostic)]
 pub enum DistProjectBinError {
     #[error("error installing project:\n{0}")]
+    #[diagnostic(forward(0))]
     InstallProject(#[from] InstallProjectError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[cfg(not(target_os = "linux"))]
     #[error(
@@ -63,6 +67,7 @@ Cannot link the following binaries:
     )]
     CannotLinkBinaryLibs(String),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaInstallation(#[from] LuaInstallationError),
     #[error(transparent)]
     CC(#[from] cc::Error),

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -6,6 +6,7 @@ use std::{
 
 use bon::Builder;
 use bytes::Bytes;
+use miette::Diagnostic;
 use thiserror::Error;
 use url::{ParseError, Url};
 
@@ -212,15 +213,17 @@ impl RemoteRockDownload {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum DownloadRockspecError {
     #[error("failed to download rockspec: {0}")]
     Request(#[from] reqwest::Error),
     #[error("failed to convert rockspec response: {0}")]
     ResponseConversion(#[from] FromUtf8Error),
     #[error("error initialising remote package DB:\n{0}")]
+    #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     DownloadSrcRock(#[from] DownloadSrcRockError),
 }
 
@@ -334,21 +337,26 @@ async fn download_remote_rock(
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum SearchAndDownloadError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Search(#[from] SearchError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Download(#[from] DownloadSrcRockError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     DownloadRockspec(#[from] DownloadRockspecError),
     #[error("io operation failed: {0}")]
     Io(#[from] io::Error),
     #[error("UTF-8 conversion failed: {0}")]
     Utf8(#[from] FromUtf8Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Rockspec(#[from] LuaRockspecError),
     #[error("error initialising remote package DB:\n{0}")]
+    #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("failed to read packed rock {0}:\n{1}")]
     ZipRead(String, zip::result::ZipError),
@@ -357,6 +365,7 @@ pub enum SearchAndDownloadError {
     #[error("{0} not found in the packed rock.")]
     RockspecNotFoundInPackedRock(String),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     PackageSpecFromPackageReq(#[from] PackageSpecFromPackageReqError),
     #[error("git source {0} without a revision or tag.")]
     MissingCheckoutRef(String),
@@ -387,7 +396,7 @@ async fn search_and_download_src_rock(
     Ok(download_src_rock(&remote_package.package, &source_url, progress, config).await?)
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum DownloadSrcRockError {
     #[error("failed to download source rock: {0}")]
     Request(#[from] reqwest::Error),

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use bon::Builder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use thiserror::Error;
 use which::which;
 
@@ -61,7 +62,7 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ExecError {
     #[error("failed to run {cmd}: {source}")]
     RunCommandFailed {
@@ -72,24 +73,31 @@ pub enum ExecError {
     #[error("{cmd} exited with non-zero exit code: {}", exit_code.map(|code| code.to_string()).unwrap_or("unknown".into()))]
     RunCommandNonZeroExitCode { cmd: String, exit_code: Option<i32> },
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionError(#[from] LuaVersionError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     BuildProject(#[from] BuildWorkspaceError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     InstallCommand(#[from] InstallCommandError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
     #[error("failed to execute '{0}':\n{1}")]
     Io(String, io::Error),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum InstallCommandError {
     InstallError(#[from] InstallError),

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -1,17 +1,3 @@
-use auth_git2::{GitAuthenticator, Prompter};
-use bon::Builder;
-use git2::build::RepoBuilder;
-use git2::{FetchOptions, RemoteCallbacks};
-use remove_dir_all::remove_dir_all;
-use ssri::Integrity;
-use std::fs::File;
-use std::io;
-use std::io::Cursor;
-use std::io::Read;
-use std::path::Path;
-use std::path::PathBuf;
-use thiserror::Error;
-
 use crate::build::utils::recursive_copy_dir;
 use crate::config::Config;
 use crate::git::url::RemoteGitUrlParseError;
@@ -24,6 +10,20 @@ use crate::package::PackageSpec;
 use crate::progress::Progress;
 use crate::progress::ProgressBar;
 use crate::rockspec::Rockspec;
+use auth_git2::{GitAuthenticator, Prompter};
+use bon::Builder;
+use git2::build::RepoBuilder;
+use git2::{FetchOptions, RemoteCallbacks};
+use miette::Diagnostic;
+use remove_dir_all::remove_dir_all;
+use ssri::Integrity;
+use std::fs::File;
+use std::io;
+use std::io::Cursor;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+use thiserror::Error;
 
 use super::DownloadSrcRockError;
 use super::UnpackError;
@@ -105,17 +105,20 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum FetchSrcError {
     #[error("failed to clone rock source:\n{0}")]
     GitClone(#[from] git2::Error),
     #[error("failed to parse git URL:\n{0}")]
+    #[diagnostic(forward(0))]
     GitUrlParse(#[from] RemoteGitUrlParseError),
     #[error(transparent)]
     Request(#[from] reqwest::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Unpack(#[from] UnpackError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     FetchSrcRock(#[from] FetchSrcRockError),
     #[error("unable to remove the '.git' directory:\n{0}")]
     CleanGitDir(io::Error),
@@ -157,7 +160,7 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum FetchSrcRockError {
     DownloadSrcRock(#[from] DownloadSrcRockError),

--- a/lux-lib/src/operations/fetch_vendored.rs
+++ b/lux-lib/src/operations/fetch_vendored.rs
@@ -3,10 +3,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bon::Builder;
-use path_slash::PathExt;
-use thiserror::Error;
-
 use crate::{
     lockfile::RemotePackageSourceUrl,
     lua_rockspec::{LuaRockspecError, RemoteLuaRockspec},
@@ -16,6 +12,10 @@ use crate::{
     remote_package_db::{RemotePackageDB, SearchError},
     remote_package_source::RemotePackageSource,
 };
+use bon::Builder;
+use miette::Diagnostic;
+use path_slash::PathExt;
+use thiserror::Error;
 
 /// Fetch a vendored rock from `<vendor_dir>`
 #[derive(Builder)]
@@ -27,9 +27,10 @@ pub(crate) struct FetchVendored<'a> {
     progress: &'a Progress<ProgressBar>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum FetchVendoredError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Search(#[from] SearchError),
     #[error("could not find a vendored RockSpec for package {0} in vendor directory {1}.")]
     RockspecNotFound(PackageSpec, String),

--- a/lux-lib/src/operations/gen_luarc.rs
+++ b/lux-lib/src/operations/gen_luarc.rs
@@ -7,6 +7,7 @@ use crate::workspace::WorkspaceTreeError;
 use crate::workspace::LUX_DIR_NAME;
 use bon::Builder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathBufExt;
 use pathdiff::diff_paths;
 use serde::{Deserialize, Serialize};
@@ -16,11 +17,13 @@ use std::path::PathBuf;
 use thiserror::Error;
 use tokio::fs;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum GenLuaRcError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
     #[error("failed to serialize luarc content:\n{0}")]
     Serialize(String),

--- a/lux-lib/src/operations/install/mod.rs
+++ b/lux-lib/src/operations/install/mod.rs
@@ -25,13 +25,13 @@ use crate::{
 
 pub use crate::operations::install::spec::PackageInstallSpec;
 
+use super::{DownloadedRockspec, RemoteRockDownload};
 use bon::Builder;
 use bytes::Bytes;
 use futures::StreamExt;
 use itertools::Itertools;
+use miette::Diagnostic;
 use thiserror::Error;
-
-use super::{DownloadedRockspec, RemoteRockDownload};
 
 pub mod spec;
 
@@ -147,29 +147,38 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum InstallError {
     #[error("unable to resolve dependencies:\n{0}")]
+    #[diagnostic(forward(0))]
     ResolveDependencies(#[from] ResolveDependenciesError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaInstallation(#[from] LuaInstallationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     FlushLockfile(#[from] FlushLockfileError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
     #[error("error instantiating LuaRocks compatibility layer:\n{0}")]
+    #[diagnostic(forward(0))]
     LuaRocks(#[from] LuaRocksError),
     #[error("error installing LuaRocks compatibility layer:\n{0}")]
+    #[diagnostic(forward(0))]
     LuaRocksInstall(#[from] LuaRocksInstallError),
     #[error("failed to build {0}: {1}")]
     Build(PackageName, BuildError),
     #[error("failed to install build depencency {0}:\n{1}")]
     BuildDependency(PackageName, BuildError),
     #[error("error initialising remote package DB:\n{0}")]
+    #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("failed to install pre-built rock {0}:\n{1}")]
     InstallBinaryRock(PackageName, InstallBinaryRockError),

--- a/lux-lib/src/operations/install_project.rs
+++ b/lux-lib/src/operations/install_project.rs
@@ -1,8 +1,3 @@
-use bon::Builder;
-use itertools::Itertools;
-use std::sync::Arc;
-use thiserror::Error;
-
 use crate::{
     build::{Build, BuildBehaviour, BuildError},
     config::Config,
@@ -14,28 +9,42 @@ use crate::{
     project::{project_toml::LocalProjectTomlValidationError, Project, ProjectError},
     tree::{self, InstallTree, TreeError},
 };
+use bon::Builder;
+use itertools::Itertools;
+use miette::Diagnostic;
+use std::sync::Arc;
+use thiserror::Error;
 
 use super::InstallError;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum InstallProjectError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Project(#[from] ProjectError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaInstallation(#[from] LuaInstallationError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaRocks(#[from] LuaRocksError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaRocksInstall(#[from] LuaRocksInstallError),
     #[error("error installind dependencies:\n{0}")]
+    #[diagnostic(forward(0))]
     InstallDependencies(InstallError),
     #[error("error installind build dependencies:\n{0}")]
+    #[diagnostic(forward(0))]
     InstallBuildDependencies(InstallError),
     #[error("error building project:\n{0}")]
+    #[diagnostic(forward(0))]
     Build(#[from] BuildError),
 }
 

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -16,6 +16,7 @@ use crate::tree::Tree;
 use bon::Builder;
 use clean_path::Clean;
 use itertools::Itertools;
+use miette::Diagnostic;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::fs::File;
@@ -54,7 +55,7 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("failed to pack rock: {0}")]
 pub enum PackError {
     Zip(#[from] zip::result::ZipError),

--- a/lux-lib/src/operations/pin.rs
+++ b/lux-lib/src/operations/pin.rs
@@ -1,18 +1,18 @@
 use std::io;
 
-use fs_extra::dir::CopyOptions;
-use itertools::Itertools;
-use thiserror::Error;
-
 use crate::{
     lockfile::{FlushLockfileError, LocalPackageId, PinnedState},
     package::PackageSpec,
     tree::{InstallTree, Tree, TreeError},
 };
+use fs_extra::dir::CopyOptions;
+use itertools::Itertools;
+use miette::Diagnostic;
+use thiserror::Error;
 
 // TODO(vhyrro): Differentiate pinned LocalPackages at the type level?
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum PinError {
     #[error("package with ID {0} not found in the lockfile")]
     PackageNotFound(LocalPackageId),
@@ -27,8 +27,10 @@ pub enum PinError {
         rock: PackageSpec,
     },
     #[error(transparent)]
+    #[diagnostic(transparent)]
     FlushLockfile(#[from] FlushLockfileError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error("failed to move old package: {0}")]
     MoveItemsFailure(#[from] fs_extra::error::Error),

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -4,6 +4,7 @@ use async_recursion::async_recursion;
 use bon::Builder;
 use futures::StreamExt;
 use itertools::Itertools;
+use miette::Diagnostic;
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -23,9 +24,10 @@ use crate::{
 
 use super::{Download, PackageInstallSpec, RemoteRockDownload, SearchAndDownloadError};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ResolveDependenciesError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     SearchAndDownload(#[from] SearchAndDownloadError),
     #[error("cyclic dependency detected:\n{0}")]
     CyclicDependency(DependencyCycle),

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -2,6 +2,7 @@ use std::{ops::Deref, path::PathBuf};
 
 use bon::Builder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use nonempty::NonEmpty;
 use serde::Deserialize;
 use thiserror::Error;
@@ -21,7 +22,7 @@ use crate::{
 
 use super::RunLuaError;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 #[error("'{0}' should not be used as a `command` as it is not cross-platform.
 You should only change the default `command` if it is a different Lua interpreter that behaves identically on all platforms.
 Consider removing the `command` field and letting Lux choose the default Lua interpreter instead.")]
@@ -62,16 +63,23 @@ impl Deref for RunCommand {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 #[error(transparent)]
 pub enum RunError {
+    #[diagnostic(transparent)]
     Toml(#[from] LocalProjectTomlValidationError),
+    #[diagnostic(transparent)]
     RunCommand(#[from] RunCommandError),
+    #[diagnostic(transparent)]
     LuaVersion(#[from] LuaVersionError),
+    #[diagnostic(transparent)]
     RunLua(#[from] RunLuaError),
+    #[diagnostic(transparent)]
     WorkspaceError(#[from] WorkspaceError),
+    #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
     Io(#[from] std::io::Error),
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error("No `run` field found in `lux.toml`")]
     NoRunField,

--- a/lux-lib/src/operations/run_lua.rs
+++ b/lux-lib/src/operations/run_lua.rs
@@ -16,6 +16,7 @@ use std::{
     process::Stdio,
 };
 
+use miette::Diagnostic;
 use thiserror::Error;
 use tokio::process::Command;
 
@@ -26,9 +27,10 @@ use crate::{
     tree::TreeError,
 };
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RunLuaError {
     #[error("error running lua: {0}")]
+    #[diagnostic(forward(0))]
     LuaBinary(#[from] LuaBinaryError),
     #[error("failed to run {lua_cmd}: {source}")]
     LuaCommandFailed {
@@ -42,9 +44,11 @@ pub enum RunLuaError {
         exit_code: Option<i32>,
     },
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
 
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
 }
 

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -1,5 +1,6 @@
 use std::{io, sync::Arc};
 
+use super::{Install, InstallError, PackageInstallSpec, RemoveError, Uninstall};
 use crate::{
     build::BuildBehaviour,
     config::Config,
@@ -18,9 +19,8 @@ use crate::{
 };
 use bon::Builder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use thiserror::Error;
-
-use super::{Install, InstallError, PackageInstallSpec, RemoveError, Uninstall};
 
 /// A rocks sync builder, for synchronising a tree with a lockfile.
 #[derive(Builder)]
@@ -125,29 +125,38 @@ impl SyncReport {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum SyncError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     FlushLockfile(#[from] FlushLockfileError),
     #[error("failed to create install tree at {0}:\n{1}")]
     FailedToCreateDirectory(String, io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Install(#[from] InstallError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Remove(#[from] RemoveError),
     #[error("integrity error for package {0}: {1}\n")]
     Integrity(PackageName, LockfileIntegrityError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Project(#[from] ProjectError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LocalProjectTomlValidationError(#[from] LocalProjectTomlValidationError),
     #[error("failed to generate `.luarc.json`:\n{0}")]
+    #[diagnostic(forward(0))]
     GenLuaRc(#[from] GenLuaRcError),
 }
 

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -1,5 +1,8 @@
 use std::{io, ops::Deref, path::PathBuf, process::Command, sync::Arc};
 
+use super::{
+    BuildWorkspace, BuildWorkspaceError, Install, InstallError, PackageInstallSpec, Sync, SyncError,
+};
 use crate::tree::InstallTree;
 use crate::workspace::{WorkspaceError, WorkspaceTreeError};
 use crate::{
@@ -17,12 +20,9 @@ use crate::{
 };
 use bon::Builder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathBufExt;
 use thiserror::Error;
-
-use super::{
-    BuildWorkspace, BuildWorkspaceError, Install, InstallError, PackageInstallSpec, Sync, SyncError,
-};
 
 #[cfg(target_family = "unix")]
 const BUSTED_EXE: &str = "busted";
@@ -79,13 +79,16 @@ pub enum TestEnv {
     Impure,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RunTestsError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Config(#[from] ConfigError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     InstallTestDependencies(#[from] InstallTestDependenciesError),
     #[error("error building project:\n{0}")]
+    #[diagnostic(forward(0))]
     BuildProject(#[from] BuildWorkspaceError),
     #[error("tests failed!")]
     TestFailure,
@@ -94,22 +97,31 @@ pub enum RunTestsError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Project(#[from] ProjectError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Paths(#[from] PathsError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] WorkspaceTreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ProjectTomlValidation(#[from] LocalProjectTomlValidationError),
     #[error("failed to sync dependencies: {0}")]
+    #[diagnostic(forward(0))]
     Sync(#[from] SyncError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     TestSpec(#[from] TestSpecError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersion(#[from] LuaVersionError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaBinary(#[from] LuaBinaryError),
 }
 
@@ -226,8 +238,9 @@ async fn run_project_tests(
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("error installing test dependencies: {0}")]
+#[diagnostic(forward(0))]
 pub enum InstallTestDependenciesError {
     WorkspaceTree(#[from] WorkspaceTreeError),
     Tree(#[from] TreeError),

--- a/lux-lib/src/operations/uninstall.rs
+++ b/lux-lib/src/operations/uninstall.rs
@@ -9,16 +9,19 @@ use crate::{config::Config, tree::Tree};
 use bon::Builder;
 use futures::StreamExt;
 use itertools::Itertools;
+use miette::Diagnostic;
 use thiserror::Error;
-
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum RemoveError {
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     FlushLockfile(#[from] FlushLockfileError),
 }
 

--- a/lux-lib/src/operations/unpack.rs
+++ b/lux-lib/src/operations/unpack.rs
@@ -1,6 +1,7 @@
 use async_recursion::async_recursion;
 use flate2::read::GzDecoder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathExt;
 use std::fs::File;
 use std::io;
@@ -15,7 +16,7 @@ use tokio::fs;
 use crate::progress::Progress;
 use crate::progress::ProgressBar;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum UnpackError {
     #[error("failed to unpack source: {0}")]
     Io(#[from] io::Error),

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -1,9 +1,5 @@
 use std::{io, sync::Arc};
 
-use bon::Builder;
-use itertools::Itertools;
-use thiserror::Error;
-
 use crate::{
     config::Config,
     lockfile::{
@@ -18,30 +14,43 @@ use crate::{
     tree::{self, InstallTree, Tree, TreeError},
     workspace::{Workspace, WorkspaceError, WorkspaceTreeError},
 };
+use bon::Builder;
+use itertools::Itertools;
+use miette::Diagnostic;
+use thiserror::Error;
 
 use super::{Install, InstallError, PackageInstallSpec, RemoveError, SyncError, Uninstall};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum UpdateError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     RockConstraintUnsatisfied(#[from] RockConstraintUnsatisfied),
     #[error("failed to update rock: {0}")]
+    #[diagnostic(forward(0))]
     Install(#[from] InstallError),
     #[error("failed to remove old rock: {0}")]
+    #[diagnostic(forward(0))]
     Remove(#[from] RemoveError),
     #[error("error initialising remote package DB:\n{0}")]
+    #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("error loading the workspace:\n{0}")]
+    #[diagnostic(forward(0))]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error("error initialising the workspace install tree:\n{0}")]
+    #[diagnostic(forward(0))]
     WorkspaceTree(#[from] WorkspaceTreeError),
     #[error("error syncing the workspace install tree:\n{0}")]
+    #[diagnostic(forward(0))]
     Sync(#[from] SyncError),
 }
 

--- a/lux-lib/src/operations/vendor.rs
+++ b/lux-lib/src/operations/vendor.rs
@@ -8,6 +8,7 @@ use bon::Builder;
 use bytes::Bytes;
 use futures::StreamExt;
 use itertools::Itertools;
+use miette::Diagnostic;
 use path_slash::PathExt;
 use strum::IntoEnumIterator;
 use thiserror::Error;
@@ -64,15 +65,19 @@ pub struct Vendor<'a> {
     progress: Option<Arc<Progress<MultiProgress>>>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum VendorError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
     #[error("project validation failed:\n{0}")]
+    #[diagnostic(forward(0))]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
     #[error("error initialising remote package DB:\n{0}")]
+    #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("failed to resolve dependencies:\n{0}")]
+    #[diagnostic(forward(0))]
     ResolveDependencies(#[from] ResolveDependenciesError),
     #[error("failed to delete vendor directory {0}:\n{1}")]
     DeleteVendorDir(String, io::Error),
@@ -85,8 +90,10 @@ pub enum VendorError {
     #[error("failed to write Lua RockSpec {0}:\n{1}")]
     WriteLuaRockSpec(String, io::Error),
     #[error("failed to unpack src.rock:\n{0}")]
+    #[diagnostic(forward(0))]
     Unpack(#[from] UnpackError),
     #[error("failed to fetch rock source:\n{0}")]
+    #[diagnostic(forward(0))]
     FetchSrc(#[from] FetchSrcError),
 }
 

--- a/lux-lib/src/package/mod.rs
+++ b/lux-lib/src/package/mod.rs
@@ -1,9 +1,9 @@
 use itertools::Itertools;
 
+use miette::Diagnostic;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::{cmp::Ordering, fmt::Display, str::FromStr};
 use thiserror::Error;
-
 mod outdated;
 mod version;
 
@@ -24,7 +24,7 @@ use crate::{
     variables::{GetVariableError, HasVariables},
 };
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum PackageSpecFromPackageReqError {
     #[error("invalid version for rock {rock}: {err}")]
     Version {
@@ -172,7 +172,7 @@ impl Default for RemotePackageTypeFilterSpec {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ParseRemotePackageError {
     #[error("unable to parse package {0}. expected format: `name@version`")]
     InvalidInput(String),
@@ -303,7 +303,7 @@ impl DisplayAsLuaKV for BuildDependencies<'_> {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum PackageReqParseError {
     #[error("could not parse dependency name from {0}")]
     InvalidDependencyName(String),

--- a/lux-lib/src/package/outdated.rs
+++ b/lux-lib/src/package/outdated.rs
@@ -1,16 +1,16 @@
 use std::fmt::Display;
 
-use thiserror::Error;
-
 use crate::remote_package_db::RemotePackageDB;
+use miette::Diagnostic;
+use thiserror::Error;
 
 use super::{version::PackageVersion, PackageName, PackageReq, PackageSpec, PackageVersionReq};
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("rock {0} not found")]
 pub struct RockNotFound(PackageName);
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("rock {} has no version that satisfies constraint {}", .name, .constraint.to_string())]
 pub struct RockConstraintUnsatisfied {
     name: PackageName,

--- a/lux-lib/src/package/version.rs
+++ b/lux-lib/src/package/version.rs
@@ -7,12 +7,12 @@ use std::{
 use html_escape::decode_html_entities;
 use itertools::Itertools;
 
+use miette::Diagnostic;
 use nonempty::NonEmpty;
 use semver::{Comparator, Error, Op, Version, VersionReq};
 use serde::{de, Deserialize, Deserializer, Serialize};
 use thiserror::Error;
-
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum VersionReqToVersionError {
     #[error("cannot parse version from non-exact version requirement '{0}'")]
     NonExactVersionReq(VersionReq),
@@ -136,9 +136,10 @@ impl TryFrom<PackageVersionReq> for PackageVersion {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum PackageVersionParseError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Specrev(#[from] SpecrevParseError),
     #[error("failed to parse version: {0}")]
     Version(#[from] Error),
@@ -465,7 +466,7 @@ pub(crate) trait HasModRev {
     fn to_modrev_string(&self) -> String;
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub struct PackageVersionReqError(#[from] Error);
 
@@ -585,7 +586,7 @@ fn trim_specrev(version_str: &str) -> &str {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum SpecrevParseError {
     #[error("specrev {specrev} in version {full_version} contains non-numeric characters")]
     InvalidSpecrev {

--- a/lux-lib/src/path.rs
+++ b/lux-lib/src/path.rs
@@ -1,14 +1,14 @@
-use itertools::Itertools;
-use path_slash::PathBufExt;
-use serde::Serialize;
-use std::{env, fmt::Display, path::PathBuf, str::FromStr};
-use thiserror::Error;
-
 use crate::{
     build::utils::c_dylib_extension,
     lua_version::LuaVersion,
     tree::{InstallTree, TreeError},
 };
+use itertools::Itertools;
+use miette::Diagnostic;
+use path_slash::PathBufExt;
+use serde::Serialize;
+use std::{env, fmt::Display, path::PathBuf, str::FromStr};
+use thiserror::Error;
 
 const LUA_PATH_SEPARATOR: &str = ";";
 const LUA_INIT: &str = "require('lux').loader()";
@@ -25,9 +25,10 @@ pub struct Paths {
     version: LuaVersion,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum PathsError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
 }
 

--- a/lux-lib/src/project/gen.rs
+++ b/lux-lib/src/project/gen.rs
@@ -3,16 +3,16 @@ use std::{
     str::FromStr,
 };
 
-use ::serde::Deserialize;
-use git2::Repository;
-use serde::Serialize;
-use thiserror::Error;
-
 use crate::{
     lua_rockspec::{RockSourceInternal, SourceUrl, SourceUrlError},
     package::{PackageName, PackageSpec, PackageVersion, PackageVersionParseError, SpecRev},
     variables::{self, Environment, GetVariableError, HasVariables, VariableSubstitutionError},
 };
+use ::serde::Deserialize;
+use git2::Repository;
+use miette::Diagnostic;
+use serde::Serialize;
+use thiserror::Error;
 
 use super::ProjectRoot;
 
@@ -45,7 +45,7 @@ pub(crate) struct RockSourceTemplate {
     tag: Option<String>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum GenerateSourceError {
     #[error(
         "unsupported version {0}.\nCan only generate source for SemVer versions, 'dev' or 'scm'."
@@ -56,8 +56,10 @@ pub enum GenerateSourceError {
     #[error("need a `source.dev` (dev/scm URL) in lux.toml for dev versions.")]
     MissingDevUrl(String),
     #[error("error substituting project source variables:\n{0}")]
+    #[diagnostic(forward(0))]
     VariableSubstitution(#[from] VariableSubstitutionError),
     #[error("error parsing source URL from template:\n{0}")]
+    #[diagnostic(forward(0))]
     SourceUrl(#[from] SourceUrlError),
     #[error("error generating git source URL:\n{0}")]
     Git(#[from] git2::Error),
@@ -180,11 +182,12 @@ impl RockSourceTemplate {
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone, Default)]
 pub(crate) struct PackageVersionTemplate(Option<PackageVersion>);
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum GenerateVersionError {
     #[error("error generating version from git repository metadata:\n{0}")]
     Git(#[from] git2::Error),
     #[error("error parsing version from git ref:\n{0}")]
+    #[diagnostic(forward(0))]
     PackageVersionParse(#[from] PackageVersionParseError),
 }
 

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use path_slash::PathBufExt;
 use project_toml::{
     LocalProjectTomlValidationError, PartialProjectToml, RemoteProjectTomlValidationError,
@@ -44,42 +45,87 @@ pub use project_toml::PROJECT_TOML;
 
 pub const EXTRA_ROCKSPEC: &str = "extra.rockspec";
 
-#[derive(Error, Debug)]
+/// A wrapper around [`toml::de::Error`] plus the original source code and the byte range where the
+/// error occurred so that `miette` can render the failure with line numbers and context.
+#[derive(Debug, Error, Diagnostic)]
+#[error("{message}", message = _inner.message())]
+#[diagnostic(
+    code(lux_lib::toml::deserialize),
+    help("check that the file is valid TOML and matches the expected schema")
+)]
+pub struct TomlDeError {
+    #[source]
+    _inner: Box<toml::de::Error>,
+    #[source_code]
+    src: NamedSource<String>,
+    #[label("here")]
+    span: SourceSpan,
+}
+
+impl TomlDeError {
+    pub fn new(name: &str, src: &str, inner: toml::de::Error) -> Self {
+        let src = NamedSource::new(name, src.to_string());
+        let span = inner.span().unwrap_or(0..0).into();
+        Self {
+            _inner: Box::new(inner),
+            src,
+            span,
+        }
+    }
+
+    pub fn inner(&self) -> &toml::de::Error {
+        &self._inner
+    }
+}
+
+pub(crate) fn parse_toml<T>(name: &str, src: &str) -> Result<T, TomlDeError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    toml::from_str(src).map_err(|e| TomlDeError::new(name, src, e))
+}
+
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum ProjectError {
     #[error("error reading project TOML at {0}:\n{1}")]
     ReadProjectTOML(String, io::Error),
     #[error("error creating project root at {0}:\n{1}")]
     CreateProjectRoot(String, io::Error),
+    #[diagnostic(transparent)]
     Project(#[from] LocalProjectTomlValidationError),
-    Toml(#[from] toml::de::Error),
+    #[diagnostic(transparent)]
+    Toml(#[from] TomlDeError),
     #[error("error when parsing `extra.rockspec`: {0}")]
+    #[diagnostic(forward(0))]
     Rockspec(#[from] PartialRockspecError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum IntoLocalRockspecError {
     LocalProjectTomlValidationError(#[from] LocalProjectTomlValidationError),
     RockspecError(#[from] LuaRockspecError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum IntoRemoteRockspecError {
     RocksTomlValidationError(#[from] RemoteProjectTomlValidationError),
     RockspecError(#[from] LuaRockspecError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ProjectEditError {
     #[error(transparent)]
     Io(#[from] tokio::io::Error),
     #[error(transparent)]
     Toml(#[from] toml_edit::TomlError),
     #[error("error parsing {PROJECT_TOML} after edit. This is probably a bug.")]
-    TomlDe(#[from] toml::de::Error),
+    #[diagnostic(forward(0))]
+    TomlDe(#[from] TomlDeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Git(#[from] GitError),
     #[error("unable to query latest version for {0}")]
     LatestVersionNotFound(PackageName),
@@ -88,10 +134,11 @@ pub enum ProjectEditError {
     #[error("expected string, but got {0}")]
     ExpectedString(Box<toml_edit::Value>),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     GitUrlShorthandParse(#[from] git::shorthand::ParseError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum PinError {
     #[error("package {0} not found in dependencies")]
     PackageNotFound(PackageName),
@@ -103,7 +150,8 @@ pub enum PinError {
     #[error(transparent)]
     Toml(#[from] toml_edit::TomlError),
     #[error("error parsing lux.toml after edit. This is probably a bug.")]
-    TomlDe(#[from] toml::de::Error),
+    #[diagnostic(forward(0))]
+    TomlDe(#[from] TomlDeError),
     #[error(transparent)]
     Io(#[from] tokio::io::Error),
 }
@@ -159,7 +207,11 @@ impl Project {
 
             let mut project = Project {
                 root: ProjectRoot(root.to_path_buf()),
-                toml: PartialProjectToml::new(&toml_content, ProjectRoot(root.to_path_buf()))?,
+                toml: PartialProjectToml::new(
+                    &project_toml_path.to_string_lossy(),
+                    &toml_content,
+                    ProjectRoot(root.to_path_buf()),
+                )?,
             };
 
             if let Some(extra_rockspec) = project.extra_rockspec()? {
@@ -262,7 +314,11 @@ impl Project {
 
         let toml_content = project_toml.to_string();
         tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        self.toml = PartialProjectToml::new(
+            self.toml_path().to_str().unwrap_or("<lux.toml>"),
+            &toml_content,
+            self.root.clone(),
+        )?;
 
         Ok(())
     }
@@ -309,7 +365,11 @@ impl Project {
 
         let toml_content = project_toml.to_string();
         tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        self.toml = PartialProjectToml::new(
+            self.toml_path().to_str().unwrap_or("<lux.toml>"),
+            &toml_content,
+            self.root.clone(),
+        )?;
 
         Ok(())
     }
@@ -351,7 +411,11 @@ impl Project {
 
         let toml_content = project_toml.to_string();
         tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        self.toml = PartialProjectToml::new(
+            self.toml_path().to_str().unwrap_or("<lux.toml>"),
+            &toml_content,
+            self.root.clone(),
+        )?;
 
         Ok(())
     }
@@ -437,7 +501,11 @@ impl Project {
 
         let toml_content = project_toml.to_string();
         tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        self.toml = PartialProjectToml::new(
+            self.toml_path().to_str().unwrap_or("<lux.toml>"),
+            &toml_content,
+            self.root.clone(),
+        )?;
 
         Ok(())
     }
@@ -566,7 +634,11 @@ impl Project {
 
         let toml_content = project_toml.to_string();
         tokio::fs::write(self.toml_path(), &toml_content).await?;
-        self.toml = PartialProjectToml::new(&toml_content, self.root.clone())?;
+        self.toml = PartialProjectToml::new(
+            self.toml_path().to_str().unwrap_or("<lux.toml>"),
+            &toml_content,
+            self.root.clone(),
+        )?;
 
         Ok(())
     }

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -15,17 +15,11 @@ use crate::lua_version::LuaVersion;
 use crate::operations::RunCommand;
 use crate::package::PackageNameList;
 use crate::package::SpecRev;
+use crate::project::TomlDeError;
 use crate::rockspec::lua_dependency::LuaDependencySpec;
 use crate::ROCKSPEC_FUEL_LIMIT;
 use std::io;
 use std::{collections::HashMap, path::PathBuf};
-
-use itertools::Itertools;
-use nonempty::NonEmpty;
-use serde::de;
-use serde::{Deserialize, Deserializer};
-use ssri::Integrity;
-use thiserror::Error;
 
 use crate::{
     config::Config,
@@ -41,6 +35,13 @@ use crate::{
     },
     rockspec::{LuaVersionCompatibility, Rockspec},
 };
+use itertools::Itertools;
+use miette::Diagnostic;
+use nonempty::NonEmpty;
+use serde::de;
+use serde::{Deserialize, Deserializer};
+use ssri::Integrity;
+use thiserror::Error;
 
 use super::gen::GenerateSourceError;
 use super::gen::RockSourceTemplate;
@@ -135,11 +136,13 @@ where
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum ProjectTomlError {
     #[error("error generating rockspec source:\n{0}")]
+    #[diagnostic(forward(0))]
     GenerateSource(#[from] GenerateSourceError),
     #[error("error generating rockspec version:\n{0}")]
+    #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
     #[error("generated rockspec exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
     FuelLimitExceeded,
@@ -151,19 +154,23 @@ Please report this issue."#
     GeneratedInvalidLua(String),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum LocalProjectTomlValidationError {
     #[error("no lua version provided")]
     NoLuaVersion,
     #[error("could not decode the test spec:\n:{0}")]
+    #[diagnostic(forward(0))]
     TestSpecError(#[from] TestSpecDecodeError),
     #[error("could not decode the build spec:\n:{0}")]
+    #[diagnostic(forward(0))]
     BuildSpecInternal(#[from] BuildSpecInternalError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     PlatformValidation(#[from] PlatformValidationError),
     #[error("{}copy_directories cannot contain a rockspec name", ._0.as_ref().map(|p| format!("{p}: ")).unwrap_or_default())]
     CopyDirectoriesContainRockspecName(Option<String>),
     #[error("could not decode the source spec:\n:{0}")]
+    #[diagnostic(forward(0))]
     RockSource(#[from] RockSourceError),
     #[error("duplicate dependencies: {0}")]
     DuplicateDependencies(PackageNameList),
@@ -188,18 +195,23 @@ pub enum LocalProjectTomlValidationError {
     )]
     DependenciesContainLua,
     #[error("error generating rockspec source:\n{0}")]
+    #[diagnostic(forward(0))]
     GenerateSource(#[from] GenerateSourceError),
     #[error("error generating rockspec version:\n{0}")]
+    #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum RemoteProjectTomlValidationError {
     #[error("error generating rockspec source:\n{0}")]
+    #[diagnostic(forward(0))]
     GenerateSource(#[from] GenerateSourceError),
     #[error("error generating rockspec version:\n{0}")]
+    #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LocalProjectTomlValidationError(#[from] LocalProjectTomlValidationError),
 }
 
@@ -251,10 +263,14 @@ impl HasIntegrity for PartialProjectToml {
 }
 
 impl PartialProjectToml {
-    pub(crate) fn new(str: &str, project_root: ProjectRoot) -> Result<Self, toml::de::Error> {
+    pub(crate) fn new(
+        name: &str,
+        str: &str,
+        project_root: ProjectRoot,
+    ) -> Result<Self, TomlDeError> {
         Ok(Self {
             project_root,
-            ..toml::from_str(str)?
+            ..super::parse_toml(name, str)?
         })
     }
 
@@ -825,7 +841,7 @@ fn validate_generated_lua(lua_str: &str) -> Result<(), ProjectTomlError> {
     .map_err(|err| ProjectTomlError::GeneratedInvalidLua(err.to_string()))?
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum ProjectTomlIntegrityError {
     LuaRockspecError(#[from] LuaRockspecError),
@@ -1052,7 +1068,7 @@ mod tests {
     use crate::{
         git::{url::RemoteGitUrl, GitSource},
         lua_rockspec::{PartialLuaRockspec, PerPlatform, RemoteLuaRockspec, RockSourceSpec},
-        project::{Project, ProjectRoot},
+        project::{Project, ProjectRoot, PROJECT_TOML},
         rockspec::{lua_dependency::LuaDependencySpec, Rockspec},
     };
 
@@ -1081,7 +1097,8 @@ mod tests {
         type = "builtin"
         "#;
 
-        let project = PartialProjectToml::new(project_toml, ProjectRoot::default()).unwrap();
+        let project =
+            PartialProjectToml::new(PROJECT_TOML, project_toml, ProjectRoot::default()).unwrap();
         let _ = project.into_remote(None).unwrap();
 
         let project_toml = r#"
@@ -1137,7 +1154,8 @@ mod tests {
         type = "builtin"
         "#;
 
-        let project = PartialProjectToml::new(project_toml, ProjectRoot::default()).unwrap();
+        let project =
+            PartialProjectToml::new(PROJECT_TOML, project_toml, ProjectRoot::default()).unwrap();
         let _ = project.into_remote(None).unwrap();
     }
 
@@ -1290,7 +1308,8 @@ mod tests {
 
         let expected_rockspec = RemoteLuaRockspec::new(expected_rockspec).unwrap();
 
-        let project_toml = PartialProjectToml::new(project_toml, ProjectRoot::default()).unwrap();
+        let project_toml =
+            PartialProjectToml::new(PROJECT_TOML, project_toml, ProjectRoot::default()).unwrap();
         let rockspec = project_toml
             .into_remote(None)
             .unwrap()
@@ -1440,7 +1459,8 @@ mod tests {
             &mergable_rockspec_content
         );
 
-        let project_toml = PartialProjectToml::new(project_toml, ProjectRoot::default()).unwrap();
+        let project_toml =
+            PartialProjectToml::new(PROJECT_TOML, project_toml, ProjectRoot::default()).unwrap();
         let partial_rockspec = PartialLuaRockspec::new(mergable_rockspec_content).unwrap();
         let expected_rockspec = RemoteLuaRockspec::new(&remote_rockspec_content).unwrap();
 
@@ -1495,7 +1515,7 @@ mod tests {
         type = "builtin"
         "#;
 
-        PartialProjectToml::new(project_toml, ProjectRoot::default())
+        PartialProjectToml::new(PROJECT_TOML, project_toml, ProjectRoot::default())
             .unwrap()
             .into_local()
             .unwrap_err();
@@ -1518,7 +1538,8 @@ mod tests {
                 "#,
             );
 
-            PartialProjectToml::new(&project_toml, ProjectRoot::default()).unwrap_err();
+            PartialProjectToml::new(PROJECT_TOML, &project_toml, ProjectRoot::default())
+                .unwrap_err();
         }
     }
 
@@ -1536,7 +1557,7 @@ mod tests {
             type = "builtin"
         "#;
 
-        PartialProjectToml::new(rockspec_content, ProjectRoot::default())
+        PartialProjectToml::new(PROJECT_TOML, rockspec_content, ProjectRoot::default())
             .unwrap()
             .into_remote(None)
             .unwrap_err();
@@ -1557,7 +1578,7 @@ mod tests {
             type = "builtin"
         "#;
 
-        PartialProjectToml::new(rockspec_content, ProjectRoot::default())
+        PartialProjectToml::new(PROJECT_TOML, rockspec_content, ProjectRoot::default())
             .unwrap()
             .into_remote(None)
             .unwrap();

--- a/lux-lib/src/remote_package_db/mod.rs
+++ b/lux-lib/src/remote_package_db/mod.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 use itertools::Itertools;
 
+use miette::Diagnostic;
 use thiserror::Error;
-
 /// Package database, used to look up remote rocks
 #[derive(Clone, Debug)]
 pub struct RemotePackageDB(Impl);
@@ -22,27 +22,31 @@ enum Impl {
     Lock(LocalPackageLock),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RemotePackageDBError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ManifestError(#[from] ManifestError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     ConfigError(#[from] ConfigError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum SearchError {
     #[error("no rock that matches '{0}' found")]
     RockNotFound(PackageReq),
     #[error("no rock that matches '{0}' found in the lockfile.")]
     RockNotFoundInLockfile(PackageReq),
     #[error("error when pulling manifest:\n{0}")]
+    #[diagnostic(forward(0))]
     Manifest(#[from] ManifestError),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RemotePackageDbIntegrityError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Lockfile(#[from] LockfileIntegrityError),
 }
 

--- a/lux-lib/src/remote_package_source/mod.rs
+++ b/lux-lib/src/remote_package_source/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use miette::Diagnostic;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -65,7 +66,7 @@ impl Serialize for RemotePackageSource {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RemotePackageSourceError {
     #[error("error parsing remote source URL {0}. Missing URL.")]
     MissingUrl(String),

--- a/lux-lib/src/rockspec/lua_dependency.rs
+++ b/lux-lib/src/rockspec/lua_dependency.rs
@@ -1,8 +1,5 @@
 use std::{collections::HashMap, convert::Infallible, fmt::Display, str::FromStr};
 
-use serde::{Deserialize, Deserializer};
-use thiserror::Error;
-
 use crate::{
     lockfile::{OptState, PinnedState},
     lua_rockspec::{
@@ -10,10 +7,14 @@ use crate::{
     },
     package::{PackageName, PackageReq, PackageReqParseError, PackageSpec, PackageVersionReq},
 };
+use miette::Diagnostic;
+use serde::{Deserialize, Deserializer};
+use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum LuaDependencySpecParseError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     PackageReq(#[from] PackageReqParseError),
 }
 

--- a/lux-lib/src/tree/dist.rs
+++ b/lux-lib/src/tree/dist.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashMap, io, path::PathBuf};
 
-use thiserror::Error;
-
 use super::{InstallTree, RockLayout, Tree, TreeError};
 use crate::{
     config::{tree::RockLayoutConfig, Config},
@@ -10,11 +8,13 @@ use crate::{
     package::{PackageName, PackageVersion},
     tree::mk_rock_layout,
 };
+use miette::{Diagnostic, Result};
+use thiserror::Error;
 
 const SRC_DIR_NAME: &str = "lua";
 const LIB_DIR_NAME: &str = "lib";
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(
     r#"cannot install conflicting packages in flat tree:
 package: {name}

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -9,9 +9,9 @@ use crate::{
 use std::{collections::HashMap, io, path::PathBuf};
 
 use itertools::Itertools;
+use miette::Diagnostic;
 use nonempty::NonEmpty;
 use thiserror::Error;
-
 mod dist;
 mod list;
 
@@ -76,13 +76,14 @@ pub struct Tree {
     build_tree_dir: PathBuf,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum TreeError {
     #[error("unable to create directory {0}:\n{1}")]
     CreateDir(String, io::Error),
     #[error("unable to write to {0}:\n{1}")]
     WriteFile(String, io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
 }
 

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -11,6 +11,7 @@ use crate::{config::Config, project::Project};
 
 use bon::Builder;
 use itertools::Itertools;
+use miette::Diagnostic;
 use reqwest::multipart::{Form, Part};
 use reqwest::StatusCode;
 use serde::Deserialize;
@@ -56,7 +57,7 @@ pub struct VersionCheckResponse {
     version: String,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ToolCheckError {
     #[error("error parsing tool check URL:\n{0}")]
     ParseError(#[from] url::ParseError),
@@ -67,7 +68,7 @@ pub enum ToolCheckError {
     ToolOutdated(String, VersionCheckResponse),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum UserCheckError {
     #[error("error parsing user check URL:\n{0}")]
     ParseError(#[from] url::ParseError),
@@ -79,7 +80,7 @@ pub enum UserCheckError {
     Server(Url, StatusCode),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum RockCheckError {
     #[error("parse error while checking rock status on server:\n{0}")]
     ParseError(#[from] url::ParseError),
@@ -87,7 +88,7 @@ pub enum RockCheckError {
     Request(#[from] reqwest::Error),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum UploadError {
     #[error("error parsing upload URL:\n{0}")]
@@ -125,6 +126,7 @@ pub enum UploadError {
     #[error("the maximum supported number of rockspec revisions per version has been exceeded")]
     MaxSpecRevsExceeded,
     #[error("rock already exists on server. Error downloading existing rockspec:\n{0}")]
+    #[diagnostic(forward(0))]
     SearchAndDownload(#[from] SearchAndDownloadError),
     #[error("error computing rockspec hash:\n{0}")]
     Hash(io::Error),
@@ -134,7 +136,7 @@ pub enum UploadError {
 
 pub struct ApiKey(String);
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 #[error("no API key provided! Please set the $LUX_API_KEY environment variable")]
 pub struct ApiKeyUnspecified;
 

--- a/lux-lib/src/variables.rs
+++ b/lux-lib/src/variables.rs
@@ -1,7 +1,7 @@
 use chumsky::{prelude::*, Parser};
+use miette::Diagnostic;
 use thiserror::Error;
-
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Diagnostic)]
 pub enum VariableSubstitutionError {
     #[error("unable to substitute variables {0:#?}")]
     SubstitutionError(Vec<String>),
@@ -9,7 +9,7 @@ pub enum VariableSubstitutionError {
     RecursionLimit,
 }
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Diagnostic)]
 #[error("{0}")]
 pub(crate) struct GetVariableError(String);
 

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -1,9 +1,5 @@
 use std::{io, path::PathBuf};
 
-use bon::Builder;
-use itertools::Itertools;
-use thiserror::Error;
-
 use crate::{
     config::Config,
     lua_rockspec::LuaModule,
@@ -11,6 +7,10 @@ use crate::{
     package::PackageReq,
     tree::{InstallTree, TreeError},
 };
+use bon::Builder;
+use itertools::Itertools;
+use miette::Diagnostic;
+use thiserror::Error;
 
 /// A rocks module finder.
 #[derive(Builder)]
@@ -46,13 +46,15 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum WhichError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
     #[error("lua module {0} not found.")]
     ModuleNotFound(LuaModule),

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -4,23 +4,23 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use glob::glob;
-use itertools::Itertools;
-use lets_find_up::{find_up_with, FindUpKind, FindUpOptions};
-use nonempty::NonEmpty;
-use path_slash::PathBufExt;
-use thiserror::Error;
-
 use crate::{
     config::Config,
     lockfile::{LockfileError, ReadOnly, WorkspaceLockfile},
     lua_rockspec::LuaVersionError,
     lua_version::LuaVersion,
     package::PackageName,
-    project::{Project, ProjectError, PROJECT_TOML},
+    project::{Project, ProjectError, TomlDeError, PROJECT_TOML},
     tree::{InstallTree, Tree, TreeError},
     workspace::workspace_toml::{WorkspaceMemberSpec, WorkspaceToml},
 };
+use glob::glob;
+use itertools::Itertools;
+use lets_find_up::{find_up_with, FindUpKind, FindUpOptions};
+use miette::Diagnostic;
+use nonempty::NonEmpty;
+use path_slash::PathBufExt;
+use thiserror::Error;
 
 pub mod workspace_toml;
 
@@ -48,25 +48,28 @@ impl Deref for WorkspaceRoot {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum WorkspaceError {
     #[error("cannot get current directory: {0}")]
     GetCwd(io::Error),
     #[error("error reading lux.toml at {0}:\n{1}")]
     ReadLuxTOML(String, io::Error),
     #[error("error deserializing workspace TOML:\n{0}")]
-    TOML(String),
+    #[diagnostic(transparent)]
+    TOML(TomlDeError),
     #[error("no project found at '{0}'")]
     ProjectNotFound(PathBuf),
     #[error("glob error: '{0}'")]
     Glob(String),
     #[error("error deserializing project TOML:\n{0}")]
+    #[diagnostic(forward(0))]
     Project(#[from] ProjectError),
     #[error("no project or workspace found")]
     NoWorkspaceOrProject,
     #[error("empty workspace at '{0}'")]
     EmptyWorkspace(PathBuf),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
     #[error("not a lux project or workspace directory:\n'{0}'")]
     NotAWorkspaceDir(PathBuf),
@@ -76,11 +79,13 @@ pub enum WorkspaceError {
     PackageNotFound(PackageName, WorkspaceRoot),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum WorkspaceTreeError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Tree(#[from] TreeError),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     LuaVersionError(#[from] LuaVersionError),
 }
 
@@ -334,8 +339,8 @@ impl Workspace {
     }
 
     fn from_toml(toml_content: &str, root: &Path) -> Result<Self, WorkspaceError> {
-        let toml = WorkspaceToml::new(toml_content)
-            .map_err(|err| WorkspaceError::TOML(err.to_string()))?;
+        let toml =
+            WorkspaceToml::new(WORKSPACE_TOML, toml_content).map_err(WorkspaceError::TOML)?;
         let mut members = Vec::new();
         for member in toml.workspace.members {
             match member {

--- a/lux-lib/src/workspace/workspace_toml.rs
+++ b/lux-lib/src/workspace/workspace_toml.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use serde::{de, Deserialize};
 
+use crate::project::{parse_toml, TomlDeError};
+
 /// The `lux.toml` file for a workspace.
 /// Used to deserialize a workspace with multiple projects.
 #[derive(Clone, Debug, Deserialize)]
@@ -10,8 +12,8 @@ pub(super) struct WorkspaceToml {
 }
 
 impl WorkspaceToml {
-    pub(super) fn new(toml_content: &str) -> Result<Self, toml::de::Error> {
-        toml::from_str(toml_content)
+    pub(super) fn new(name: &str, toml_content: &str) -> Result<Self, TomlDeError> {
+        parse_toml(name, toml_content)
     }
 }
 
@@ -60,7 +62,7 @@ mod tests {
                 "glob:projects/baz/*",
             ]
         "#;
-        let workspace_toml = WorkspaceToml::new(toml_content).unwrap();
+        let workspace_toml = WorkspaceToml::new("lux.toml", toml_content).unwrap();
         assert_eq!(
             workspace_toml.workspace.members,
             vec![

--- a/lux-workspace-hack/Cargo.toml
+++ b/lux-workspace-hack/Cargo.toml
@@ -45,6 +45,7 @@ lazy_static = { version = "1", default-features = false, features = ["spin_no_st
 lock_api = { version = "0.4", features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
+miette = { version = "7", features = ["fancy"] }
 miniz_oxide = { version = "0.8", features = ["simd"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
@@ -60,6 +61,7 @@ simd-adler32 = { version = "0.3" }
 slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 subtle = { version = "2", default-features = false, features = ["i128"] }
+textwrap = { version = "0.16", default-features = false, features = ["unicode-linebreak", "unicode-width"] }
 time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
@@ -69,7 +71,6 @@ toml_edit = { version = "0.22", features = ["serde"] }
 toml_parser = { version = "1" }
 toml_writer = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }
-tracing-core = { version = "0.1" }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }
 url = { version = "2", features = ["serde"] }
 winnow-ca01ad9e24f5d932 = { package = "winnow", version = "0.7" }
@@ -106,6 +107,7 @@ lazy_static = { version = "1", default-features = false, features = ["spin_no_st
 lock_api = { version = "0.4", features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
+miette = { version = "7", features = ["fancy"] }
 miniz_oxide = { version = "0.8", features = ["simd"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
@@ -122,6 +124,7 @@ slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 subtle = { version = "2", default-features = false, features = ["i128"] }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+textwrap = { version = "0.16", default-features = false, features = ["unicode-linebreak", "unicode-width"] }
 time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
@@ -131,7 +134,6 @@ toml_edit = { version = "0.22", features = ["serde"] }
 toml_parser = { version = "1" }
 toml_writer = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }
-tracing-core = { version = "0.1" }
 typenum = { version = "1", default-features = false, features = ["const-generics"] }
 url = { version = "2", features = ["serde"] }
 winnow-ca01ad9e24f5d932 = { package = "winnow", version = "0.7" }


### PR DESCRIPTION
Draft, wouldn't bother reviewing yet.

This PR hotswaps the codebase with `miette`, a library for beautified error messages. Lux's biggest weakness right now is error messages that can be hard to understand or conceptualize. The goal of this PR is twofold:
- [x] Mark every `thiserror` struct with `Diagnostic` for miette support
- [ ] Improve error messages throughout the entire project (this one will take a bit)

Uncertain TODOs:
- Write tests for error cases, to ensure rendering looks as expected?
