### PR TITLE
fix(lint)!: resolve CLI argument parsing regression in lx lint

### DIFF
--- a/lux-cli/src/lint.rs
+++ b/lux-cli/src/lint.rs
@@ -12,6 +12,7 @@ use crate::workspace::top_level_ignored_files;
 #[derive(Args)]
 pub struct Lint {
     /// Path to a workspace, directory, or Lua file to lint. Defaults to the current workspace.
+    #[arg(short, long)]
     path: Option<PathBuf>,
     /// Arguments to pass to the luacheck command.{n}
     /// If you pass arguments to luacheck, Lux will not pass any default arguments.


### PR DESCRIPTION
Small fix that changes positional path arg to option/flag regression introduced in #1656 

Close #1666

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
