### PR TITLE
fix: prevent miette from intercepting help output

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -37,13 +37,20 @@ async fn main() -> Result<()> {
     }))?;
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
-        Err(err) => match clap_to_miette(err) {
-            Ok(report) => return Err(report),
-            Err(text) => {
-                print!("{text}");
-                return Err(miette::miette!("not enough arguments supplied"));
+        Err(err) => {
+            if !err.use_stderr() {
+                let _ = err.print();
+                return Ok(());
             }
-        },
+
+            match clap_to_miette(err) {
+                Ok(report) => return Err(report),
+                Err(text) => {
+                    print!("{text}");
+                    return Err(miette::miette!("not enough arguments supplied"));
+                }
+            }
+        }
     };
 
     let lua_version = cli.lua_version.or({


### PR DESCRIPTION
Fixes a minor bug where using `--help` printed the expected output but also appended a `miette` "not enough arguments" error.

Before:
```
$ cargo lx info --help

Show metadata for any rock

Usage: lx info <PACKAGE>

Arguments:
  <PACKAGE>

Options:
  -h, --help  Print help
Error:   × not enough arguments supplied // caught as error
```


After:
```
$ cargo lx info --help

Show metadata for any rock

Usage: lx info <PACKAGE>

Arguments:
  <PACKAGE>

Options:
  -h, --help  Print help
```

Still return this when no argument were passed:
```
$ cargo lx info

Error:   × missing required argument `<PACKAGE>`
```

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
