### PR TITLE
refactor!: unify logging

### DIFF
--- a/lux-cli/src/download.rs
+++ b/lux-cli/src/download.rs
@@ -16,10 +16,10 @@ pub async fn download(dl_data: Download, config: Config) -> Result<()> {
         .await?;
 
     bar.map(|b| {
-        b.finish_with_message(format!(
-            "Succesfully downloaded {}@{}",
-            rock.name, rock.version
-        ))
+        b.finish_with_message(
+            format!("Succesfully downloaded {}@{}", rock.name, rock.version),
+            lux_lib::logging::LogLevel::Info,
+        )
     });
 
     Ok(())

--- a/lux-cli/src/fetch.rs
+++ b/lux-cli/src/fetch.rs
@@ -30,14 +30,17 @@ pub async fn fetch_remote(data: UnpackRemote, config: Config) -> Result<()> {
         .unwrap_or_else(|| destination);
 
     bar.map(|b| {
-        b.finish_with_message(format!(
-            "
+        b.finish_with_message(
+            format!(
+                "
 You may now enter the following directory:
 {}
 and type `lux build` to build.
     ",
-            build_dir.as_path().display()
-        ))
+                build_dir.as_path().display()
+            ),
+            lux_lib::logging::LogLevel::Info,
+        )
     });
 
     Ok(())

--- a/lux-cli/src/install_lua.rs
+++ b/lux-cli/src/install_lua.rs
@@ -27,11 +27,14 @@ pub async fn install_lua(config: Config) -> Result<()> {
         .ok_or_else(|| miette!("error getting lua include parent directory"))?;
 
     bar.map(|bar| {
-        bar.finish_with_message(format!(
-            "🌔 Installed Lua ({}) to {}",
-            version_stringified,
-            lua_root.display()
-        ))
+        bar.finish_with_message(
+            format!(
+                "🌔 Installed Lua ({}) to {}",
+                version_stringified,
+                lua_root.display()
+            ),
+            lux_lib::logging::LogLevel::Info,
+        )
     });
 
     Ok(())

--- a/lux-cli/src/unpack.rs
+++ b/lux-cli/src/unpack.rs
@@ -30,13 +30,16 @@ pub async fn unpack(data: Unpack, config: Config) -> Result<()> {
     let unpack_path = lux_lib::operations::unpack_src_rock(src_file, destination, &bar).await?;
 
     bar.map(|b| {
-        b.finish_with_message(format!(
-            "
+        b.finish_with_message(
+            format!(
+                "
 You may now enter the following directory:
 {}
 and type `lux make` to build.",
-            unpack_path.display()
-        ))
+                unpack_path.display()
+            ),
+            lux_lib::logging::LogLevel::Info,
+        )
     });
 
     Ok(())
@@ -57,13 +60,16 @@ pub async fn unpack_remote(data: UnpackRemote, config: Config) -> Result<()> {
     let unpack_path = lux_lib::operations::unpack_src_rock(cursor, destination, &bar).await?;
 
     bar.map(|p| {
-        p.finish_with_message(format!(
-            "
+        p.finish_with_message(
+            format!(
+                "
 You may now enter the following directory:
 {}
 and type `lux make` to build.",
-            unpack_path.display()
-        ))
+                unpack_path.display()
+            ),
+            lux_lib::logging::LogLevel::Info,
+        )
     });
 
     Ok(())

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -165,8 +165,12 @@ async fn cleanup(output_paths: &RockLayout, progress: &Progress<ProgressBar>) ->
     match tokio::fs::remove_dir_all(root_dir).await {
         Ok(_) => (),
         Err(err) => {
-            progress
-                .map(|p| p.println(format!("Error cleaning up {}: {}", root_dir.display(), err)));
+            progress.map(|p| {
+                p.println(
+                    format!("Error cleaning up {}: {}", root_dir.display(), err),
+                    crate::logging::LogLevel::Error,
+                )
+            });
         }
     };
 }

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -489,14 +489,14 @@ async fn do_build_lua_unix(
         Ok(output) if !output.status.success() && build_target != "generic" => {
             progress.map(|p| {
                 p.println(format!(
-                    r#"⚠️ WARNING: Could not build Lua target '{build_target}'. Attempting a 'generic' Lua target build.
+                    r#"Could not build Lua target '{build_target}'. Attempting a 'generic' Lua target build.
 Some functionality may be limited, including dynamic module loading and REPL history.
 
 stderr:
 {}
 "#,
                     String::from_utf8_lossy(&output.stderr)
-                ))
+                ),crate::logging::LogLevel::Warn)
             });
             let fallback_output = Command::new(config.make_cmd())
                 .current_dir(build_dir)

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -81,16 +81,19 @@ where
                         fetch.rockspec.version().clone(),
                     );
                     fetch.progress.map(|p| {
-                        p.println(format!(
-                            "⚠️ WARNING: Failed to fetch source for {}: {}",
-                            &package, err
-                        ))
+                        p.println(
+                            format!("Failed to fetch source for {}: {}", &package, err),
+                            crate::logging::LogLevel::Warn,
+                        )
                     });
                     fetch.progress.map(|p| {
-                        p.println(format!(
-                            "⚠️ Falling back to searching for a .src.rock archive on {}",
-                            fetch.config.server()
-                        ))
+                        p.println(
+                            format!(
+                                "Falling back to searching for a .src.rock archive on {}",
+                                fetch.config.server()
+                            ),
+                            crate::logging::LogLevel::Warn,
+                        )
                     });
                     let metadata =
                         FetchSrcRock::new(&package, fetch.dest_dir, fetch.config, fetch.progress)

--- a/lux-lib/src/progress.rs
+++ b/lux-lib/src/progress.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, sync::Arc, time::Duration};
 
-use crate::{config::Config, logging::LoggingState};
+use crate::{
+    config::Config,
+    logging::{LogLevel, LoggingState},
+};
 
 mod private {
     pub trait HasProgress {}
@@ -84,6 +87,14 @@ impl MultiProgress {
     }
 }
 
+fn get_msg_prefix(level: LogLevel) -> String {
+    match level {
+        LogLevel::Warn => "⚠️ WARNING: ".to_string(),
+        LogLevel::Error => "❌ ERROR: ".to_string(),
+        LogLevel::Info => "".to_string(),
+    }
+}
+
 impl ProgressBar {
     pub fn new() -> Self {
         let bar =
@@ -109,7 +120,7 @@ impl ProgressBar {
         match crate::logging::state() {
             crate::logging::LoggingState::Enabled => {
                 crate::logging::push(
-                    crate::logging::LogLevel::Info,
+                    LogLevel::Info,
                     msg.clone().into_owned(),
                     Some("progress".to_string()),
                 );
@@ -128,25 +139,26 @@ impl ProgressBar {
         self.0.position()
     }
 
-    pub fn println<M>(&self, message: M)
+    pub fn println<M>(&self, message: M, level: LogLevel)
     where
         M: AsRef<str>,
     {
         match crate::logging::state() {
             crate::logging::LoggingState::Enabled => {
                 crate::logging::push(
-                    crate::logging::LogLevel::Info,
+                    level,
                     message.as_ref().to_string(),
                     Some("progress".to_string()),
                 );
             }
             crate::logging::LoggingState::Disabled => {
-                self.0.println(message.as_ref());
+                self.0
+                    .println(format!("{}{}", get_msg_prefix(level), message.as_ref()));
             }
         }
     }
 
-    pub fn finish_with_message<M>(&self, message: M)
+    pub fn finish_with_message<M>(&self, message: M, level: LogLevel)
     where
         M: Into<Cow<'static, str>>,
     {
@@ -154,13 +166,14 @@ impl ProgressBar {
         match crate::logging::state() {
             crate::logging::LoggingState::Enabled => {
                 crate::logging::push(
-                    crate::logging::LogLevel::Info,
+                    level,
                     msg.clone().into_owned(),
                     Some("progress".to_string()),
                 );
             }
             crate::logging::LoggingState::Disabled => {
-                self.0.finish_with_message(msg);
+                self.0
+                    .finish_with_message(format!("{}{}", get_msg_prefix(level), msg));
             }
         }
     }


### PR DESCRIPTION
Ref: https://github.com/lumen-oss/lux/issues/1697


For now I just did put a log level parameter into the progress.println function. Instead of introducing a new `Severity` enum, I used the existing `crate::logging::LogLevel` enum. Therefore just 2./3. is addressed.

Is there a particular reason why we'd want to go through `logging::warn` etc instead of just do as I did?

By reusing the existing enum I think the following is no longer relevant
> Refactor logging:warn(), logging::error() etc to either use the enum Severity or to unify with the progress_bar.println() function.

TODO (separate PR?):
- [ ] Change CLI to no longer use `[e]println!`, tracing instead if I understood correctly, haven't dug into this yet

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
