### PR TITLE
feat(tracing): more trace spans

### DIFF
--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -134,7 +134,8 @@ pub struct Cli {
     #[arg(long, value_name = "variable", visible_short_alias = 'v', value_parser = parse_key_val::<String, String>)]
     pub variables: Option<Vec<(String, String)>>,
 
-    /// Display verbose output of commands executed.
+    /// Display verbose output of commands executed, enabling DEBUG logs.{n}
+    /// To enable TRACE logs, set RUST_LOG=trace.
     #[arg(long)]
     pub verbose: bool,
 

--- a/lux-lib/src/build/builtin.rs
+++ b/lux-lib/src/build/builtin.rs
@@ -156,6 +156,7 @@ pub enum AutoDetectModulesError {
     ParseLuaModule(#[from] ParseLuaModuleError),
 }
 
+#[tracing::instrument(level = "trace")]
 fn autodetect_modules(
     build_dir: &Path,
     exclude: HashSet<PathBuf>,
@@ -213,6 +214,7 @@ fn autodetect_modules(
         .try_collect()
 }
 
+#[tracing::instrument(level = "trace")]
 fn autodetect_bin_scripts(build_dir: &Path) -> Vec<PathBuf> {
     WalkDir::new(build_dir.join("src").join("bin"))
         .into_iter()

--- a/lux-lib/src/build/cmake.rs
+++ b/lux-lib/src/build/cmake.rs
@@ -49,9 +49,11 @@ pub enum CMakeError {
     VariableSubstitution(#[from] VariableSubstitutionError),
 }
 
+#[derive(Debug)]
 struct CMakeVariables;
 
 impl HasVariables for CMakeVariables {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, input: &str) -> Result<Option<String>, GetVariableError> {
         Ok(match input {
             "CMAKE_MODULE_PATH" => Some(env::var("CMAKE_MODULE_PATH").unwrap_or("".into())),
@@ -165,6 +167,7 @@ impl BuildBackend for CMakeBuildSpec {
     }
 }
 
+#[tracing::instrument(level = "trace", skip(config))]
 async fn spawn_cmake_cmd(cmd: &mut Command, config: &Config) -> Result<(), CMakeError> {
     match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
         Ok(child) => match child.wait_with_output().await {

--- a/lux-lib/src/build/command.rs
+++ b/lux-lib/src/build/command.rs
@@ -110,6 +110,7 @@ impl BuildBackend for CommandBuildSpec {
     }
 }
 
+#[tracing::instrument(level = "trace", skip(config))]
 async fn run_command(
     command: &str,
     output_paths: &RockLayout,

--- a/lux-lib/src/build/external_dependency.rs
+++ b/lux-lib/src/build/external_dependency.rs
@@ -54,6 +54,7 @@ pub struct ExternalDependencyInfo {
     pub(crate) lib_info: Option<Library>,
 }
 
+#[tracing::instrument(level = "trace")]
 fn pkg_config_probe(name: &str) -> Option<Library> {
     PkgConfig::new()
         .print_system_libs(false)
@@ -64,6 +65,7 @@ fn pkg_config_probe(name: &str) -> Option<Library> {
 }
 
 impl ExternalDependencyInfo {
+    #[tracing::instrument(level = "trace", skip(config))]
     pub fn probe(
         name: &str,
         dependency: &ExternalDependencySpec,
@@ -126,6 +128,7 @@ impl ExternalDependencyInfo {
         Self::fallback_probe(name, dependency, config)
     }
 
+    #[tracing::instrument(level = "trace", skip(config))]
     fn fallback_probe(
         name: &str,
         dependency: &ExternalDependencySpec,
@@ -279,6 +282,7 @@ impl ExternalDependencyInfo {
 }
 
 impl HasVariables for HashMap<String, ExternalDependencyInfo> {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, input: &str) -> Result<Option<String>, GetVariableError> {
         Ok(input.split_once('_').and_then(|(dep_key, dep_dir_type)| {
             self.get(dep_key)

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -205,6 +205,7 @@ pub enum BuildBehaviour {
     Force,
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 async fn run_build<R: Rockspec + HasIntegrity, T: InstallTree + Sync>(
     rockspec: &R,
     args: RunBuildArgs<'_, T>,
@@ -227,6 +228,7 @@ async fn run_build<R: Rockspec + HasIntegrity, T: InstallTree + Sync>(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(level = "trace", skip(rockspec, tree, config))]
 async fn install<R: Rockspec + HasIntegrity, T: InstallTree>(
     rockspec: &R,
     tree: &T,
@@ -297,6 +299,7 @@ async fn install<R: Rockspec + HasIntegrity, T: InstallTree>(
     Ok(())
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 async fn do_build<R, T>(build: Build<'_, R, T>) -> Result<LocalPackage, BuildError>
 where
     R: Rockspec + HasIntegrity,
@@ -497,6 +500,7 @@ where
             .any(|copy_dir_name| copy_dir_name == &PathBuf::from(&dir_name))
 }
 
+#[tracing::instrument(level = "trace")]
 async fn recursive_copy_doc_dir(
     output_paths: &RockLayout,
     build_dir: &Path,

--- a/lux-lib/src/build/patch.rs
+++ b/lux-lib/src/build/patch.rs
@@ -56,6 +56,7 @@ pub enum PatchError {
     },
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 pub(crate) fn do_apply(args: Patch<'_>) -> Result<(), PatchError> {
     for (path, patch_str) in args.patches {
         let patch = diffy::Patch::from_str(patch_str)

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -127,6 +127,7 @@ impl BuildBackend for RustMluaBuildSpec {
     }
 }
 
+#[tracing::instrument(level = "trace")]
 fn install_rust_libs(
     modules: HashMap<String, PathBuf>,
     target_path: &Path,
@@ -145,6 +146,7 @@ fn install_rust_libs(
     Ok(())
 }
 
+#[tracing::instrument(level = "trace")]
 fn install_lua_libs(
     include: HashMap<PathBuf, PathBuf>,
     build_dir: &Path,
@@ -161,6 +163,7 @@ fn install_lua_libs(
     Ok(())
 }
 
+#[tracing::instrument(level = "trace")]
 async fn cleanup(output_paths: &RockLayout) -> () {
     let root_dir = &output_paths.rock_path;
 

--- a/lux-lib/src/build/treesitter_parser.rs
+++ b/lux-lib/src/build/treesitter_parser.rs
@@ -96,6 +96,7 @@ fn is_query_file(path: &Path) -> bool {
     path.extension().is_some_and(|ext| ext == "scm")
 }
 
+#[tracing::instrument(level = "trace")]
 async fn install_inline_queries(
     queries_dir: &Path,
     queries: std::collections::HashMap<PathBuf, String>,
@@ -115,6 +116,7 @@ async fn install_inline_queries(
     Ok(())
 }
 
+#[tracing::instrument(level = "trace")]
 async fn install_source_queries(
     source_queries_dir: &Path,
     queries_dir: &Path,
@@ -155,6 +157,7 @@ async fn install_source_queries(
     Ok(())
 }
 
+#[tracing::instrument(level = "trace")]
 async fn install_queries(
     build_dir: &Path,
     queries_dir: &Path,
@@ -174,6 +177,7 @@ async fn install_queries(
     }
 }
 
+#[tracing::instrument(level = "trace")]
 async fn build_parser(
     build_dir: &Path,
     parser_dir: &Path,

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -93,6 +93,7 @@ pub(crate) fn copy_lua_to_module_path(
 
 /// Recursively copy a directory.
 /// This respects ignore files and excludes hidden files and directories.
+#[tracing::instrument(level = "trace")]
 pub(crate) async fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(), io::Error> {
     if src.exists() {
         for file in project_files(src) {
@@ -237,6 +238,7 @@ pub(crate) async fn compile_c_files(
 }
 
 /// On MSVC, we need to create Lua definitions manually
+#[tracing::instrument(level = "trace")]
 fn mk_def_file(
     dir: &Path,
     output_file_name: &str,
@@ -675,6 +677,7 @@ pub(crate) fn trace_command_output(output: &Output) {
     }
 }
 
+#[tracing::instrument("Installing wrapped binary", level = "trace", skip(tree))]
 async fn install_wrapped_binary(
     source: &Path,
     target: &str,
@@ -737,6 +740,7 @@ exit /b %ERRORLEVEL%
 }
 
 #[cfg(unix)]
+#[tracing::instrument(level = "trace")]
 async fn set_executable_permissions(script: &Path) -> std::io::Result<()> {
     let mut perms = tokio::fs::metadata(&script).await?.permissions();
     perms.set_mode(0o744);
@@ -751,6 +755,7 @@ async fn set_executable_permissions(script: &Path) -> std::io::Result<()> {
 /// But that's unlikely to be the case in practise.
 /// If a script is mistaken for a Lua script, package authors can disable
 /// wrapping with the `deploy.wrap_bin_scripts` rockspec config.
+#[tracing::instrument(level = "trace")]
 async fn is_compatible_lua_script(
     file: &Path,
     lua: &LuaInstallation,
@@ -790,6 +795,7 @@ async fn is_compatible_lua_script(
 /// Uses the bundled Lua interpreter. This may be less reliable,
 /// as it cannot load scripts for an incompatible Lua version.
 /// But it works for test dependencies like nlua.
+#[tracing::instrument(level = "trace")]
 async fn is_compatible_lua_script_fallback(
     file: &Path,
     lua_installation: &LuaInstallation,

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -254,6 +254,7 @@ impl Config {
 }
 
 impl HasVariables for Config {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, input: &str) -> Result<Option<String>, GetVariableError> {
         Ok(self.variables.get(input).cloned())
     }
@@ -291,7 +292,7 @@ pub enum ConfigError {
 ///   or call [`ConfigBuilder::new`] to start from a deserialised configuration file.
 /// - Populate the fields from overriding sources (e.g. CLI arguments).
 /// - Finish with [`ConfigBuilder::build`].
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ConfigBuilder {
     #[serde(
         default,
@@ -555,6 +556,7 @@ impl ConfigBuilder {
         }
     }
 
+    #[tracing::instrument(level = "trace")]
     pub fn build(self) -> Result<Config, ConfigError> {
         let data_dir = self.data_dir.unwrap_or(Config::default_data_path()?);
         let cache_dir = self.cache_dir.unwrap_or(Config::default_cache_path()?);

--- a/lux-lib/src/git/utils.rs
+++ b/lux-lib/src/git/utils.rs
@@ -28,6 +28,7 @@ pub(crate) enum SemVerTagOrSha {
     CommitSha(String),
 }
 
+#[tracing::instrument(level = "trace")]
 pub(crate) fn latest_semver_tag_or_commit_sha(
     url: &RemoteGitUrl,
 ) -> Result<SemVerTagOrSha, GitError> {
@@ -40,6 +41,7 @@ pub(crate) fn latest_semver_tag_or_commit_sha(
     }
 }
 
+#[tracing::instrument(level = "trace")]
 fn latest_semver_tag(url: &RemoteGitUrl) -> Result<Option<String>, GitError> {
     let temp_dir = tempdir().map_err(GitError::CreateTempDir)?;
 

--- a/lux-lib/src/hash.rs
+++ b/lux-lib/src/hash.rs
@@ -10,6 +10,7 @@ pub trait HasIntegrity {
 }
 
 impl HasIntegrity for PathBuf {
+    #[tracing::instrument(level = "trace")]
     fn hash(&self) -> io::Result<Integrity> {
         let mut integrity_opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
         if self.is_dir() {
@@ -34,6 +35,7 @@ impl HasIntegrity for Path {
 }
 
 impl HasIntegrity for Bytes {
+    #[tracing::instrument(level = "trace")]
     fn hash(&self) -> io::Result<Integrity> {
         let mut integrity_opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
         integrity_opts.input(self);

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -1052,6 +1052,7 @@ impl<P: LockfilePermissions> WorkspaceLockfile<P> {
 
 impl Lockfile<ReadOnly> {
     /// Create a new `Lockfile`, writing an empty file if none exists.
+    #[tracing::instrument(level = "trace")]
     pub(crate) fn new(
         filepath: PathBuf,
         rock_layout: RockLayoutConfig,
@@ -1079,6 +1080,7 @@ impl Lockfile<ReadOnly> {
 
     /// Load a `Lockfile`, failing if none exists.
     /// If `expected_rock_layout` is `Some`, this fails if the rock layouts don't match
+    #[tracing::instrument(level = "trace")]
     pub fn load(
         filepath: PathBuf,
         expected_rock_layout: Option<&RockLayoutConfig>,
@@ -1114,6 +1116,7 @@ impl Lockfile<ReadOnly> {
 
     /// Converts the current lockfile into a writeable one, executes `cb` and flushes
     /// the lockfile.
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn map_then_flush<T, F, E>(self, cb: F) -> Result<T, FlushLockfileError>
     where
         F: FnOnce(&mut Lockfile<ReadWrite>) -> Result<T, E>,
@@ -1154,6 +1157,7 @@ impl Lockfile<ReadOnly> {
 
 impl WorkspaceLockfile<ReadOnly> {
     /// Create a new `ProjectLockfile`, writing an empty file if none exists.
+    #[tracing::instrument(level = "trace")]
     pub fn new(filepath: PathBuf) -> Result<WorkspaceLockfile<ReadOnly>, LockfileError> {
         // Ensure that the lockfile exists
         match File::options().create_new(true).write(true).open(&filepath) {
@@ -1178,6 +1182,7 @@ impl WorkspaceLockfile<ReadOnly> {
     }
 
     /// Load a `ProjectLockfile`, failing if none exists.
+    #[tracing::instrument(level = "trace")]
     pub fn load(filepath: PathBuf) -> Result<WorkspaceLockfile<ReadOnly>, LockfileError> {
         let content = std::fs::read_to_string(&filepath).map_err(LockfileError::Load)?;
         let mut lockfile: WorkspaceLockfile<ReadOnly> =

--- a/lux-lib/src/lua.rs
+++ b/lux-lib/src/lua.rs
@@ -6,6 +6,8 @@ use lazy_static::lazy_static;
 
 lazy_static! {
     static ref LUA_RUNTIME: Runtime = {
+        let span = tracing::debug_span!("Initialising Lua runtime");
+        let _enter = span.enter();
         #[allow(clippy::expect_used)]
         Builder::new_multi_thread()
             .enable_all()

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -97,10 +97,12 @@ pub enum LuaInstallationError {
 }
 
 impl LuaInstallation {
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn new_from_config(config: &Config) -> Result<Self, LuaInstallationError> {
         Self::new(LuaVersion::from(config)?, config).await
     }
 
+    #[tracing::instrument(level = "trace", skip(config))]
     pub async fn new(version: &LuaVersion, config: &Config) -> Result<Self, LuaInstallationError> {
         let _lock = NEW_MUTEX.lock().await;
         if let Some(lua_intallation) = Self::probe(version, config.external_deps()) {
@@ -134,6 +136,7 @@ impl LuaInstallation {
         }
     }
 
+    #[tracing::instrument(level = "trace")]
     pub(crate) fn probe(
         version: &LuaVersion,
         search_config: &ExternalDependencySearchConfig,
@@ -181,6 +184,7 @@ impl LuaInstallation {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(config))]
     pub async fn install(
         version: &LuaVersion,
         config: &Config,
@@ -266,6 +270,7 @@ impl LuaInstallation {
 }
 
 impl HasVariables for LuaInstallation {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, input: &str) -> Result<Option<String>, GetVariableError> {
         Ok(match input {
             "LUA_INCDIR" => self

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -214,6 +214,7 @@ where
     }
 }
 
+#[tracing::instrument(level = "trace", skip(entry))]
 async fn install_manifest_entries<T>(
     entry: &HashMap<PathBuf, T>,
     src: &Path,

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -121,6 +121,7 @@ impl LuaRocksInstallation {
     }
 
     #[cfg(target_family = "unix")]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn ensure_installed(
         &self,
         lua: &LuaInstallation,
@@ -149,6 +150,7 @@ impl LuaRocksInstallation {
     }
 
     #[cfg(target_family = "windows")]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn ensure_installed(
         &self,
         _lua: &LuaInstallation,
@@ -187,6 +189,7 @@ impl LuaRocksInstallation {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn make(
         self,
         rockspec_path: &Path,

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -48,6 +48,7 @@ if you are using a custom server, make sure it returns correctly formatted manif
     LuaVersion(#[from] LuaVersionUnset),
 }
 
+#[tracing::instrument(level = "trace", skip(client))]
 pub(super) async fn get_manifest(
     url: Url,
     manifest_version: String,
@@ -99,6 +100,7 @@ pub(super) async fn get_manifest(
     }
 }
 
+#[tracing::instrument(level = "trace", skip(config))]
 pub(crate) async fn manifest_from_cache_or_server(
     server_url: &Url,
     config: &Config,
@@ -145,6 +147,7 @@ pub(crate) async fn manifest_from_cache_or_server(
     get_manifest(url, manifest_version.clone(), &cache, &client).await
 }
 
+#[tracing::instrument(level = "trace", skip(config))]
 pub(crate) async fn manifest_from_server_only(
     server_url: &Url,
     config: &Config,

--- a/lux-lib/src/manifest/metadata_from_vendor_dir.rs
+++ b/lux-lib/src/manifest/metadata_from_vendor_dir.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 /// Construct manifest metadata from a vendor directory.
+#[tracing::instrument(level = "trace")]
 pub(crate) fn manifest_from_vendor_dir(vendor_dir: &Path) -> ManifestMetadata {
     let mut repository = HashMap::new();
     for (package, package_type) in WalkDir::new(vendor_dir)

--- a/lux-lib/src/manifest/mod.rs
+++ b/lux-lib/src/manifest/mod.rs
@@ -46,6 +46,7 @@ impl Manifest {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(config))]
     pub async fn from_config(server_url: Url, config: &Config) -> Result<Self, ManifestError> {
         if let Some(vendor_dir) = config.vendor_dir() {
             let server_url: Url = Url::from_file_path(vendor_dir)

--- a/lux-lib/src/project/gen.rs
+++ b/lux-lib/src/project/gen.rs
@@ -68,9 +68,11 @@ pub enum GenerateSourceError {
 }
 
 /// Helper for substituting git variables from a git project
+#[derive(Debug)]
 struct GitProject<'a>(&'a ProjectRoot);
 
 impl HasVariables for GitProject<'_> {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, input: &str) -> Result<Option<String>, GetVariableError> {
         Ok(match input {
             "REF" => {

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -195,6 +195,7 @@ pub struct Project {
 
 impl Project {
     /// Load a project at the specified path, if it exists
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn from_exact(start: impl AsRef<Path>) -> Result<Option<Self>, ProjectError> {
         if !start.as_ref().exists() {
             return Ok(None);

--- a/lux-lib/src/remote_package_db/mod.rs
+++ b/lux-lib/src/remote_package_db/mod.rs
@@ -51,6 +51,7 @@ pub enum RemotePackageDbIntegrityError {
 }
 
 impl RemotePackageDB {
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn from_config(config: &Config) -> Result<Self, RemotePackageDBError> {
         let mut manifests = Vec::new();
         for server in config.enabled_dev_servers()? {

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -126,6 +126,7 @@ impl RockLayout {
 }
 
 impl HasVariables for RockLayout {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, var: &str) -> Result<Option<String>, GetVariableError> {
         Ok(match var {
             "PREFIX" => Some(format_path(&self.rock_path)),

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -263,6 +263,7 @@ impl From<SignatureProtocol> for gpgme::Protocol {
     }
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 async fn upload_from_project(args: ProjectUpload<'_>) -> Result<(), UploadError> {
     let project = args.project;
     let api_key = args.api_key.unwrap_or(ApiKey::new()?);
@@ -377,6 +378,7 @@ mod helpers {
             .join(endpoint)
     }
 
+    #[tracing::instrument(level = "trace", skip(client))]
     pub(crate) async fn ensure_tool_version(
         client: &Client,
         server_url: &Url,
@@ -400,6 +402,7 @@ mod helpers {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(client, api_key))]
     pub(crate) async fn verify_tfa_code(
         client: &Client,
         server_url: &Url,
@@ -429,6 +432,7 @@ mod helpers {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(client, api_key))]
     pub(crate) async fn ensure_user_exists(
         client: &Client,
         api_key: &ApiKey,
@@ -448,6 +452,7 @@ mod helpers {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) async fn generate_rockspec(
         project: &Project,
         client: &Client,
@@ -496,6 +501,7 @@ mod helpers {
         Err(UploadError::MaxSpecRevsExceeded)
     }
 
+    #[tracing::instrument(level = "trace", skip(client, api_key))]
     async fn rock_exists(
         client: &Client,
         api_key: &ApiKey,

--- a/lux-lib/src/variables.rs
+++ b/lux-lib/src/variables.rs
@@ -35,9 +35,11 @@ pub(crate) trait HasVariables {
 }
 
 /// Helper for variable substitution with environment variables
+#[derive(Debug)]
 pub(crate) struct Environment {}
 
 impl HasVariables for Environment {
+    #[tracing::instrument(level = "trace")]
     fn get_variable(&self, input: &str) -> Result<Option<String>, GetVariableError> {
         Ok(std::env::var(input).ok())
     }
@@ -84,6 +86,7 @@ fn parser<'a>(
 
 /// Substitute variables of the format `$(VAR)`, where `VAR` is the variable name
 /// passed to `get_var`.
+#[tracing::instrument(level = "trace", skip(variables))]
 pub(crate) fn substitute(
     variables: &[&dyn HasVariables],
     input: &str,

--- a/lux-lib/src/which/mod.rs
+++ b/lux-lib/src/which/mod.rs
@@ -38,6 +38,7 @@ where
         self
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn search(self) -> Result<PathBuf, WhichError>
     where
         State: which_builder::IsComplete,

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -265,6 +265,7 @@ impl Workspace {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn from_exact(start: impl AsRef<Path>) -> Result<Option<Self>, WorkspaceError> {
         if !start.as_ref().exists() {
             return Ok(None);
@@ -291,6 +292,7 @@ impl Workspace {
         }
     }
 
+    #[tracing::instrument(level = "trace", skip(start))]
     pub fn from(start: impl AsRef<Path>) -> Result<Option<Self>, WorkspaceError> {
         if !start.as_ref().exists() {
             return Ok(None);


### PR DESCRIPTION
Add a bunch of trace spans to lux-lib, mostly for IO actions.

Closes #920.

To get trace output, run:

```
RUST_LOG=trace lx ...
```

`lx --verbose ...` runs with debug logs enabled.