### PR TITLE
feat: allow dispatching logging to lua

### DIFF
--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -509,10 +509,16 @@ async fn link_c_artifacts(
     };
     if config.verbose() {
         if !&output.stdout.is_empty() {
-            println!("{}", String::from_utf8_lossy(&output.stdout));
+            crate::logging::info(
+                String::from_utf8_lossy(&output.stdout).to_string(),
+                Some("build".to_string()),
+            );
         }
         if !&output.stderr.is_empty() {
-            eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+            crate::logging::warn(
+                String::from_utf8_lossy(&output.stderr).to_string(),
+                Some("build".to_string()),
+            );
         }
     }
 
@@ -603,10 +609,16 @@ pub(crate) async fn install_binary(
 pub(crate) fn log_command_output(output: &Output, config: &Config) {
     if config.verbose() {
         if !output.stderr.is_empty() {
-            println!("{}", String::from_utf8_lossy(&output.stderr));
+            crate::logging::info(
+                String::from_utf8_lossy(&output.stderr).to_string(),
+                Some("build".to_string()),
+            );
         }
         if !output.stdout.is_empty() {
-            println!("{}", String::from_utf8_lossy(&output.stdout));
+            crate::logging::info(
+                String::from_utf8_lossy(&output.stdout).to_string(),
+                Some("build".to_string()),
+            );
         }
     }
 }

--- a/lux-lib/src/lib.rs
+++ b/lux-lib/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod git;
 pub mod hash;
 pub mod lockfile;
+pub mod logging;
 pub mod lua;
 pub mod lua_installation;
 pub mod lua_rockspec;

--- a/lux-lib/src/logging.rs
+++ b/lux-lib/src/logging.rs
@@ -1,0 +1,156 @@
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use lazy_static::lazy_static;
+use serde::Serialize;
+
+const MAX_BACKLOG: usize = 200;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LogEntry {
+    pub level: LogLevel,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggingState {
+    Disabled,
+    Enabled,
+}
+
+lazy_static! {
+    static ref LOG_BUFFER: Mutex<VecDeque<LogEntry>> = Mutex::new(VecDeque::new());
+    static ref LOG_STATE: Mutex<LoggingState> = Mutex::new(LoggingState::Disabled);
+}
+
+#[allow(clippy::expect_used)]
+pub fn set_state(state: LoggingState) {
+    *LOG_STATE.lock().expect("log lock poisoned") = state;
+}
+
+#[allow(clippy::expect_used)]
+pub fn state() -> LoggingState {
+    *LOG_STATE.lock().expect("log lock poisoned")
+}
+
+#[allow(clippy::expect_used)]
+pub fn info(message: String, target: Option<String>) {
+    match state() {
+        LoggingState::Enabled => push(LogLevel::Info, message, target),
+        LoggingState::Disabled => println!("{}", message),
+    }
+}
+
+pub fn warn(message: String, target: Option<String>) {
+    match state() {
+        LoggingState::Enabled => push(LogLevel::Warn, message, target),
+        LoggingState::Disabled => eprintln!("{}", message),
+    }
+}
+
+#[allow(clippy::expect_used)]
+pub fn error(message: String, target: Option<String>) {
+    match state() {
+        LoggingState::Enabled => push(LogLevel::Error, message, target),
+        LoggingState::Disabled => eprintln!("{}", message),
+    }
+}
+
+#[allow(clippy::expect_used)]
+pub fn push(level: LogLevel, message: String, target: Option<String>) {
+    if let LoggingState::Disabled = state() {
+        return;
+    }
+
+    let entry = LogEntry {
+        level,
+        message,
+        target,
+    };
+
+    let mut buffer = LOG_BUFFER.lock().expect("log lock poisoned");
+
+    buffer.push_back(entry);
+
+    if buffer.len() > MAX_BACKLOG {
+        buffer.pop_front();
+    }
+}
+
+#[allow(clippy::expect_used)]
+pub fn drain() -> Vec<LogEntry> {
+    if let LoggingState::Disabled = state() {
+        return Vec::new();
+    }
+
+    let mut buffer = LOG_BUFFER.lock().expect("log lock poisoned");
+    buffer.drain(..).collect()
+}
+
+#[allow(clippy::expect_used)]
+pub fn clear() {
+    let mut buffer = LOG_BUFFER.lock().expect("log lock poisoned");
+
+    buffer.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+
+    fn reset() {
+        set_state(LoggingState::Disabled);
+        clear();
+    }
+
+    #[test]
+    #[serial]
+    fn test_push_and_drain() {
+        reset();
+        set_state(LoggingState::Enabled);
+        push(LogLevel::Info, "info".to_string(), None);
+        push(
+            LogLevel::Warn,
+            "warning".to_string(),
+            Some("build".to_string()),
+        );
+        push(
+            LogLevel::Error,
+            "error".to_string(),
+            Some("fetch".to_string()),
+        );
+
+        let entries = drain();
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(entries[0].level, LogLevel::Info));
+        assert_eq!(entries[0].message, "info");
+        assert!(entries[0].target.is_none());
+        assert!(matches!(entries[1].level, LogLevel::Warn));
+        assert_eq!(entries[1].message, "warning");
+        assert_eq!(entries[1].target.as_deref(), Some("build"));
+        assert!(matches!(entries[2].level, LogLevel::Error));
+
+        assert!(drain().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_push_noop_when_disabled() {
+        reset();
+        set_state(LoggingState::Disabled);
+        push(LogLevel::Info, "should not appear".to_string(), None);
+        assert!(drain().is_empty());
+    }
+}

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -126,11 +126,9 @@ async fn exec(run: Exec<'_>) -> Result<(), ExecError> {
     let lua_init = if run.disable_loader.unwrap_or(false) {
         None
     } else if user_tree.version().lux_lib_dir().is_none() {
-        eprintln!(
-            "⚠️ WARNING: lux-lua library not found.
-    Cannot use the `lux.loader`.
-    To suppress this warning, set the `--no-loader` option.
-                    "
+        crate::logging::warn(
+            "⚠️ WARNING: lux-lua library not found.\n    Cannot use the `lux.loader`.\n    To suppress this warning, set the `--no-loader` option.".to_string(),
+            Some("exec".to_string()),
         );
         None
     } else {

--- a/lux-lib/src/operations/run.rs
+++ b/lux-lib/src/operations/run.rs
@@ -160,11 +160,9 @@ async fn run_with_command(
     let lua_init = if disable_loader {
         None
     } else if tree.version().lux_lib_dir().is_none() {
-        eprintln!(
-            "⚠️ WARNING: lux-lua library not found.
-    Cannot use the `lux.loader`.
-    To suppress this warning, set the `--no-loader` option.
-                    "
+        crate::logging::warn(
+            "⚠️ WARNING: lux-lua library not found.\n    Cannot use the `lux.loader`.\n    To suppress this warning, set the `--no-loader` option.".to_string(),
+            Some("run".to_string()),
         );
         None
     } else {

--- a/lux-lib/src/operations/run_lua.rs
+++ b/lux-lib/src/operations/run_lua.rs
@@ -94,11 +94,9 @@ where
         let loader_init = if args.disable_loader.unwrap_or(false) {
             "".to_string()
         } else if !is_lux_lua_available && args.tree.version().lux_lib_dir().is_none() {
-            eprintln!(
-                "⚠️ WARNING: lux-lua library not found.
-Cannot use the `lux.loader`.
-To suppress this warning, set the `--no-loader` option.
-                "
+            crate::logging::warn(
+                "⚠️ WARNING: lux-lua library not found.\nCannot use the `lux.loader`.\nTo suppress this warning, set the `--no-loader` option.".to_string(),
+                Some("run_lua".to_string()),
             );
             "".to_string()
         } else {

--- a/lux-lib/src/progress.rs
+++ b/lux-lib/src/progress.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc, time::Duration};
 
-use crate::config::Config;
+use crate::{config::Config, logging::LoggingState};
 
 mod private {
     pub trait HasProgress {}
@@ -84,7 +84,11 @@ impl ProgressBar {
     pub fn new() -> Self {
         let bar =
             indicatif::ProgressBar::new_spinner().with_finish(indicatif::ProgressFinish::AndClear);
-        bar.enable_steady_tick(Duration::from_millis(100));
+
+        if let LoggingState::Disabled = crate::logging::state() {
+            // NOTE: this spawns a background thread which causes rendering (we don't want that)
+            bar.enable_steady_tick(Duration::from_millis(100));
+        }
 
         Self(bar)
     }
@@ -97,7 +101,19 @@ impl ProgressBar {
     where
         M: Into<Cow<'static, str>>,
     {
-        self.0.set_message(message)
+        let msg: Cow<'static, str> = message.into();
+        match crate::logging::state() {
+            crate::logging::LoggingState::Enabled => {
+                crate::logging::push(
+                    crate::logging::LogLevel::Info,
+                    msg.clone().into_owned(),
+                    Some("progress".to_string()),
+                );
+            }
+            crate::logging::LoggingState::Disabled => {
+                self.0.set_message(msg);
+            }
+        }
     }
 
     pub fn set_position(&self, position: u64) {
@@ -112,14 +128,37 @@ impl ProgressBar {
     where
         M: AsRef<str>,
     {
-        self.0.println(message)
+        match crate::logging::state() {
+            crate::logging::LoggingState::Enabled => {
+                crate::logging::push(
+                    crate::logging::LogLevel::Info,
+                    message.as_ref().to_string(),
+                    Some("progress".to_string()),
+                );
+            }
+            crate::logging::LoggingState::Disabled => {
+                self.0.println(message.as_ref());
+            }
+        }
     }
 
     pub fn finish_with_message<M>(&self, message: M)
     where
         M: Into<Cow<'static, str>>,
     {
-        self.0.finish_with_message(message)
+        let msg: Cow<'static, str> = message.into();
+        match crate::logging::state() {
+            crate::logging::LoggingState::Enabled => {
+                crate::logging::push(
+                    crate::logging::LogLevel::Info,
+                    msg.clone().into_owned(),
+                    Some("progress".to_string()),
+                );
+            }
+            crate::logging::LoggingState::Disabled => {
+                self.0.finish_with_message(msg);
+            }
+        }
     }
 
     pub fn finish_and_clear(&self) {

--- a/lux-lua/src/lib.rs
+++ b/lux-lua/src/lib.rs
@@ -8,6 +8,7 @@ mod config;
 #[cfg(feature = "definitions")]
 pub mod definitions;
 mod loader;
+mod logging;
 pub mod lua_impls;
 mod operations;
 mod project;
@@ -32,6 +33,7 @@ impl TypedUserData for LuxModule {
         fields.add_field("workspace", workspace::WorkspaceModule);
         fields.add_field("project", project::ProjectModule);
         fields.add_field("operations", operations::OperationsModule);
+        fields.add_field("logging", logging::LoggingModule);
     }
 }
 

--- a/lux-lua/src/logging.rs
+++ b/lux-lua/src/logging.rs
@@ -1,0 +1,75 @@
+use mlua::prelude::*;
+use mlua_extras::typed::{Type, Typed, TypedDataMethods, TypedUserData, WrappedBuilder};
+
+#[derive(Clone)]
+pub(crate) struct LoggingModule;
+
+impl Typed for LoggingModule {
+    fn ty() -> Type {
+        Type::named("LoggingModule")
+    }
+}
+
+impl TypedUserData for LoggingModule {
+    fn add_methods<M: TypedDataMethods<Self>>(methods: &mut M) {
+        methods.document("Toggle logging capture");
+        methods.param(
+            "enabled",
+            "Whether logging capture should be enabled (default: false)",
+        );
+        methods.add_function("set_enabled", |_, enabled: bool| {
+            let state = if enabled {
+                lux_lib::logging::LoggingState::Enabled
+            } else {
+                lux_lib::logging::LoggingState::Disabled
+            };
+            lux_lib::logging::set_state(state);
+            Ok(())
+        });
+
+        methods.document("Drain all buffered log entries and return them as an array of tables");
+        methods.ret(
+            "Array of log entries, each with 'level', 'message', and optional 'target' fields",
+        );
+        methods.add_function("drain", |lua, ()| {
+            let entries = lux_lib::logging::drain();
+            lua.to_value(&entries).map_err(mlua::Error::external)
+        });
+
+        methods.document("Clear all buffered log entries without returning them");
+        methods.add_function("clear", |_, ()| {
+            lux_lib::logging::clear();
+            Ok(())
+        });
+    }
+
+    fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {
+        docs.add("Module for capturing Lux log output");
+    }
+}
+
+impl mlua::UserData for LoggingModule {
+    fn add_fields<F: mlua::UserDataFields<Self>>(fields: &mut F) {
+        let mut wrapper = WrappedBuilder::new(fields);
+        <Self as TypedUserData>::add_fields(&mut wrapper);
+    }
+
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        let mut wrapper = WrappedBuilder::new(methods);
+        <Self as TypedUserData>::add_methods(&mut wrapper);
+    }
+}
+
+#[cfg(feature = "definitions")]
+mod definitions_registry {
+    use mlua_extras::typed::{Type, TypedClassBuilder};
+
+    use crate::definitions::LuxDefinition;
+
+    inventory::submit! {
+        LuxDefinition {
+            name: "LoggingModule",
+            build: || Type::class(TypedClassBuilder::new::<super::LoggingModule>().build()),
+        }
+    }
+}


### PR DESCRIPTION
In `lux.nvim` we need the ability to silence indicatif spinners and to dispatch the progress messages elsewhere (specifically to a sink on the Lua side which captures the messages and lets us drain them to display them).

This means the progress messages will arrive in chunks, but will arrive fairly frequently due to the high traffic of `await` calls. 