### PR TITLE
feat(error-reporting)!: config + rockspec diagnostics

### DIFF
--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -111,9 +111,22 @@ impl Config {
     pub fn enabled_dev_servers(&self) -> Result<Vec<Url>, ConfigError> {
         let mut enabled_dev_servers = Vec::new();
         if self.enable_development_packages {
-            enabled_dev_servers.push(self.server().join(DEV_PATH)?);
+            let config_file = ConfigBuilder::config_file()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
+            enabled_dev_servers.push(self.server().join(DEV_PATH).map_err(|source| {
+                ConfigError::UrlParseError {
+                    source,
+                    help: Some(format!("check the `server` URL in {config_file}")),
+                }
+            })?);
             for server in self.extra_servers() {
-                enabled_dev_servers.push(server.join(DEV_PATH)?);
+                enabled_dev_servers.push(server.join(DEV_PATH).map_err(|source| {
+                    ConfigError::UrlParseError {
+                        source,
+                        help: Some(format!("check the `extra_servers` URLs in {config_file}")),
+                    }
+                })?);
             }
         }
         Ok(enabled_dev_servers)
@@ -248,16 +261,28 @@ impl HasVariables for Config {
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum ConfigError {
-    #[error(transparent)]
-    Io(#[from] io::Error),
+    #[error("failed to read config file {config_file}")]
+    ConfigRead {
+        config_file: String,
+        source: io::Error,
+        #[help]
+        help: Option<String>,
+    },
     #[error(transparent)]
     #[diagnostic(transparent)]
     NoValidHomeDirectory(#[from] NoValidHomeDirectory),
-    #[error("error deserializing Lux config")]
-    #[diagnostic(forward(0))]
-    Deserialize(#[from] TomlDeError),
-    #[error("error parsing URL: {0}")]
-    UrlParseError(#[from] url::ParseError),
+    #[error("error parsing {config_file}")]
+    Deserialize {
+        config_file: String,
+        #[diagnostic_source]
+        source: TomlDeError,
+    },
+    #[error("error parsing URL: {source}")]
+    UrlParseError {
+        source: url::ParseError,
+        #[help]
+        help: Option<String>,
+    },
 }
 
 /// Incrementally builds a [`Config`] by layering configuration sources.
@@ -311,11 +336,23 @@ impl ConfigBuilder {
     pub fn new() -> Result<Self, ConfigError> {
         let config_file = Self::config_file()?;
         if config_file.is_file() {
-            let content = std::fs::read_to_string(&config_file)?;
-            Ok(crate::project::parse_toml(
-                config_file.to_string_lossy().as_ref(),
-                &content,
-            )?)
+            let config_file_name = config_file.to_string_lossy().to_string();
+            let content = std::fs::read_to_string(&config_file).map_err(|source| {
+                ConfigError::ConfigRead {
+                    config_file: config_file_name.clone(),
+                    source,
+                    help: Some(format!(
+                        "check that {} exists and is readable",
+                        config_file.display()
+                    )),
+                }
+            })?;
+            crate::project::parse_toml(&config_file_name, &content).map_err(|source| {
+                ConfigError::Deserialize {
+                    config_file: config_file_name,
+                    source,
+                }
+            })
         } else {
             Ok(Self::default())
         }

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -18,7 +18,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use build::*;
 pub use dependency::*;
 pub use deploy::*;
-use miette::Diagnostic;
+use miette::{Diagnostic, NamedSource, SourceSpan};
 pub use partial::*;
 pub use platform::*;
 pub use rock_source::*;
@@ -48,51 +48,75 @@ use crate::{
 #[derive(Error, Debug, Diagnostic)]
 pub enum LuaRockspecError {
     #[error("manifest exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
+    #[diagnostic(
+        code(lux_lib::lua_rockspec::fuel_limit_exceeded),
+        help(
+            r#"the rockspec may be too complex or contain too many dependencies.
+try reducing the number of dependencies or simplifying build instructions.
+"#
+        )
+    )]
     FuelLimitExceeded,
-    #[error(
-        r#"could not parse rockspec ({cause}):
-
-    {content}"#
+    #[error("could not parse rockspec")]
+    #[diagnostic(code(lux_lib::lua_rockspec::execution),
+        help("check the rockspec or lux.toml for valid syntax and make sure it matches the specification."),
+        url("https://lux.lumen-labs.org/reference/lux-toml")
     )]
     ExecutionError {
         #[source]
         cause: ottavino::ExternError,
-        content: String,
+        #[source_code]
+        content: NamedSource<String>,
+        #[label("this package")]
+        span: SourceSpan,
     },
-    #[error(
-        r#"could not find rockspec field '{field}':
-
-    {content}"#
-    )]
-    LuaKeyNotFound { field: String, content: String },
-    #[error(
-        r#"could not deserialize rockspec field '{field}':
-
-    {content}"#
+    #[error("invalid field '{field}'")]
+    #[diagnostic(code(lux_lib::lua_rockspec::key_deserialization),
+        help("check the rockspec or lux.toml for valid syntax and make sure it matches the specification."),
+        url("https://lux.lumen-labs.org/reference/lux-toml")
     )]
     LuaKeyDeserializationFailure {
         field: String,
-        content: String,
         #[source]
-        cause: ottavino_util::serde::de::Error,
+        cause: Box<ottavino_util::serde::de::Error>,
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("here")]
+        span: SourceSpan,
     },
     #[error("{}copy_directories cannot contain the rockspec name", ._0.as_ref().map(|p| format!("{p}: ")).unwrap_or_default())]
     CopyDirectoriesContainRockspecName(Option<String>),
-    #[error(
-        r#"could not parse rockspec ({cause})
-
-    {content}"#
+    #[error("error parsing table (field: '{field}')")]
+    #[diagnostic(code(lux_lib::lua_rockspec::lua_table),
+        help("check the rockspec or lux.toml for valid syntax and make sure it matches the specification."),
+        url("https://lux.lumen-labs.org/reference/lux-toml")
     )]
     LuaTable {
-        content: String,
+        field: String,
+        #[source_code]
+        content: NamedSource<String>,
+        #[label("here")]
+        span: SourceSpan,
         #[source]
-        cause: LuaTableError,
+        cause: Box<LuaTableError>,
     },
     #[error("cannot create Lua rockspec with off-spec dependency: {0}")]
+    #[diagnostic(
+        code(lux_lib::lua_rockspec::off_spec_dependency),
+        url("https://lux.lumen-labs.org/reference/lux-toml#dependencies")
+    )]
     OffSpecDependency(PackageName),
     #[error("cannot create Lua rockspec with off-spec build dependency: {0}")]
+    #[diagnostic(
+        code(lux_lib::lua_rockspec::off_spec_build_dependency),
+        url("https://lux.lumen-labs.org/reference/lux-toml#dependencies")
+    )]
     OffSpecBuildDependency(PackageName),
     #[error("cannot create Lua rockspec with off-spec test dependency: {0}")]
+    #[diagnostic(
+        code(lux_lib::lua_rockspec::off_spec_test_dependency),
+        url("https://lux.lumen-labs.org/reference/lux-toml#dependencies")
+    )]
     OffSpecTestDependency(PackageName),
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -143,9 +167,10 @@ impl<'gc> HasRockspecKey<'gc> for ottavino::Table<'gc> {
     ) -> Result<V, LuaRockspecError> {
         from_value(self.get_value(ctx, key.clone())).map_err(|cause| {
             LuaRockspecError::LuaKeyDeserializationFailure {
-                field: key,
-                content: rockspec_content.to_string(),
-                cause,
+                field: key.clone(),
+                cause: Box::new(cause),
+                src: NamedSource::new("rockspec", rockspec_content.to_string()),
+                span: find_value_span(rockspec_content, &key),
             }
         })
     }
@@ -207,8 +232,9 @@ impl LocalLuaRockspec {
                     value => from_value(value).map_err(|cause| {
                         LuaRockspecError::LuaKeyDeserializationFailure {
                             field: "source".into(),
-                            content: rockspec_content.to_string(),
-                            cause,
+                            cause: Box::new(cause),
+                            src: NamedSource::new("rockspec", rockspec_content.to_string()),
+                            span: find_value_span(rockspec_content, "source"),
                         }
                     })?,
                 };
@@ -223,14 +249,18 @@ impl LocalLuaRockspec {
                     version: globals.get_rockspec_key(ctx, "version".into(), rockspec_content)?,
                     description: parse_lua_tbl_or_default(ctx, "description").map_err(|cause| {
                         LuaRockspecError::LuaTable {
-                            content: rockspec_content.to_string(),
-                            cause,
+                            field: "description".into(),
+                            content: NamedSource::new("rockspec", rockspec_content.to_string()),
+                            span: find_value_span(rockspec_content, "description"),
+                            cause: Box::new(cause),
                         }
                     })?,
                     supported_platforms: parse_lua_tbl_or_default(ctx, "supported_platforms")
                         .map_err(|cause| LuaRockspecError::LuaTable {
-                            content: rockspec_content.to_string(),
-                            cause,
+                            field: "supported_platforms".into(),
+                            content: NamedSource::new("rockspec", rockspec_content.to_string()),
+                            span: find_value_span(rockspec_content, "supported_platforms"),
+                            cause: Box::new(cause),
                         })?,
                     lua: lua_version_req,
                     dependencies: strip_lua(dependencies),
@@ -251,9 +281,14 @@ impl LocalLuaRockspec {
 
                 Ok(Ok(rockspec))
             })
-            .map_err(|cause| LuaRockspecError::ExecutionError {
-                content: rockspec_content.to_string(),
-                cause,
+            .map_err(|cause| {
+                let src = NamedSource::new("rockspec", rockspec_content.to_string());
+                let span = find_value_span(rockspec_content, "package");
+                LuaRockspecError::ExecutionError {
+                    content: src,
+                    span,
+                    cause,
+                }
             })??;
 
         let rockspec_file_name = format!("{}-{}.rockspec", rockspec.package(), rockspec.version());
@@ -399,9 +434,14 @@ impl RemoteLuaRockspec {
                 source,
             }))
         })
-        .map_err(|cause| LuaRockspecError::ExecutionError {
-            content: rockspec_content.to_string(),
-            cause,
+        .map_err(|cause| {
+            let src = NamedSource::new("rockspec", rockspec_content.to_string());
+            let span = find_value_span(rockspec_content, "package");
+            LuaRockspecError::ExecutionError {
+                content: src,
+                span,
+                cause,
+            }
         })?
     }
 
@@ -595,6 +635,41 @@ pub struct RockDescription {
     /// A list of short strings that specify labels for categorization of this rock.
     #[serde(default)]
     pub labels: Vec<String>,
+}
+
+fn find_key_span(rockspec_content: &str, key: &str) -> SourceSpan {
+    rockspec_content
+        .match_indices(key)
+        .find(|&(start, _)| {
+            let end = start + key.len();
+            let prefix_ok =
+                start == 0 || !rockspec_content.as_bytes()[start - 1].is_ascii_alphanumeric();
+            let suffix_ok = rockspec_content
+                .get(end..)
+                .is_some_and(|s| s.starts_with('=') || s.trim_start().starts_with('='));
+            prefix_ok && suffix_ok
+        })
+        .map(|(start, _)| (start..start + key.len()).into())
+        .unwrap_or((0..0).into())
+}
+
+fn find_value_span(rockspec_content: &str, key: &str) -> SourceSpan {
+    let key = find_key_span(rockspec_content, key);
+    if key.is_empty() {
+        return key;
+    }
+    let key_offset = key.offset();
+    let key_end = key_offset + key.len();
+    let eq_start = key_end + rockspec_content[key_end..].find('=').unwrap_or(0);
+    let value_offset = eq_start + 1;
+    let line_end = rockspec_content[value_offset..]
+        .find('\n')
+        .map(|i| value_offset + i)
+        .unwrap_or(rockspec_content.len());
+    let trimmed = &rockspec_content[value_offset..line_end];
+    let start = value_offset + (trimmed.len() - trimmed.trim_start().len());
+    let end = line_end - (trimmed.len() - trimmed.trim_end().len());
+    (start..end).into()
 }
 
 fn deserialize_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
@@ -1814,5 +1889,50 @@ external_dependencies = {
             .external_dependencies()
             .get(&PlatformIdentifier::Windows);
         assert!(windows_external_deps.get("OPENSSL").is_some());
+    }
+
+    #[test]
+    pub fn find_value_span_spaces() {
+        let source = "package = 'foo'\nversion = '1.0'";
+        let span = find_value_span(source, "package");
+        assert_eq!(&source[span.offset()..span.offset() + span.len()], "'foo'");
+    }
+
+    #[test]
+    pub fn find_value_span_no_spaces() {
+        let source = "package='foo'";
+        let span = find_value_span(source, "package");
+        assert_eq!(&source[span.offset()..span.offset() + span.len()], "'foo'");
+    }
+
+    #[test]
+    pub fn find_value_span_returns_empty_when_not_found() {
+        let source = "version = '1.0'";
+        let span = find_value_span(source, "package");
+        assert_eq!(span.len(), 0);
+    }
+
+    #[test]
+    pub fn find_value_span_skips_url_containing_field() {
+        let source = "homepage = 'https://luapackager.com'\npackage = 'foo'";
+        let span = find_value_span(source, "package");
+        assert_eq!(&source[span.offset()..span.offset() + span.len()], "'foo'");
+    }
+
+    #[test]
+    pub fn find_value_span_double_quoted() {
+        let source = r#"package = "foo""#;
+        let span = find_value_span(source, "package");
+        assert_eq!(
+            &source[span.offset()..span.offset() + span.len()],
+            r#""foo""#
+        );
+    }
+
+    #[test]
+    pub fn find_value_span_table() {
+        let source = "description = {\n    summary = 'bar'\n}";
+        let span = find_value_span(source, "description");
+        assert_eq!(&source[span.offset()..span.offset() + span.len()], "{");
     }
 }

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -64,7 +64,7 @@ try reducing the number of dependencies or simplifying build instructions.
     )]
     ExecutionError {
         #[source]
-        cause: ottavino::ExternError,
+        cause: Box<ottavino::ExternError>,
         #[source_code]
         content: NamedSource<String>,
         #[label("this package")]
@@ -287,7 +287,7 @@ impl LocalLuaRockspec {
                 LuaRockspecError::ExecutionError {
                     content: src,
                     span,
-                    cause,
+                    cause: Box::new(cause),
                 }
             })??;
 
@@ -414,35 +414,40 @@ impl RemoteLuaRockspec {
     pub fn new(rockspec_content: &str) -> Result<Self, LuaRockspecError> {
         let mut lua = ottavino::Lua::core();
 
-        lua.try_enter(|ctx| {
-            let closure = Closure::load(ctx, None, rockspec_content.as_bytes())?;
+        let source = lua
+            .try_enter(|ctx| {
+                let closure = Closure::load(ctx, None, rockspec_content.as_bytes())?;
 
-            let executor = Executor::start(ctx, closure.into(), ());
+                let executor = Executor::start(ctx, closure.into(), ());
 
-            let output = executor.step(ctx, &mut Fuel::with(ROCKSPEC_FUEL_LIMIT))?;
+                let output = executor.step(ctx, &mut Fuel::with(ROCKSPEC_FUEL_LIMIT))?;
 
-            if !output {
-                return Ok(Err(LuaRockspecError::FuelLimitExceeded));
-            }
+                if !output {
+                    return Ok(Err(LuaRockspecError::FuelLimitExceeded));
+                }
 
-            let globals = ctx.globals();
+                let globals = ctx.globals();
 
-            let source = globals.get_rockspec_key(ctx, "source".into(), rockspec_content)?;
+                let source: PerPlatform<RemoteRockSource> =
+                    globals.get_rockspec_key(ctx, "source".into(), rockspec_content)?;
 
-            Ok(Ok(RemoteLuaRockspec {
-                local: LocalLuaRockspec::new(rockspec_content, ProjectRoot::new())?,
-                source,
-            }))
+                Ok(Ok(source))
+            })
+            .map_err(|cause| {
+                let src = NamedSource::new("rockspec", rockspec_content.to_string());
+                let span = find_value_span(rockspec_content, "package");
+                LuaRockspecError::ExecutionError {
+                    content: src,
+                    span,
+                    cause: Box::new(cause),
+                }
+            })??;
+
+        Ok(RemoteLuaRockspec {
+            // NOTE: Calling this outside of `lua.try_enter` reduces error message repetition
+            local: LocalLuaRockspec::new(rockspec_content, ProjectRoot::new())?,
+            source,
         })
-        .map_err(|cause| {
-            let src = NamedSource::new("rockspec", rockspec_content.to_string());
-            let span = find_value_span(rockspec_content, "package");
-            LuaRockspecError::ExecutionError {
-                content: src,
-                span,
-                cause,
-            }
-        })?
     }
 
     pub fn from_package_and_source_spec(

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -63,43 +63,16 @@ try reducing the number of dependencies or simplifying build instructions.
         url("https://lux.lumen-labs.org/reference/lux-toml")
     )]
     ExecutionError {
-        #[source]
-        cause: Box<ottavino::ExternError>,
+        cause: Box<String>,
         #[source_code]
         content: NamedSource<String>,
         #[label("this package")]
-        span: SourceSpan,
-    },
-    #[error("invalid field '{field}'")]
-    #[diagnostic(code(lux_lib::lua_rockspec::key_deserialization),
-        help("check the rockspec or lux.toml for valid syntax and make sure it matches the specification."),
-        url("https://lux.lumen-labs.org/reference/lux-toml")
-    )]
-    LuaKeyDeserializationFailure {
-        field: String,
-        #[source]
-        cause: Box<ottavino_util::serde::de::Error>,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("here")]
-        span: SourceSpan,
+        pkg_span: SourceSpan,
+        #[label("{cause}")]
+        err_span: Option<SourceSpan>,
     },
     #[error("{}copy_directories cannot contain the rockspec name", ._0.as_ref().map(|p| format!("{p}: ")).unwrap_or_default())]
     CopyDirectoriesContainRockspecName(Option<String>),
-    #[error("error parsing table (field: '{field}')")]
-    #[diagnostic(code(lux_lib::lua_rockspec::lua_table),
-        help("check the rockspec or lux.toml for valid syntax and make sure it matches the specification."),
-        url("https://lux.lumen-labs.org/reference/lux-toml")
-    )]
-    LuaTable {
-        field: String,
-        #[source_code]
-        content: NamedSource<String>,
-        #[label("here")]
-        span: SourceSpan,
-        #[source]
-        cause: Box<LuaTableError>,
-    },
     #[error("cannot create Lua rockspec with off-spec dependency: {0}")]
     #[diagnostic(
         code(lux_lib::lua_rockspec::off_spec_dependency),
@@ -121,6 +94,55 @@ try reducing the number of dependencies or simplifying build instructions.
     #[error(transparent)]
     #[diagnostic(transparent)]
     ProjectToml(#[from] ProjectTomlError),
+}
+
+impl LuaRockspecError {
+    fn from_ottavino(cause: ottavino::ExternError, rockspec_content: &str) -> Self {
+        let msg = match &cause {
+            ottavino::ExternError::Runtime(rt) => rt.to_string(),
+            _ => cause.to_string(),
+        };
+        let field = msg
+            .strip_prefix("invalid rockspec field '")
+            .and_then(|rest| rest.split('\'').next())
+            .map(|f| f.to_owned());
+        let err_span = field.as_deref().and_then(|field| {
+            let span = find_key_span(rockspec_content, field);
+            if span.is_empty() {
+                None
+            } else {
+                Some(span)
+            }
+        });
+        LuaRockspecError::ExecutionError {
+            cause: Box::new(msg),
+            content: NamedSource::new("rockspec", rockspec_content.to_string()),
+            pkg_span: find_value_span(rockspec_content, "package"),
+            err_span,
+        }
+    }
+}
+
+/// This error can be returned within `ottavino::Lua::try_enter`.
+/// ottavino wraps it in an [`ottavino::ExternError`], which Lux wraps inn
+/// a [`LuaRockspecError::ExecutionError`]
+#[derive(Error, Debug, Diagnostic)]
+enum ParseLuaRockspecFieldError {
+    #[error("invalid rockspec field '{field}': {source}")]
+    Deserialize {
+        field: String,
+        source: Box<ottavino_util::serde::de::Error>,
+    },
+    #[error(
+        r#"invalid rockspec field '{field}'.
+Failed to parse a table field: {source}"#
+    )]
+    DeserializeTable {
+        field: String,
+        source: Box<ottavino_util::serde::de::Error>,
+    },
+    #[error("invalid rockspec field '{field}'. expected a table, but got: {invalid_type}")]
+    NotATable { field: String, invalid_type: String },
 }
 
 /// RockSpec for a local rock installation, deserialized from a `.rockspec` file
@@ -153,24 +175,29 @@ trait HasRockspecKey<'gc> {
     fn get_rockspec_key<V: Deserialize<'gc>>(
         &self,
         ctx: ottavino::Context<'gc>,
-        key: String,
-        rockspec_content: &str,
-    ) -> Result<V, LuaRockspecError>;
+        key: &str,
+    ) -> Result<V, ParseLuaRockspecFieldError>;
 }
 
 impl<'gc> HasRockspecKey<'gc> for ottavino::Table<'gc> {
     fn get_rockspec_key<V: Deserialize<'gc>>(
         &self,
         ctx: ottavino::Context<'gc>,
-        key: String,
-        rockspec_content: &str,
-    ) -> Result<V, LuaRockspecError> {
-        from_value(self.get_value(ctx, key.clone())).map_err(|cause| {
-            LuaRockspecError::LuaKeyDeserializationFailure {
-                field: key.clone(),
-                cause: Box::new(cause),
-                src: NamedSource::new("rockspec", rockspec_content.to_string()),
-                span: find_value_span(rockspec_content, &key),
+        key: &str,
+    ) -> Result<V, ParseLuaRockspecFieldError> {
+        let value = self.get_value(ctx, key.to_string());
+        let is_table = matches!(&value, ottavino::Value::Table(_));
+        from_value(value).map_err(|source| {
+            if is_table {
+                ParseLuaRockspecFieldError::DeserializeTable {
+                    field: key.into(),
+                    source: Box::new(source),
+                }
+            } else {
+                ParseLuaRockspecFieldError::Deserialize {
+                    field: key.into(),
+                    source: Box::new(source),
+                }
             }
         })
     }
@@ -198,7 +225,7 @@ impl LocalLuaRockspec {
                 let globals = ctx.globals();
 
                 let dependencies: PerPlatform<Vec<LuaDependencySpec>> =
-                    globals.get_rockspec_key(ctx, "dependencies".into(), rockspec_content)?;
+                    globals.get_rockspec_key(ctx, "dependencies")?;
 
                 let lua_version_req = dependencies
                     .current_platform()
@@ -220,60 +247,38 @@ impl LocalLuaRockspec {
                 }
 
                 let build_dependencies: PerPlatform<Vec<LuaDependencySpec>> =
-                    globals.get_rockspec_key(ctx, "build_dependencies".into(), rockspec_content)?;
+                    globals.get_rockspec_key(ctx, "build_dependencies")?;
 
                 let test_dependencies: PerPlatform<Vec<LuaDependencySpec>> =
-                    globals.get_rockspec_key(ctx, "test_dependencies".into(), rockspec_content)?;
+                    globals.get_rockspec_key(ctx, "test_dependencies")?;
 
                 let source: PerPlatform<RemoteRockSource> = match globals.get_value(ctx, "source") {
                     ottavino::Value::Nil => {
                         PerPlatform::new(RockSourceSpec::File(project_root.to_path_buf()).into())
                     }
-                    value => from_value(value).map_err(|cause| {
-                        LuaRockspecError::LuaKeyDeserializationFailure {
+                    value => from_value(value).map_err(|source| {
+                        ParseLuaRockspecFieldError::Deserialize {
                             field: "source".into(),
-                            cause: Box::new(cause),
-                            src: NamedSource::new("rockspec", rockspec_content.to_string()),
-                            span: find_value_span(rockspec_content, "source"),
+                            source: Box::new(source),
                         }
                     })?,
                 };
 
                 let rockspec = LocalLuaRockspec {
-                    rockspec_format: globals.get_rockspec_key(
-                        ctx,
-                        "rockspec_format".into(),
-                        rockspec_content,
-                    )?,
-                    package: globals.get_rockspec_key(ctx, "package".into(), rockspec_content)?,
-                    version: globals.get_rockspec_key(ctx, "version".into(), rockspec_content)?,
-                    description: parse_lua_tbl_or_default(ctx, "description").map_err(|cause| {
-                        LuaRockspecError::LuaTable {
-                            field: "description".into(),
-                            content: NamedSource::new("rockspec", rockspec_content.to_string()),
-                            span: find_value_span(rockspec_content, "description"),
-                            cause: Box::new(cause),
-                        }
-                    })?,
-                    supported_platforms: parse_lua_tbl_or_default(ctx, "supported_platforms")
-                        .map_err(|cause| LuaRockspecError::LuaTable {
-                            field: "supported_platforms".into(),
-                            content: NamedSource::new("rockspec", rockspec_content.to_string()),
-                            span: find_value_span(rockspec_content, "supported_platforms"),
-                            cause: Box::new(cause),
-                        })?,
+                    rockspec_format: globals.get_rockspec_key(ctx, "rockspec_format")?,
+                    package: globals.get_rockspec_key(ctx, "package")?,
+                    version: globals.get_rockspec_key(ctx, "version")?,
+                    description: parse_lua_tbl_or_default(ctx, "description")?,
+                    supported_platforms: parse_lua_tbl_or_default(ctx, "supported_platforms")?,
                     lua: lua_version_req,
                     dependencies: strip_lua(dependencies),
                     build_dependencies: strip_lua(build_dependencies),
                     test_dependencies: strip_lua(test_dependencies),
-                    external_dependencies: globals.get_rockspec_key(
-                        ctx,
-                        "external_dependencies".into(),
-                        rockspec_content,
-                    )?,
-                    build: globals.get_rockspec_key(ctx, "build".into(), rockspec_content)?,
-                    test: globals.get_rockspec_key(ctx, "test".into(), rockspec_content)?,
-                    deploy: globals.get_rockspec_key(ctx, "deploy".into(), rockspec_content)?,
+                    external_dependencies: globals
+                        .get_rockspec_key(ctx, "external_dependencies")?,
+                    build: globals.get_rockspec_key(ctx, "build")?,
+                    test: globals.get_rockspec_key(ctx, "test")?,
+                    deploy: globals.get_rockspec_key(ctx, "deploy")?,
                     raw_content: rockspec_content.into(),
 
                     source,
@@ -281,15 +286,7 @@ impl LocalLuaRockspec {
 
                 Ok(Ok(rockspec))
             })
-            .map_err(|cause| {
-                let src = NamedSource::new("rockspec", rockspec_content.to_string());
-                let span = find_value_span(rockspec_content, "package");
-                LuaRockspecError::ExecutionError {
-                    content: src,
-                    span,
-                    cause: Box::new(cause),
-                }
-            })??;
+            .map_err(|cause| LuaRockspecError::from_ottavino(cause, rockspec_content))??;
 
         let rockspec_file_name = format!("{}-{}.rockspec", rockspec.package(), rockspec.version());
 
@@ -429,19 +426,11 @@ impl RemoteLuaRockspec {
                 let globals = ctx.globals();
 
                 let source: PerPlatform<RemoteRockSource> =
-                    globals.get_rockspec_key(ctx, "source".into(), rockspec_content)?;
+                    globals.get_rockspec_key(ctx, "source")?;
 
                 Ok(Ok(source))
             })
-            .map_err(|cause| {
-                let src = NamedSource::new("rockspec", rockspec_content.to_string());
-                let span = find_value_span(rockspec_content, "package");
-                LuaRockspecError::ExecutionError {
-                    content: src,
-                    span,
-                    cause: Box::new(cause),
-                }
-            })??;
+            .map_err(|cause| LuaRockspecError::from_ottavino(cause, rockspec_content))??;
 
         Ok(RemoteLuaRockspec {
             // NOTE: Calling this outside of `lua.try_enter` reduces error message repetition
@@ -724,30 +713,24 @@ impl Display for RockspecFormat {
     }
 }
 
-#[derive(Error, Debug, Diagnostic)]
-pub enum LuaTableError {
-    #[error("could not parse '{variable}'. Expected list, but got {invalid_type}")]
-    ParseError {
-        variable: String,
-        invalid_type: String,
-    },
-    #[error(transparent)]
-    DeserializationError(#[from] ottavino_util::serde::de::Error),
-}
-
 fn parse_lua_tbl_or_default<T>(
     ctx: ottavino::Context<'_>,
-    lua_var_name: &str,
-) -> Result<T, LuaTableError>
+    field: &str,
+) -> Result<T, ParseLuaRockspecFieldError>
 where
     T: Default,
     T: DeserializeOwned,
 {
-    let ret = match ctx.globals().get_value(ctx, lua_var_name.to_string()) {
+    let ret = match ctx.globals().get_value(ctx, field.to_string()) {
         ottavino::Value::Nil => T::default(),
-        value @ ottavino::Value::Table(_) => from_value(value)?,
-        value => Err(LuaTableError::ParseError {
-            variable: lua_var_name.to_string(),
+        value @ ottavino::Value::Table(_) => {
+            from_value(value).map_err(|source| ParseLuaRockspecFieldError::DeserializeTable {
+                field: field.to_string(),
+                source: Box::new(source),
+            })?
+        }
+        value => Err(ParseLuaRockspecFieldError::NotATable {
+            field: field.to_string(),
             invalid_type: value.type_name().to_string(),
         })?,
     };
@@ -1939,5 +1922,86 @@ external_dependencies = {
         let source = "description = {\n    summary = 'bar'\n}";
         let span = find_value_span(source, "description");
         assert_eq!(&source[span.offset()..span.offset() + span.len()], "{");
+    }
+
+    #[test]
+    pub fn parse_lua_rockspec_field_error() {
+        let rockspec_content = "package = 'my-lua-lib'\nfoo = 123";
+        let extern_err = ottavino::Lua::core()
+            .try_enter(|_ctx| {
+                Err(ParseLuaRockspecFieldError::Deserialize {
+                    field: "foo".into(),
+                    source: Box::new(ottavino_util::serde::de::Error::Message(
+                        "expected bar".into(),
+                    )),
+                })?;
+                Ok(())
+            })
+            .unwrap_err();
+        let err = LuaRockspecError::from_ottavino(extern_err, rockspec_content);
+        match err {
+            LuaRockspecError::ExecutionError {
+                cause,
+                err_span: Some(span),
+                ..
+            } => {
+                assert!(cause.contains("invalid rockspec field 'foo'"));
+                assert_eq!(
+                    &rockspec_content[span.offset()..span.offset() + span.len()],
+                    "foo"
+                );
+            }
+            other => panic!("expected ExecutionError with err_span, got: {other:?}"),
+        }
+        let extern_err = ottavino::Lua::core()
+            .try_enter(|_ctx| {
+                Err(ParseLuaRockspecFieldError::DeserializeTable {
+                    field: "foo".into(),
+                    source: Box::new(ottavino_util::serde::de::Error::Message(
+                        "expected bar".into(),
+                    )),
+                })?;
+                Ok(())
+            })
+            .unwrap_err();
+        let err = LuaRockspecError::from_ottavino(extern_err, rockspec_content);
+        match err {
+            LuaRockspecError::ExecutionError {
+                cause,
+                err_span: Some(span),
+                ..
+            } => {
+                assert!(cause.contains("invalid rockspec field 'foo'"));
+                assert_eq!(
+                    &rockspec_content[span.offset()..span.offset() + span.len()],
+                    "foo"
+                );
+            }
+            other => panic!("expected ExecutionError with err_span, got: {other:?}"),
+        }
+        let extern_err = ottavino::Lua::core()
+            .try_enter(|_ctx| {
+                Err(ParseLuaRockspecFieldError::NotATable {
+                    field: "foo".into(),
+                    invalid_type: "integer".into(),
+                })?;
+                Ok(())
+            })
+            .unwrap_err();
+        let err = LuaRockspecError::from_ottavino(extern_err, rockspec_content);
+        match err {
+            LuaRockspecError::ExecutionError {
+                cause,
+                err_span: Some(span),
+                ..
+            } => {
+                assert!(cause.contains("invalid rockspec field 'foo'"));
+                assert_eq!(
+                    &rockspec_content[span.offset()..span.offset() + span.len()],
+                    "foo"
+                );
+            }
+            other => panic!("expected ExecutionError with err_span, got: {other:?}"),
+        }
     }
 }

--- a/lux-lib/src/lua_rockspec/partial.rs
+++ b/lux-lib/src/lua_rockspec/partial.rs
@@ -33,6 +33,10 @@ pub struct PartialLuaRockspec {
 #[derive(Debug, Error, Diagnostic)]
 pub enum PartialRockspecError {
     #[error("rockspec execution exceeded fuel limit of {ROCKSPEC_FUEL_LIMIT} steps")]
+    #[diagnostic(help(
+        r#"the rockspec may be too complex or contain too many dependencies.
+        Try reducing the number of dependencies or simplifying build instructions."#
+    ))]
     FuelLimitExceeded,
     #[error("field '{0}' should not be declared in extra.rockspec")]
     ExtraneousField(String),

--- a/lux-lib/src/lua_version/mod.rs
+++ b/lux-lib/src/lua_version/mod.rs
@@ -8,8 +8,10 @@ use crate::{
     config::Config,
     package::{PackageVersion, PackageVersionReq},
 };
+use itertools::Itertools;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use thiserror::Error;
 
@@ -115,17 +117,23 @@ impl LuaVersion {
 }
 
 #[derive(Error, Debug, Diagnostic)]
-#[error(
-    r#"lua version not set.
-Please provide a version through `lx --lua-version <ver> <cmd>`
-Valid versions are: '5.1', '5.2', '5.3', '5.4', '5.5', 'jit' and 'jit52'.
-"#
-)]
-pub struct LuaVersionUnset;
+#[error("lua version not set")]
+pub struct LuaVersionUnset {
+    #[help]
+    help: String,
+}
 
 impl LuaVersion {
     pub fn from(config: &Config) -> Result<&Self, LuaVersionUnset> {
-        config.lua_version().ok_or(LuaVersionUnset)
+        config.lua_version().ok_or(LuaVersionUnset {
+            help: format!(
+                r#"provide a version through `lx --lua-version <ver> <cmd>`
+or make sure Lux can discover your Lua installation on your PATH.
+valid versions are: {}
+"#,
+                LuaVersion::iter().join(",")
+            ),
+        })
     }
 }
 
@@ -141,10 +149,12 @@ impl FromStr for LuaVersion {
             "5.5" | "55" => Ok(LuaVersion::Lua55),
             "jit" | "luajit" => Ok(LuaVersion::LuaJIT),
             "jit52" | "luajit52" => Ok(LuaVersion::LuaJIT52),
-            _ => Err(r#"unrecognized Lua version.
-                 Supported versions: '5.1', '5.2', '5.3', '5.4', '5.5', 'jit', 'jit52'.
-                 "#
-            .into()),
+            _ => Err(format!(
+                r#"unrecognized Lua version.
+supported versions: {}
+            "#,
+                LuaVersion::iter().join(",")
+            )),
         }
     }
 }

--- a/lux-lib/src/luarocks/rock_manifest.rs
+++ b/lux-lib/src/luarocks/rock_manifest.rs
@@ -29,6 +29,10 @@ pub enum RockManifestError {
     #[error("could not deserialize rock_manifest: {0}")]
     Serde(#[from] ottavino_util::serde::de::Error),
     #[error("rock_manifest exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
+    #[diagnostic(help(
+        r#"the rockspec may be too complex or contain too many dependencies.
+        Try reducing the number of dependencies or simplifying build instructions."#
+    ))]
     FuelLimitExceeded,
 }
 

--- a/lux-lib/src/manifest/metadata.rs
+++ b/lux-lib/src/manifest/metadata.rs
@@ -30,6 +30,10 @@ pub enum ManifestLuaError {
     #[error("failed to deserialize Lua manifest:\n{0}")]
     DeserializationError(#[from] ottavino_util::serde::de::Error),
     #[error("manifest exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
+    #[diagnostic(help(
+        r#"the rockspec may be too complex or contain too many dependencies.
+        Try reducing the number of dependencies or simplifying build instructions."#
+    ))]
     FuelLimitExceeded,
 }
 

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -216,8 +216,16 @@ impl RemoteRockDownload {
 #[derive(Error, Debug, Diagnostic)]
 pub enum DownloadRockspecError {
     #[error("failed to download rockspec: {0}")]
+    #[diagnostic(help(
+        "check your network connection and verify the package exists on the server."
+    ))]
     Request(#[from] reqwest::Error),
     #[error("failed to convert rockspec response: {0}")]
+    #[diagnostic(help(
+        r#"the server returned a response that is not valid UTF-8.
+check your network connection and server configuration.
+if the issue persists, the server may be temporarily unavailable."#
+    ))]
     ResponseConversion(#[from] FromUtf8Error),
     #[error("error initialising remote package DB:\n{0}")]
     #[diagnostic(forward(0))]
@@ -349,8 +357,14 @@ pub enum SearchAndDownloadError {
     #[diagnostic(transparent)]
     DownloadRockspec(#[from] DownloadRockspecError),
     #[error("io operation failed: {0}")]
+    #[diagnostic(help("check that the destination directory exists and is writable."))]
     Io(#[from] io::Error),
     #[error("UTF-8 conversion failed: {0}")]
+    #[diagnostic(help(
+        r#"the server returned a response that is not valid UTF-8.
+check your network connection and server configuration.
+if the issue persists, the server may be temporarily unavailable."#
+    ))]
     Utf8(#[from] FromUtf8Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -359,21 +373,55 @@ pub enum SearchAndDownloadError {
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("failed to read packed rock {0}:\n{1}")]
+    #[diagnostic(help(
+        r#"the downloaded rock may be corrupted.
+check your network connection and rerun the command to re-download it."#
+    ))]
     ZipRead(String, zip::result::ZipError),
     #[error("failed to extract packed rock {0}:\n{1}")]
+    #[diagnostic(help(
+        r#"the downloaded rock may be corrupted.
+check your network connection and rerun the command to re-download it."#
+    ))]
     ZipExtract(String, zip::result::ZipError),
     #[error("{0} not found in the packed rock.")]
+    #[diagnostic(help(
+        r#"the packed rock does not contain the expected rockspec.
+check your network connection and rerun the command to re-download it."#
+    ))]
     RockspecNotFoundInPackedRock(String),
     #[error(transparent)]
     #[diagnostic(transparent)]
     PackageSpecFromPackageReq(#[from] PackageSpecFromPackageReqError),
     #[error("git source {0} without a revision or tag.")]
+    #[diagnostic(help(
+        r#"lux requires a pinned revision or tag to ensure reproducible builds.
+without one, the same version could resolve to different code at different times.
+try a different version, or report it to the package maintainer."#
+    ))]
     MissingCheckoutRef(String),
     #[error("cannot download from a local rock source.")]
+    #[diagnostic(
+        help(
+            r#"lux cannot download rocks from a local path.
+for local dependencies, use `path` in your lux.toml."#
+        ),
+        url("https://lux.lumen-labs.org/reference/lux-toml#local-dependencies")
+    )]
     LocalSource,
     #[error("cannot download from a local rock or embedded rockspec source.")]
+    #[diagnostic(
+        help(
+            r#"lux cannot download rocks from a local path.
+for local dependencies, use `path` in your lux.toml."#
+        ),
+        url("https://lux.lumen-labs.org/reference/lux-toml#local-dependencies")
+    )]
     NonURLSource,
     #[error("client error:\n{0}")]
+    #[diagnostic(help(
+        "check your network connection and verify the package exists on the server."
+    ))]
     Request(#[from] reqwest::Error),
 }
 
@@ -399,6 +447,9 @@ async fn search_and_download_src_rock(
 #[derive(Error, Debug, Diagnostic)]
 pub enum DownloadSrcRockError {
     #[error("failed to download source rock: {0}")]
+    #[diagnostic(help(
+        "check your network connection and verify the package exists on the server."
+    ))]
     Request(#[from] reqwest::Error),
     #[error("failed to parse source rock URL: {0}")]
     Parse(#[from] ParseError),

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -282,7 +282,8 @@ async fn download_remote_rock(
                 .map_err(DownloadRockspecError::Request)?;
             let content = String::from_utf8(bytes.into())?;
             let rockspec = DownloadedRockspec {
-                rockspec: RemoteLuaRockspec::new(&content)?,
+                rockspec: RemoteLuaRockspec::new(&content)
+                    .map_err(|err| SearchAndDownloadError::Rockspec(Box::new(err)))?,
                 source: remote_package.source,
                 source_url: remote_package.source_url,
             };
@@ -292,7 +293,8 @@ async fn download_remote_rock(
         }
         RemotePackageSource::RockspecContent(content) => {
             let rockspec = DownloadedRockspec {
-                rockspec: RemoteLuaRockspec::new(content)?,
+                rockspec: RemoteLuaRockspec::new(content)
+                    .map_err(|err| SearchAndDownloadError::Rockspec(Box::new(err)))?,
                 source: remote_package.source,
                 source_url: remote_package.source_url,
             };
@@ -368,7 +370,7 @@ if the issue persists, the server may be temporarily unavailable."#
     Utf8(#[from] FromUtf8Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Rockspec(#[from] LuaRockspecError),
+    Rockspec(Box<LuaRockspecError>),
     #[error("error initialising remote package DB:\n{0}")]
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
@@ -609,6 +611,7 @@ pub(crate) async fn unpack_rockspec(
         .map_err(|err| SearchAndDownloadError::ZipExtract(rock.file_name.clone(), err))?;
     let mut content = String::new();
     rockspec_file.read_to_string(&mut content)?;
-    let rockspec = RemoteLuaRockspec::new(&content)?;
+    let rockspec = RemoteLuaRockspec::new(&content)
+        .map_err(|err| SearchAndDownloadError::Rockspec(Box::new(err)))?;
     Ok(rockspec)
 }

--- a/lux-lib/src/operations/exec.rs
+++ b/lux-lib/src/operations/exec.rs
@@ -67,10 +67,15 @@ pub enum ExecError {
     #[error("failed to run {cmd}: {source}")]
     RunCommandFailed {
         cmd: String,
-        #[source]
         source: io::Error,
+        #[help]
+        help: Option<String>,
     },
-    #[error("{cmd} exited with non-zero exit code: {}", exit_code.map(|code| code.to_string()).unwrap_or("unknown".into()))]
+    #[error(
+        "{cmd} exited with non-zero exit code: {}",
+        exit_code.map(|code| code.to_string()).unwrap_or("unknown".into())
+    )]
+    #[diagnostic(help("check the command's output for errors."))]
     RunCommandNonZeroExitCode { cmd: String, exit_code: Option<i32> },
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -153,10 +158,21 @@ async fn exec(run: Exec<'_>) -> Result<(), ExecError> {
         .await
     {
         Ok(status) => Ok(status),
-        Err(err) => Err(ExecError::RunCommandFailed {
-            cmd: run.command.to_string(),
-            source: err,
-        }),
+        Err(err) => {
+            let help = if err.to_string().starts_with("No such file") {
+                Some(format!(
+                    "make sure '{}' is available on your PATH",
+                    run.command
+                ))
+            } else {
+                None
+            };
+            Err(ExecError::RunCommandFailed {
+                cmd: run.command.to_string(),
+                source: err,
+                help,
+            })
+        }
     }?;
     if status.success() {
         Ok(())

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -111,11 +111,13 @@ where
 #[derive(Error, Debug, Diagnostic)]
 pub enum FetchSrcError {
     #[error("failed to clone rock source:\n{0}")]
+    #[diagnostic(help("check your network connection and verify the git URL is correct."))]
     GitClone(#[from] git2::Error),
     #[error("failed to parse git URL:\n{0}")]
     #[diagnostic(forward(0))]
     GitUrlParse(#[from] RemoteGitUrlParseError),
     #[error(transparent)]
+    #[diagnostic(help("check your network connection."))]
     Request(#[from] reqwest::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -124,18 +126,24 @@ pub enum FetchSrcError {
     #[diagnostic(transparent)]
     FetchSrcRock(#[from] FetchSrcRockError),
     #[error("unable to remove the '.git' directory:\n{0}")]
+    #[diagnostic(help(
+        "check that no process is using the directory and you have write permissions."
+    ))]
     CleanGitDir(io::Error),
     #[error("unable to compute hash:\n{0}")]
     Hash(io::Error),
     #[error("unable to copy {src} to {dest}:\n{err}")]
+    #[diagnostic(help("check that the source exists and the destination is writable."))]
     CopyDir {
         src: PathBuf,
         dest: PathBuf,
         err: io::Error,
     },
     #[error("unable to open {file}:\n{err}")]
+    #[diagnostic(help("check that the file exists and is readable."))]
     FileOpen { file: PathBuf, err: io::Error },
     #[error("unable to read {file}:\n{err}")]
+    #[diagnostic(help("check that the file exists and is readable."))]
     FileRead { file: PathBuf, err: io::Error },
 }
 

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -106,15 +106,15 @@ pub enum ProjectError {
 #[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum IntoLocalRockspecError {
-    LocalProjectTomlValidationError(#[from] LocalProjectTomlValidationError),
-    RockspecError(#[from] LuaRockspecError),
+    LocalProjectTomlValidationError(Box<LocalProjectTomlValidationError>),
+    RockspecError(Box<LuaRockspecError>),
 }
 
 #[derive(Error, Debug, Diagnostic)]
 #[error(transparent)]
 pub enum IntoRemoteRockspecError {
-    RocksTomlValidationError(#[from] RemoteProjectTomlValidationError),
-    RockspecError(#[from] LuaRockspecError),
+    RocksTomlValidationError(Box<RemoteProjectTomlValidationError>),
+    RockspecError(Box<LuaRockspecError>),
 }
 
 #[derive(Error, Debug, Diagnostic)]
@@ -245,14 +245,22 @@ impl Project {
     }
 
     pub fn local_rockspec(&self) -> Result<LocalLuaRockspec, IntoLocalRockspecError> {
-        Ok(self.toml().into_local()?.to_lua_rockspec()?)
+        self.toml()
+            .into_local()
+            .map_err(|err| IntoLocalRockspecError::LocalProjectTomlValidationError(Box::new(err)))?
+            .to_lua_rockspec()
+            .map_err(|err| IntoLocalRockspecError::RockspecError(Box::new(err)))
     }
 
     pub fn remote_rockspec(
         &self,
         specrev: Option<SpecRev>,
     ) -> Result<RemoteLuaRockspec, IntoRemoteRockspecError> {
-        Ok(self.toml().into_remote(specrev)?.to_lua_rockspec()?)
+        self.toml()
+            .into_remote(specrev)
+            .map_err(|err| IntoRemoteRockspecError::RocksTomlValidationError(Box::new(err)))?
+            .to_lua_rockspec()
+            .map_err(|err| IntoRemoteRockspecError::RockspecError(Box::new(err)))
     }
 
     pub fn extra_rockspec(&self) -> Result<Option<PartialLuaRockspec>, PartialRockspecError> {

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -145,6 +145,10 @@ pub enum ProjectTomlError {
     #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
     #[error("generated rockspec exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
+    #[diagnostic(help(
+        r#"the rockspec may be too complex or contain too many dependencies.
+        Try reducing the number of dependencies or simplifying build instructions."#
+    ))]
     FuelLimitExceeded,
     #[error(
         r#"generated invalid Lua from TOML:


### PR DESCRIPTION
This PR adds some more error diagnostics, focused on config and lua rockspecs.

Lua rockspecs used to render horribly, because ottavino wraps Lux errors in a `ExternError` within `lua.try_enter`. That resulted in 3 copies of the entire rockspec content being printed.
With miette's `source_code`, we render a snippet of the rockspec content only once and add labels pointing to the package name and the field that could not be parsed:

<img width="1276" height="483" alt="image" src="https://github.com/user-attachments/assets/df4f842d-9e72-4ced-b355-af1099106a57" />