### PR TITLE
feat(error-reporting)!: `*::fs` wrappers with `miette` diagnostics

### DIFF
--- a/lux-lib/src/build/builtin.rs
+++ b/lux-lib/src/build/builtin.rs
@@ -2,7 +2,6 @@ use itertools::Itertools;
 use miette::Diagnostic;
 use std::{
     collections::{HashMap, HashSet},
-    io,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -14,6 +13,7 @@ use crate::{
         backend::{BuildBackend, BuildInfo, RunBuildArgs},
         utils,
     },
+    fs,
     lua_rockspec::{BuiltinBuildSpec, LuaModule, ModuleSpec, ParseLuaModuleError},
     tree::{InstallTree, TreeError},
 };
@@ -36,7 +36,8 @@ pub enum BuiltinBuildError {
         source: InstallBinaryError,
     },
     #[error(transparent)]
-    Io(#[from] io::Error),
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Tree(#[from] TreeError),
@@ -79,14 +80,14 @@ impl BuildBackend for BuiltinBuildSpec {
                             external_dependencies,
                             config,
                         )
-                        .await?
+                        .await?;
                     } else {
                         let absolute_source_path = build_dir.join(source);
                         utils::copy_lua_to_module_path(
                             &absolute_source_path,
                             destination_path,
                             &output_paths.src,
-                        )?
+                        )?;
                     }
                 }
                 ModuleSpec::SourcePaths(files) => {

--- a/lux-lib/src/build/cmake.rs
+++ b/lux-lib/src/build/cmake.rs
@@ -14,6 +14,7 @@ use crate::{
         utils,
     },
     config::Config,
+    fs,
     lua_rockspec::CMakeBuildSpec,
     path::{Paths, PathsError},
     tree::{InstallTree, TreeError},
@@ -37,16 +38,17 @@ pub enum CMakeError {
         stdout: String,
         stderr: String,
     },
-    #[error("failed to run `cmake` step: {0}")]
-    Io(io::Error),
-    #[error("failed to write CMakeLists.txt: {0}")]
-    WriteCmakeLists(io::Error),
+    #[error("failed to run `cmake` step")]
+    Io { source: io::Error },
     #[error("failed to run `cmake` step: '{0}' command not found!")]
     #[diagnostic(help("run `lx debug toolchains` to check available build tools."))]
     CommandNotFound(String),
     #[error(transparent)]
     #[diagnostic(transparent)]
     VariableSubstitution(#[from] VariableSubstitutionError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 #[derive(Debug)]
@@ -88,7 +90,7 @@ impl BuildBackend for CMakeBuildSpec {
         let mut args = Vec::new();
         if let Some(content) = self.cmake_lists_content {
             let cmakelists = build_dir.join("CMakeLists.txt");
-            std::fs::write(&cmakelists, content).map_err(CMakeError::WriteCmakeLists)?;
+            fs::tokio::write(&cmakelists, content).await?;
             args.push(format!("-G\"{}\"", cmakelists.display()));
         } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
             // With msvc and x64, CMake does not select it by default so we need to be explicit.
@@ -180,7 +182,7 @@ async fn spawn_cmake_cmd(cmd: &mut Command, config: &Config) -> Result<(), CMake
                     stderr: String::from_utf8_lossy(&output.stderr).into(),
                 });
             }
-            Err(err) => return Err(CMakeError::Io(err)),
+            Err(source) => return Err(CMakeError::Io { source }),
         },
         Err(_) => return Err(CMakeError::CommandNotFound(config.cmake_cmd().clone())),
     }

--- a/lux-lib/src/build/external_dependency.rs
+++ b/lux-lib/src/build/external_dependency.rs
@@ -15,14 +15,17 @@ use thiserror::Error;
 
 use super::utils::{c_lib_extension, format_path};
 
+use crate::fs;
+
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum ExternalDependencyError {
     #[error("external dependency '{0}' not found")]
     #[diagnostic(help("{}", not_found_help(.0)))]
     NotFound(String),
-    #[error("IO error while trying to detect external dependencies: {0}")]
-    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("{0} was probed successfully, but the header {1} could not be found")]
     #[diagnostic(help(
         r#"ensure the header is installed.
@@ -384,7 +387,7 @@ pub(crate) fn to_lib_name(file: &Path) -> String {
 }
 
 fn get_lib_name(lib_dir: &Path, prefix: &str) -> Option<String> {
-    std::fs::read_dir(lib_dir)
+    fs::sync::read_dir(lib_dir)
         .ok()
         .and_then(|entries| {
             entries
@@ -401,6 +404,7 @@ fn get_lib_name(lib_dir: &Path, prefix: &str) -> Option<String> {
         })
         .map(|file| to_lib_name(&file))
 }
+
 fn is_lib_name(file_name: &str, prefix: &str) -> bool {
     #[cfg(target_family = "unix")]
     let file_name = file_name.trim_start_matches("lib");

--- a/lux-lib/src/build/luarocks.rs
+++ b/lux-lib/src/build/luarocks.rs
@@ -1,11 +1,12 @@
 use crate::build::backend::BuildInfo;
 use crate::build::backend::RunBuildArgs;
+use crate::fs;
 use crate::lua_rockspec::LuaVersionError;
 use crate::rockspec::LuaVersionCompatibility;
 use crate::rockspec::Rockspec;
 use crate::tree::InstallTree;
 use crate::tree::TreeError;
-use std::{io, path::Path};
+use std::path::Path;
 
 use crate::{
     config::Config,
@@ -14,8 +15,8 @@ use crate::{
 };
 
 use super::utils::recursive_copy_dir;
+use crate::fs::tempfile::tempdir;
 use miette::Diagnostic;
-use tempfile::tempdir;
 use thiserror::Error;
 use tracing::info_span;
 use tracing::Instrument;
@@ -24,7 +25,8 @@ use tracing::Instrument;
 #[non_exhaustive]
 pub enum LuarocksBuildError {
     #[error(transparent)]
-    Io(#[from] io::Error),
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("error instantiating luarocks compatibility layer:\n{0}")]
     #[diagnostic(forward(0))]
     LuaRocksError(#[from] LuaRocksError),
@@ -58,7 +60,7 @@ pub(crate) async fn build<R: Rockspec, T: InstallTree>(
         rockspec.package(),
         rockspec.version()
     ));
-    tokio::fs::write(
+    fs::tokio::write(
         &rockspec_file,
         rockspec
             .to_lua_remote_rockspec_string()
@@ -82,7 +84,7 @@ async fn install<R: Rockspec>(
     config: &Config,
 ) -> Result<BuildInfo, LuarocksBuildError> {
     let lua_version = rockspec.lua_version_matches(config)?;
-    std::fs::create_dir_all(&output_paths.bin)?;
+    fs::tokio::create_dir_all(&output_paths.bin).await?;
     let package_dir = luarocks_tree
         .join("lib")
         .join("lib")

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -1,4 +1,5 @@
 use crate::build::backend::{BuildBackend, BuildInfo, RunBuildArgs};
+use crate::fs;
 use crate::lockfile::{LockfileError, OptState, RemotePackageSourceUrl};
 use crate::lua_installation::LuaInstallationError;
 use crate::lua_rockspec::LuaVersionError;
@@ -148,6 +149,9 @@ pub enum BuildError {
     Io(#[from] io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -255,7 +259,7 @@ async fn install<R: Rockspec + HasIntegrity, T: InstallTree>(
         for (target, source) in &install_spec.lib {
             let absolute_source = build_dir.join(source);
             let resolved_target = output_paths.lib.join(target);
-            tokio::fs::copy(absolute_source, resolved_target).await?;
+            fs::tokio::copy(absolute_source, resolved_target).await?;
         }
     }
     if entry_type.is_entrypoint() {
@@ -292,9 +296,9 @@ async fn install<R: Rockspec + HasIntegrity, T: InstallTree>(
             let absolute_source = build_dir.join(source);
             let target = output_paths.conf.join(target);
             if let Some(parent_dir) = target.parent() {
-                tokio::fs::create_dir_all(parent_dir).await?;
+                fs::tokio::create_dir_all(parent_dir).await?;
             }
-            tokio::fs::copy(absolute_source, target).await?;
+            fs::tokio::copy(absolute_source, target).await?;
         }
     }
     Ok(())
@@ -313,7 +317,7 @@ where
 
     let tree = build.tree;
 
-    let temp_dir = tempfile::tempdir()?;
+    let temp_dir = fs::tempfile::tempdir()?;
 
     let source_metadata = match build.source_spec {
         Some(RemotePackageSourceSpec::SrcRock(SrcRockSource { bytes, source_url })) => {
@@ -388,7 +392,7 @@ where
                     //
                     // LuaRocks implementation:
                     // https://github.com/luarocks/luarocks/blob/4188fdb235aca66530d274c782374cf6afba09b8/src/luarocks/fetch.tl?plain=1#L526
-                    let has_lua_or_c_sources = std::fs::read_dir(temp_dir.path())?
+                    let has_lua_or_c_sources = fs::sync::read_dir(temp_dir.path())?
                         .filter_map(Result::ok)
                         .filter(|f| f.path().is_file())
                         .any(|f| {
@@ -399,7 +403,7 @@ where
                     if has_lua_or_c_sources {
                         temp_dir.path().into()
                     } else {
-                        let dir_entries = std::fs::read_dir(temp_dir.path())?
+                        let dir_entries = fs::sync::read_dir(temp_dir.path())?
                             .filter_map(Result::ok)
                             .filter(|f| f.path().is_dir())
                             .collect_vec();
@@ -481,7 +485,7 @@ where
             recursive_copy_doc_dir(&output_paths, &build_dir).await?;
 
             if let Ok(rockspec_str) = rockspec.to_lua_remote_rockspec_string() {
-                std::fs::write(output_paths.rockspec_path(), rockspec_str)?;
+                fs::sync::write(output_paths.rockspec_path(), rockspec_str)?;
             }
 
             Ok(package)

--- a/lux-lib/src/build/patch.rs
+++ b/lux-lib/src/build/patch.rs
@@ -1,7 +1,7 @@
+use crate::fs;
 use bon::Builder;
 use diffy::{self, ApplyError, ParsePatchError};
 use miette::Diagnostic;
-use std::io;
 use std::{collections::HashMap, path::PathBuf};
 use thiserror::Error;
 #[derive(Builder)]
@@ -27,34 +27,11 @@ where
 pub enum PatchError {
     #[error("error parsing patch {0}: {1}")]
     Parse(PathBuf, ParsePatchError),
-    #[error("failed to apply patch {patch_file}: error reading original file {orig_file}: {err}")]
-    OriginalFileRead {
-        patch_file: PathBuf,
-        orig_file: PathBuf,
-        err: io::Error,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("error applying patch {0}: {1}")]
     Apply(PathBuf, ApplyError),
-    #[error("failed to apply patch {patch_file}: error creating directory {dir}: {err}")]
-    CreateDir {
-        patch_file: PathBuf,
-        dir: PathBuf,
-        err: io::Error,
-    },
-    #[error(
-        "failed to apply patch {patch_file}: error writing modified file {modified_file}: {err}"
-    )]
-    ModifiedFileWrite {
-        patch_file: PathBuf,
-        modified_file: PathBuf,
-        err: io::Error,
-    },
-    #[error("failed to apply patch {patch_file}: error deleting file {file}: {err}")]
-    Delete {
-        patch_file: PathBuf,
-        file: PathBuf,
-        err: io::Error,
-    },
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
@@ -76,13 +53,7 @@ pub(crate) fn do_apply(args: Patch<'_>) -> Result<(), PatchError> {
 
         let original_content = original_file
             .as_ref()
-            .map(|file| {
-                std::fs::read_to_string(file).map_err(|err| PatchError::OriginalFileRead {
-                    patch_file: path.clone(),
-                    orig_file: file.clone(),
-                    err,
-                })
-            })
+            .map(fs::sync::read_to_string)
             .map_or(Ok(None), |v| v.map(Some))?
             .unwrap_or_default();
 
@@ -99,33 +70,19 @@ pub(crate) fn do_apply(args: Patch<'_>) -> Result<(), PatchError> {
             .map(|modified_file| {
                 let modified_content = diffy::apply(&original_content, &patch)
                     .map_err(|err| PatchError::Apply(path.clone(), err))?;
-                Ok((modified_file, modified_content))
+                Ok::<_, PatchError>((modified_file, modified_content))
             })
             .map_or(Ok(None), |v| v.map(Some))?
             .map(|(file, modified_content)| {
                 let parent = file.parent().unwrap_or(args.dir);
-                std::fs::create_dir_all(parent).map_err(|err| PatchError::CreateDir {
-                    patch_file: path.clone(),
-                    dir: parent.to_path_buf(),
-                    err,
-                })?;
-                std::fs::write(&file, modified_content).map_err(|err| {
-                    PatchError::ModifiedFileWrite {
-                        patch_file: path.clone(),
-                        modified_file: file,
-                        err,
-                    }
-                })
+                fs::sync::create_dir_all(parent)?;
+                Ok::<_, PatchError>(fs::sync::write(&file, modified_content)?)
             })
             .map_or(Ok(None), |v| v.map(Some))?;
 
         if modified.is_none() {
             if let Some(original) = original_file {
-                std::fs::remove_file(&original).map_err(|err| PatchError::Delete {
-                    patch_file: path.clone(),
-                    file: original,
-                    err,
-                })?
+                fs::sync::remove_file(&original)?;
             }
         }
     }
@@ -136,21 +93,22 @@ pub(crate) fn do_apply(args: Patch<'_>) -> Result<(), PatchError> {
 mod tests {
 
     use super::*;
+    use crate::fs;
     use assert_fs::TempDir;
-    use std::{fs, path::PathBuf};
+    use std::path::PathBuf;
 
     #[test]
     fn test_simple_patch() {
         let temp_dir = TempDir::new().unwrap();
         let test_file =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/patch_test/pack.lua");
-        let orig_content = std::fs::read_to_string(&test_file).unwrap();
+        let orig_content = crate::fs::sync::read_to_string(&test_file).unwrap();
         let added_line = r#"_G._ENV = rawget(_G, "_ENV") -- to satisfy tarantool strict mode"#;
         assert!(!orig_content.contains(added_line));
         let scripts_dir = temp_dir.join("scripts");
-        fs::create_dir_all(&scripts_dir).unwrap();
+        fs::sync::create_dir_all(&scripts_dir).unwrap();
         let patch_file = scripts_dir.join("pack.lua");
-        fs::copy(&test_file, &patch_file).unwrap();
+        fs::sync::copy(&test_file, &patch_file).unwrap();
         let patches = vec![(
             PathBuf::from("test_patch.diff"),
             r#"
@@ -172,7 +130,7 @@ index 959c7ed..9c6a9a1 100644
 
         Patch::new(&temp_dir.join(""), &patches).apply().unwrap();
 
-        let patched_content = std::fs::read_to_string(&patch_file).unwrap();
+        let patched_content = crate::fs::sync::read_to_string(&patch_file).unwrap();
         assert!(patched_content.contains(added_line));
     }
 
@@ -196,7 +154,7 @@ index 0000000..1cbadfb
         .collect();
         Patch::new(&temp_dir.join(""), &patches).apply().unwrap();
         let patch_file = temp_dir.join("foo/README.md");
-        let patched_content = std::fs::read_to_string(&patch_file).unwrap();
+        let patched_content = crate::fs::sync::read_to_string(&patch_file).unwrap();
         assert!(patched_content.contains("# title"));
     }
 
@@ -204,7 +162,7 @@ index 0000000..1cbadfb
     fn test_git_patch_delete_file() {
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.join("README.md");
-        std::fs::write(&test_file, "# title").unwrap();
+        crate::fs::sync::write(&test_file, "# title").unwrap();
         let patches = vec![(
             PathBuf::from("test.patch"),
             r#"

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -1,15 +1,16 @@
 use super::utils::c_dylib_extension;
 use crate::build::backend::{BuildBackend, BuildInfo, RunBuildArgs};
 use crate::build::utils;
+use crate::fs;
 use crate::lua_version::{LuaVersion, LuaVersionUnset};
 use crate::tree::InstallTree;
 use crate::{lua_rockspec::RustMluaBuildSpec, tree::RockLayout};
 use itertools::Itertools;
 use miette::Diagnostic;
 use std::collections::HashMap;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
-use std::{fs, io};
 use thiserror::Error;
 use tokio::process::Command;
 use tracing::{info_span, Instrument};
@@ -23,37 +24,14 @@ pub enum RustError {
         stdout: String,
         stderr: String,
     },
-    #[error("failed to run `cargo build`: {0}")]
-    RustBuild(io::Error),
-    #[error("unable to create directory {0}:\n{1}")]
-    CreateDir(String, io::Error),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    InstallRustLib(#[from] InstallRustLibError),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    InstallLuaLib(#[from] InstallLuaLibError),
+    #[error("failed to run `cargo build`")]
+    RustBuild { source: io::Error },
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
-}
-
-#[derive(Error, Debug, Diagnostic)]
-#[non_exhaustive]
-#[error("error installing rust library {lib}")]
-#[diagnostic(help("check that the output directory exists and is writable."))]
-pub struct InstallRustLibError {
-    lib: String,
-    source: io::Error,
-}
-
-#[derive(Error, Debug, Diagnostic)]
-#[non_exhaustive]
-#[error("error installing Lua library {lib}")]
-#[diagnostic(help("check that the output directory exists and is writable."))]
-pub struct InstallLuaLibError {
-    lib: String,
-    source: io::Error,
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 impl BuildBackend for RustMluaBuildSpec {
@@ -107,22 +85,18 @@ impl BuildBackend for RustMluaBuildSpec {
                         stderr: String::from_utf8_lossy(&output.stderr).into(),
                     });
                 }
-                Err(err) => return Err(RustError::RustBuild(err)),
+                Err(source) => return Err(RustError::RustBuild { source }),
             }
         }
-        fs::create_dir_all(&output_paths.lib).map_err(|err| {
-            RustError::CreateDir(output_paths.lib.to_string_lossy().to_string(), err)
-        })?;
+        fs::tokio::create_dir_all(&output_paths.lib).await?;
         if let Err(err) =
-            install_rust_libs(self.modules, &self.target_path, build_dir, output_paths)
+            install_rust_libs(self.modules, &self.target_path, build_dir, output_paths).await
         {
             cleanup(output_paths).await;
             return Err(err.into());
         }
-        fs::create_dir_all(&output_paths.src).map_err(|err| {
-            RustError::CreateDir(output_paths.src.to_string_lossy().to_string(), err)
-        })?;
-        if let Err(err) = install_lua_libs(self.include, build_dir, output_paths) {
+        fs::tokio::create_dir_all(&output_paths.src).await?;
+        if let Err(err) = install_lua_libs(self.include, build_dir, output_paths).await {
             cleanup(output_paths).await;
             return Err(err.into());
         }
@@ -131,37 +105,31 @@ impl BuildBackend for RustMluaBuildSpec {
 }
 
 #[tracing::instrument(level = "trace")]
-fn install_rust_libs(
+async fn install_rust_libs(
     modules: HashMap<String, PathBuf>,
     target_path: &Path,
     build_dir: &Path,
     output_paths: &RockLayout,
-) -> Result<(), InstallRustLibError> {
+) -> Result<(), fs::FsError> {
     for (module, rust_lib) in modules {
         let src = build_dir.join(target_path).join("release").join(rust_lib);
         let mut dst: PathBuf = output_paths.lib.join(module);
         dst.set_extension(c_dylib_extension());
-        fs::copy(&src, &dst).map_err(|err| InstallRustLibError {
-            lib: src.to_string_lossy().to_string(),
-            source: err,
-        })?;
+        fs::tokio::copy(&src, &dst).await?;
     }
     Ok(())
 }
 
 #[tracing::instrument(level = "trace")]
-fn install_lua_libs(
+async fn install_lua_libs(
     include: HashMap<PathBuf, PathBuf>,
     build_dir: &Path,
     output_paths: &RockLayout,
-) -> Result<(), InstallLuaLibError> {
+) -> Result<(), fs::FsError> {
     for (from, to) in include {
         let src = build_dir.join(from);
         let dst = output_paths.src.join(to);
-        fs::copy(&src, &dst).map_err(|err| InstallLuaLibError {
-            lib: src.to_string_lossy().to_string(),
-            source: err,
-        })?;
+        fs::tokio::copy(&src, &dst).await?;
     }
     Ok(())
 }
@@ -170,7 +138,7 @@ fn install_lua_libs(
 async fn cleanup(output_paths: &RockLayout) -> () {
     let root_dir = &output_paths.rock_path;
 
-    match tokio::fs::remove_dir_all(root_dir).await {
+    match fs::tokio::remove_dir_all(root_dir).await {
         Ok(_) => (),
         Err(err) => tracing::warn!("failed to clean up {}: {}", root_dir.display(), err),
     };

--- a/lux-lib/src/build/source.rs
+++ b/lux-lib/src/build/source.rs
@@ -1,4 +1,5 @@
-use std::{io, string::FromUtf8Error};
+use crate::fs;
+use std::string::FromUtf8Error;
 
 use crate::{
     build::backend::{BuildBackend, BuildInfo, RunBuildArgs},
@@ -21,8 +22,9 @@ use super::{
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum SourceBuildError {
-    #[error("IO operation failed: {0}")]
-    Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     FromUtf8(#[from] FromUtf8Error),
     #[error(transparent)]
@@ -70,12 +72,12 @@ where
 
     let mut build_spec = BuildSpec::default();
     let mut copy_directories = None;
-    for path in std::fs::read_dir(build_dir)?
+    for path in fs::sync::read_dir(build_dir)?
         .filter_map(Result::ok)
         .map(|entry| entry.path())
     {
         if path.file_name().is_some_and(|name| name == PROJECT_TOML) {
-            let toml_content = String::from_utf8(tokio::fs::read(path).await?)?;
+            let toml_content = String::from_utf8(fs::tokio::read(path).await?)?;
             let project_toml =
                 PartialProjectToml::new(PROJECT_TOML, &toml_content, ProjectRoot::new())?
                     .into_local()?;
@@ -83,7 +85,7 @@ where
             copy_directories = Some(build_spec.copy_directories);
             break;
         } else if path.extension().is_some_and(|ext| ext == "rockspec") {
-            let rockspec_content = String::from_utf8(tokio::fs::read(path).await?)?;
+            let rockspec_content = String::from_utf8(fs::tokio::read(path).await?)?;
             let rockspec = LocalLuaRockspec::new(&rockspec_content, ProjectRoot::new())?;
             build_spec = rockspec.build().current_platform().clone();
             copy_directories = Some(build_spec.copy_directories);
@@ -136,7 +138,7 @@ where
         }
         None => {
             // We copy all directories if there is no rockspec
-            for subdirectory in std::fs::read_dir(build_dir)?
+            for subdirectory in fs::sync::read_dir(build_dir)?
                 .filter_map(Result::ok)
                 .filter_map(|entry| {
                     let path = entry.path();

--- a/lux-lib/src/build/treesitter_parser.rs
+++ b/lux-lib/src/build/treesitter_parser.rs
@@ -1,9 +1,9 @@
 use crate::build::backend::{BuildBackend, BuildInfo, RunBuildArgs};
+use crate::fs;
 use crate::lua_rockspec::TreesitterParserBuildSpec;
 use crate::lua_version::LuaVersionUnset;
 use crate::tree::InstallTree;
 use miette::Diagnostic;
-use std::io;
 use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -29,22 +29,9 @@ pub enum TreesitterBuildError {
     #[error("error compiling the tree-sitter grammar: {0}")]
     #[diagnostic(help("run `lx debug toolchains` to check available build tools."))]
     TreesitterCompileError(String),
-    #[error("error creating directory {dir}: {err}")]
-    #[diagnostic(help("check that the parent directory exists and is writable."))]
-    CreateDir { dir: PathBuf, err: io::Error },
-    #[error("error writing query file: {0}")]
-    #[diagnostic(help("check that the output directory exists and is writable."))]
-    WriteQuery(io::Error),
-    #[error("error reading directory {dir}: {err}")]
-    #[diagnostic(help("ensure the directory exists and is accessible."))]
-    ReadDir { dir: PathBuf, err: io::Error },
-    #[error("error copying query file from {from} to {to}: {err}")]
-    #[diagnostic(help("ensure the source file exists and the destination is writable."))]
-    CopyQuery {
-        from: PathBuf,
-        to: PathBuf,
-        err: io::Error,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 impl BuildBackend for TreesitterParserBuildSpec {
@@ -102,17 +89,10 @@ async fn install_inline_queries(
     queries_dir: &Path,
     queries: std::collections::HashMap<PathBuf, String>,
 ) -> Result<(), TreesitterBuildError> {
-    tokio::fs::create_dir_all(queries_dir)
-        .await
-        .map_err(|err| TreesitterBuildError::CreateDir {
-            dir: queries_dir.to_path_buf(),
-            err,
-        })?;
+    fs::tokio::create_dir_all(queries_dir).await?;
     for (path, content) in queries {
         let dest = queries_dir.join(path);
-        tokio::fs::write(&dest, content)
-            .await
-            .map_err(TreesitterBuildError::WriteQuery)?;
+        fs::tokio::write(&dest, content).await?;
     }
     Ok(())
 }
@@ -122,37 +102,20 @@ async fn install_source_queries(
     source_queries_dir: &Path,
     queries_dir: &Path,
 ) -> Result<(), TreesitterBuildError> {
-    tokio::fs::create_dir_all(queries_dir)
+    fs::tokio::create_dir_all(queries_dir).await?;
+    let mut entries = fs::tokio::read_dir(source_queries_dir).await?;
+    while let Some(entry) = entries
+        .next_entry()
         .await
-        .map_err(|err| TreesitterBuildError::CreateDir {
-            dir: queries_dir.to_path_buf(),
-            err,
-        })?;
-    let mut entries = tokio::fs::read_dir(source_queries_dir)
-        .await
-        .map_err(|err| TreesitterBuildError::ReadDir {
-            dir: source_queries_dir.to_path_buf(),
-            err,
-        })?;
-    while let Some(entry) =
-        entries
-            .next_entry()
-            .await
-            .map_err(|err| TreesitterBuildError::ReadDir {
-                dir: source_queries_dir.to_path_buf(),
-                err,
-            })?
+        .map_err(|source| fs::FsError::ReadDir {
+            path: source_queries_dir.to_path_buf(),
+            source,
+        })?
     {
         let path = entry.path();
         if let Some(filename) = path.file_name().filter(|_| is_query_file(&path)) {
             let dest = queries_dir.join(filename);
-            tokio::fs::copy(&path, &dest)
-                .await
-                .map_err(|err| TreesitterBuildError::CopyQuery {
-                    from: path,
-                    to: dest,
-                    err,
-                })?;
+            fs::tokio::copy(&path, &dest).await?;
         }
     }
     Ok(())
@@ -186,12 +149,7 @@ async fn build_parser(
 ) -> Result<(), TreesitterBuildError> {
     let span = info_span!("Compiling tree-sitter parser", language = lang);
     let _enter = span.enter();
-    tokio::fs::create_dir_all(parser_dir)
-        .await
-        .map_err(|err| TreesitterBuildError::CreateDir {
-            dir: parser_dir.to_path_buf(),
-            err,
-        })?;
+    fs::tokio::create_dir_all(parser_dir).await?;
     let loader = tree_sitter_loader::Loader::with_parser_lib_path(build_dir.to_path_buf());
     let output_path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
     // HACK(vhyrro): `tree-sitter-loader` will only use a temp directory instead of a

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::Config,
+    fs,
     lua_installation::LuaInstallation,
     lua_rockspec::{DeploySpec, LuaModule, ModulePaths},
     path::{Paths, PathsError},
@@ -53,7 +54,7 @@ pub(crate) fn copy_lua_to_module_path(
     source: &PathBuf,
     target_module: &LuaModule,
     target_dir: &Path,
-) -> io::Result<()> {
+) -> Result<(), fs::FsError> {
     let span = span!(
         tracing::Level::TRACE,
         "Copying Lua module",
@@ -70,23 +71,10 @@ pub(crate) fn copy_lua_to_module_path(
     let target = target_dir.join(target_module_path);
 
     if let Some(parent) = target.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
-            io::Error::other(format!(
-                "Failed to create directory {}:\n{}",
-                parent.display(),
-                err
-            ))
-        })?;
+        fs::sync::create_dir_all(parent)?;
     }
 
-    std::fs::copy(source, &target).map_err(|err| {
-        io::Error::other(format!(
-            "Failed to copy {} to {}:\n{}",
-            source.display(),
-            target.display(),
-            err
-        ))
-    })?;
+    fs::sync::copy(source, &target)?;
 
     Ok(())
 }
@@ -94,17 +82,16 @@ pub(crate) fn copy_lua_to_module_path(
 /// Recursively copy a directory.
 /// This respects ignore files and excludes hidden files and directories.
 #[tracing::instrument(level = "trace")]
-pub(crate) async fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(), io::Error> {
+pub(crate) async fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(), fs::FsError> {
     if src.exists() {
         for file in project_files(src) {
-            let relative_src_path: PathBuf = pathdiff::diff_paths(src.join(&file), src).ok_or(
-                io::Error::other("failed to diff directories [THIS IS A BUG!]"),
-            )?;
+            let relative_src_path: PathBuf = pathdiff::diff_paths(src.join(&file), src)
+                .unwrap_or_else(|| unreachable!("diff_path with self"));
             let target = dest.join(relative_src_path);
             if let Some(parent) = target.parent() {
-                tokio::fs::create_dir_all(parent).await?;
+                fs::tokio::create_dir_all(parent).await?;
             }
-            tokio::fs::copy(&file, target).await?;
+            fs::tokio::copy(&file, target).await?;
         }
     }
     Ok(())
@@ -139,15 +126,16 @@ fn validate_output(output: &Output) -> Result<(), OutputValidationError> {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum CompileCFilesError {
-    #[error("IO operation while compiling C files:\n{0}")]
-    Io(#[from] io::Error),
-    #[error("failed to compile intermediates from C files:\n{0}")]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
+    #[error("failed to compile intermediates from C files")]
     #[diagnostic(help(
         r#"check the compiler output above for missing headers or syntax errors.
 ensure the C compiler has access to the required include paths."#
     ))]
-    CompileIntermediates(cc::Error),
-    #[error("error compiling C files (compilation failed):\n{0}")]
+    CompileIntermediates { source: cc::Error },
+    #[error("error compiling C files (compilation failed):")]
     #[diagnostic(help(
         r#"check the compiler output above for details.
 if no C compiler was found, run `lx debug toolchains` to verify your build tools."#
@@ -171,25 +159,26 @@ pub(crate) async fn compile_c_files(
     config: &Config,
 ) -> Result<(), CompileCFilesError> {
     let target = target_dir.join(target_module.to_lib_path());
-
-    let target_parent_dir = target.parent().ok_or(io::Error::other(format!(
-        "couldn't determine build target parent directory:\n{}",
-        target.display()
-    )))?;
+    let target_parent_dir = target.parent().unwrap_or_else(|| {
+        unreachable!(
+            "couldn't determine build target parent directory:\n{}",
+            target.display()
+        )
+    });
     let target_file_name = target
         .file_name()
         .unwrap_or_default()
         .to_string_lossy()
         .to_string();
 
-    std::fs::create_dir_all(target_parent_dir)?;
+    fs::sync::create_dir_all(target_parent_dir)?;
 
     let host = Triple::host();
 
     // See https://github.com/rust-lang/cc-rs/issues/594#issuecomment-2110551057
 
     let mut build = cc::Build::new();
-    let intermediate_dir = tempfile::tempdir()?;
+    let intermediate_dir = fs::tempfile::tempdir()?;
     let build = build
         .cargo_output(config.verbose())
         .cargo_debug(config.verbose())
@@ -221,7 +210,7 @@ pub(crate) async fn compile_c_files(
 
     let objects = build
         .try_compile_objects(config)
-        .map_err(CompileCFilesError::CompileIntermediates)?;
+        .map_err(|source| CompileCFilesError::CompileIntermediates { source })?;
 
     link_c_artifacts(
         build,
@@ -245,7 +234,7 @@ fn mk_def_file(
     dir: &Path,
     output_file_name: &str,
     target_module: &LuaModule,
-) -> io::Result<PathBuf> {
+) -> Result<PathBuf, fs::FsError> {
     let mut def_file: PathBuf = dir.join(output_file_name);
     def_file.set_extension(".def");
     let exported_name = target_module.to_string().replace(".", "_");
@@ -258,7 +247,7 @@ fn mk_def_file(
 luaopen_{exported_name}
 "#,
     );
-    std::fs::write(&def_file, content)?;
+    fs::sync::write(&def_file, content)?;
     Ok(def_file)
 }
 
@@ -312,8 +301,9 @@ pub(crate) fn default_libflag() -> &'static str {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum CompileCModulesError {
-    #[error("IO operation failed while compiling C modules:\n{0}")]
-    Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("failed to compile intermediates from C modules: {0}")]
     #[diagnostic(help(
         r#"check the compiler output above for missing headers or syntax errors.
@@ -339,6 +329,9 @@ if no C compiler was found, run `lx debug toolchains` to verify your build tools
 pub enum LinkCModulesError {
     #[error("IO operation failed while linking C modules:\n{0}")]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     CC(#[from] cc::Error),
     #[error("error compiling C modules (output validation failed): {0}")]
@@ -366,12 +359,14 @@ pub(crate) async fn compile_c_modules(
 ) -> Result<(), CompileCModulesError> {
     let target = target_dir.join(target_module.to_lib_path());
 
-    let target_parent_dir = target.parent().ok_or(io::Error::other(format!(
-        "couldn't determine build target parent directory:\n{}",
-        target.display()
-    )))?;
+    let target_parent_dir = target.parent().unwrap_or_else(|| {
+        unreachable!(
+            "couldn't determine build target parent directory:\n{}",
+            target.display()
+        )
+    });
 
-    tokio::fs::create_dir_all(target_parent_dir).await?;
+    fs::tokio::create_dir_all(target_parent_dir).await?;
 
     let host = Triple::host();
 
@@ -408,7 +403,7 @@ pub(crate) async fn compile_c_modules(
         .unique() // Some rocks specify the include dirs via variable substitution.
         .collect_vec();
 
-    let intermediate_dir = tempfile::tempdir()?;
+    let intermediate_dir = fs::tempfile::tempdir()?;
     let build = build
         .cargo_output(config.verbose())
         .cargo_debug(config.verbose())
@@ -530,11 +525,7 @@ async fn link_c_artifacts(
     // Linking from within a temp directory makes sure the linker doesn't create any build artifacts in
     // the current working directory.
     // See https://github.com/lumen-oss/lux/issues/1106
-    let temp_work_dir = tempfile::tempdir().map_err(|err| {
-        io::Error::other(format!(
-            "failed to create temporary directory for linking:\n{err}"
-        ))
-    })?;
+    let temp_work_dir = fs::tempfile::tempdir()?;
     let is_msvc = compiler.is_like_msvc();
     let cmd = build.try_get_compiler()?.to_command();
     let mut cmd: tokio::process::Command = cmd.into();
@@ -609,7 +600,8 @@ fn add_variable_if_set(config: &Config, name: &str, cmd: &mut Command) {
 #[derive(Debug, Error, Diagnostic)]
 pub enum InstallBinaryError {
     #[error(transparent)]
-    Io(#[from] io::Error),
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Paths(#[from] PathsError),
@@ -621,7 +613,8 @@ pub enum InstallBinaryError {
 #[derive(Debug, Error, Diagnostic)]
 pub enum WrapBinaryError {
     #[error(transparent)]
-    Io(#[from] io::Error),
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     Utf8(#[from] FromUtf8Error),
     #[error("no Lua executable found")]
@@ -648,7 +641,7 @@ pub(crate) async fn install_binary(
         target,
     );
     let _enter = span.enter();
-    tokio::fs::create_dir_all(&tree.bin()).await?;
+    fs::tokio::create_dir_all(&tree.bin()).await?;
     let paths = Paths::new(tree)?;
     let script = if config.wrap_bin_scripts()
         && deploy.wrap_bin_scripts
@@ -657,7 +650,7 @@ pub(crate) async fn install_binary(
         install_wrapped_binary(source, target, tree, lua, config).await?
     } else {
         let target = tree.bin().join(target);
-        tokio::fs::copy(source, &target).await?;
+        fs::tokio::copy(source, &target).await?;
         target
     };
 
@@ -690,9 +683,9 @@ async fn install_wrapped_binary(
     config: &Config,
 ) -> Result<PathBuf, WrapBinaryError> {
     let unwrapped_bin_dir = tree.unwrapped_bin();
-    tokio::fs::create_dir_all(&unwrapped_bin_dir).await?;
+    fs::tokio::create_dir_all(&unwrapped_bin_dir).await?;
     let unwrapped_bin = unwrapped_bin_dir.join(target);
-    tokio::fs::copy(source, &unwrapped_bin).await?;
+    fs::tokio::copy(source, &unwrapped_bin).await?;
 
     #[cfg(target_family = "unix")]
     let target = tree.bin().join(target);
@@ -739,16 +732,16 @@ exit /b %ERRORLEVEL%
         unwrapped_bin.display(),
     );
 
-    tokio::fs::write(&target, content).await?;
+    fs::tokio::write(&target, content).await?;
     Ok(target)
 }
 
 #[cfg(unix)]
 #[tracing::instrument(level = "trace")]
-async fn set_executable_permissions(script: &Path) -> std::io::Result<()> {
-    let mut perms = tokio::fs::metadata(&script).await?.permissions();
+async fn set_executable_permissions(script: &Path) -> Result<(), fs::FsError> {
+    let mut perms = fs::tokio::metadata(&script).await?.permissions();
     perms.set_mode(0o744);
-    tokio::fs::set_permissions(&script, perms).await?;
+    fs::tokio::set_permissions(&script, perms).await?;
     Ok(())
 }
 
@@ -805,7 +798,7 @@ async fn is_compatible_lua_script_fallback(
     lua_installation: &LuaInstallation,
     config: &Config,
 ) -> bool {
-    if let Ok(file_content) = tokio::fs::read_to_string(&file).await {
+    if let Ok(file_content) = fs::tokio::read_to_string(&file).await {
         let file_content_without_comments = file_content
             .lines()
             .filter(|line| !line.trim_start().starts_with("#"))

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -4,11 +4,12 @@ use itertools::Itertools;
 
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize, Serializer};
-use std::{collections::HashMap, env, io, path::PathBuf, time::Duration};
+use std::{collections::HashMap, env, path::PathBuf, time::Duration};
 use thiserror::Error;
 use tree::RockLayoutConfig;
 use url::Url;
 
+use crate::fs;
 use crate::lua_version::LuaVersion;
 use crate::project::TomlDeError;
 use crate::tree::{Tree, TreeError};
@@ -262,13 +263,9 @@ impl HasVariables for Config {
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum ConfigError {
-    #[error("failed to read config file {config_file}")]
-    ConfigRead {
-        config_file: String,
-        source: io::Error,
-        #[help]
-        help: Option<String>,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     NoValidHomeDirectory(#[from] NoValidHomeDirectory),
@@ -338,16 +335,7 @@ impl ConfigBuilder {
         let config_file = Self::config_file()?;
         if config_file.is_file() {
             let config_file_name = config_file.to_string_lossy().to_string();
-            let content = std::fs::read_to_string(&config_file).map_err(|source| {
-                ConfigError::ConfigRead {
-                    config_file: config_file_name.clone(),
-                    source,
-                    help: Some(format!(
-                        "check that {} exists and is readable",
-                        config_file.display()
-                    )),
-                }
-            })?;
+            let content = fs::sync::read_to_string(&config_file)?;
             crate::project::parse_toml(&config_file_name, &content).map_err(|source| {
                 ConfigError::Deserialize {
                     config_file: config_file_name,

--- a/lux-lib/src/fs/mod.rs
+++ b/lux-lib/src/fs/mod.rs
@@ -2,6 +2,7 @@ use miette::Diagnostic;
 use thiserror::Error;
 
 pub mod sync;
+pub mod tempfile;
 pub mod tokio;
 
 #[derive(Debug, Error, Diagnostic)]
@@ -53,6 +54,12 @@ pub enum FsError {
         path: std::path::PathBuf,
         source: std::io::Error,
     },
+    #[error("failed to create a temporaty directory")]
+    #[diagnostic(
+        code(lux_lib::fs::create_tempdir),
+        help("ensure the '{}' exists and is writable", std::env::temp_dir().display())
+    )]
+    CreateTempDir { source: std::io::Error },
     #[error("failed to create directory tree '{}'", path.display())]
     #[diagnostic(
         code(lux_lib::fs::create_dir_all),

--- a/lux-lib/src/fs/mod.rs
+++ b/lux-lib/src/fs/mod.rs
@@ -1,0 +1,138 @@
+use miette::Diagnostic;
+use thiserror::Error;
+
+pub mod sync;
+pub mod tokio;
+
+#[derive(Debug, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum FsError {
+    #[error("failed to read file '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::read),
+        help("ensure '{}' exists and is readable", path.display())
+    )]
+    Read {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to read '{}' as UTF-8 string", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::read_to_string),
+        help("ensure '{}' exists, is readable, and contains valid UTF-8", path.display())
+    )]
+    ReadToString {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to write to '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::write),
+        help("ensure the parent directory of '{}' exists and is writable", path.display())
+    )]
+    Write {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to copy '{}' to '{}'", from.display(), to.display())]
+    #[diagnostic(
+        code(lux_lib::fs::copy),
+        help("ensure '{}' exists and the parent directory of '{}' is writable", from.display(), to.display())
+    )]
+    Copy {
+        from: std::path::PathBuf,
+        to: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to create directory '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::create_dir),
+        help("ensure the parent directory of '{}' exists and is writable", path.display())
+    )]
+    CreateDir {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to create directory tree '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::create_dir_all),
+        help("ensure the path to '{}' is accessible", path.display())
+    )]
+    CreateDirAll {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to remove file '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::remove_file),
+        help("ensure '{}' exists and is writable", path.display())
+    )]
+    RemoveFile {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to remove directory '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::remove_dir_all),
+        help("ensure '{}' exists and is writable", path.display())
+    )]
+    RemoveDirAll {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to read directory '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::read_dir),
+        help("ensure '{}' exists and is a directory", path.display())
+    )]
+    ReadDir {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to get metadata for '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::metadata),
+        help("ensure '{}' exists", path.display())
+    )]
+    Metadata {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to rename '{}' to '{}'", from.display(), to.display())]
+    #[diagnostic(
+        code(lux_lib::fs::rename),
+        help("ensure '{}' exists and the parent directory of '{}' is writable", from.display(), to.display())
+    )]
+    Rename {
+        from: std::path::PathBuf,
+        to: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to set permissions on '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::set_permissions),
+        help("ensure '{}' exists and is writable", path.display())
+    )]
+    SetPermissions {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to open file '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::file_open),
+        help("ensure '{}' exists and is readable", path.display())
+    )]
+    FileOpen {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to create file '{}'", path.display())]
+    #[diagnostic(
+        code(lux_lib::fs::file_create),
+        help("ensure the parent directory of '{}' exists and is writable", path.display())
+    )]
+    FileCreate {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+}

--- a/lux-lib/src/fs/sync.rs
+++ b/lux-lib/src/fs/sync.rs
@@ -1,0 +1,134 @@
+use std::{fs, path::Path};
+
+use super::FsError;
+
+/// Wrapped [`fs::read`].
+pub(crate) fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, FsError> {
+    let path = path.as_ref();
+    fs::read(path).map_err(|source| FsError::Read {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::read_to_string`].
+pub(crate) fn read_to_string(path: impl AsRef<Path>) -> Result<String, FsError> {
+    let path = path.as_ref();
+    fs::read_to_string(path).map_err(|source| FsError::ReadToString {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::write`].
+pub(crate) fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::write(path, contents).map_err(|source| FsError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::copy`].
+pub(crate) fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64, FsError> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::copy(from, to).map_err(|source| FsError::Copy {
+        from: from.to_path_buf(),
+        to: to.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::create_dir`].
+pub(crate) fn create_dir(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::create_dir(path).map_err(|source| FsError::CreateDir {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::create_dir_all`].
+pub(crate) fn create_dir_all(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::create_dir_all(path).map_err(|source| FsError::CreateDirAll {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::remove_file`].
+pub(crate) fn remove_file(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::remove_file(path).map_err(|source| FsError::RemoveFile {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::remove_dir_all`].
+pub(crate) fn remove_dir_all(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::remove_dir_all(path).map_err(|source| FsError::RemoveDirAll {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::read_dir`].
+pub(crate) fn read_dir(path: impl AsRef<Path>) -> Result<fs::ReadDir, FsError> {
+    let path = path.as_ref();
+    fs::read_dir(path).map_err(|source| FsError::ReadDir {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::metadata`].
+pub(crate) fn metadata(path: impl AsRef<Path>) -> Result<fs::Metadata, FsError> {
+    let path = path.as_ref();
+    fs::metadata(path).map_err(|source| FsError::Metadata {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::rename`].
+pub(crate) fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), FsError> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::rename(from, to).map_err(|source| FsError::Rename {
+        from: from.to_path_buf(),
+        to: to.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::set_permissions`].
+pub(crate) fn set_permissions(path: impl AsRef<Path>, perm: fs::Permissions) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::set_permissions(path, perm).map_err(|source| FsError::SetPermissions {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::File::open`].
+pub(crate) fn open(path: impl AsRef<Path>) -> Result<fs::File, FsError> {
+    let path = path.as_ref();
+    fs::File::open(path).map_err(|source| FsError::FileOpen {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::File::create`].
+pub(crate) fn create(path: impl AsRef<Path>) -> Result<fs::File, FsError> {
+    let path = path.as_ref();
+    fs::File::create(path).map_err(|source| FsError::FileCreate {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+

--- a/lux-lib/src/fs/sync.rs
+++ b/lux-lib/src/fs/sync.rs
@@ -2,15 +2,6 @@ use std::{fs, path::Path};
 
 use super::FsError;
 
-/// Wrapped [`fs::read`].
-pub(crate) fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, FsError> {
-    let path = path.as_ref();
-    fs::read(path).map_err(|source| FsError::Read {
-        path: path.to_path_buf(),
-        source,
-    })
-}
-
 /// Wrapped [`fs::read_to_string`].
 pub(crate) fn read_to_string(path: impl AsRef<Path>) -> Result<String, FsError> {
     let path = path.as_ref();
@@ -36,15 +27,6 @@ pub(crate) fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64, 
     fs::copy(from, to).map_err(|source| FsError::Copy {
         from: from.to_path_buf(),
         to: to.to_path_buf(),
-        source,
-    })
-}
-
-/// Wrapped [`fs::create_dir`].
-pub(crate) fn create_dir(path: impl AsRef<Path>) -> Result<(), FsError> {
-    let path = path.as_ref();
-    fs::create_dir(path).map_err(|source| FsError::CreateDir {
-        path: path.to_path_buf(),
         source,
     })
 }
@@ -85,35 +67,6 @@ pub(crate) fn read_dir(path: impl AsRef<Path>) -> Result<fs::ReadDir, FsError> {
     })
 }
 
-/// Wrapped [`fs::metadata`].
-pub(crate) fn metadata(path: impl AsRef<Path>) -> Result<fs::Metadata, FsError> {
-    let path = path.as_ref();
-    fs::metadata(path).map_err(|source| FsError::Metadata {
-        path: path.to_path_buf(),
-        source,
-    })
-}
-
-/// Wrapped [`fs::rename`].
-pub(crate) fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), FsError> {
-    let from = from.as_ref();
-    let to = to.as_ref();
-    fs::rename(from, to).map_err(|source| FsError::Rename {
-        from: from.to_path_buf(),
-        to: to.to_path_buf(),
-        source,
-    })
-}
-
-/// Wrapped [`fs::set_permissions`].
-pub(crate) fn set_permissions(path: impl AsRef<Path>, perm: fs::Permissions) -> Result<(), FsError> {
-    let path = path.as_ref();
-    fs::set_permissions(path, perm).map_err(|source| FsError::SetPermissions {
-        path: path.to_path_buf(),
-        source,
-    })
-}
-
 /// Wrapped [`fs::File::open`].
 pub(crate) fn open(path: impl AsRef<Path>) -> Result<fs::File, FsError> {
     let path = path.as_ref();
@@ -131,4 +84,3 @@ pub(crate) fn create(path: impl AsRef<Path>) -> Result<fs::File, FsError> {
         source,
     })
 }
-

--- a/lux-lib/src/fs/tempfile.rs
+++ b/lux-lib/src/fs/tempfile.rs
@@ -1,0 +1,8 @@
+use tempfile::TempDir;
+
+use crate::fs::FsError;
+
+/// Wrapped [`tempfile::tempdir`].
+pub(crate) fn tempdir() -> Result<TempDir, FsError> {
+    tempfile::tempdir().map_err(|source| FsError::CreateTempDir { source })
+}

--- a/lux-lib/src/fs/tokio.rs
+++ b/lux-lib/src/fs/tokio.rs
@@ -1,0 +1,157 @@
+use std::{fs::Permissions, path::Path};
+
+use tokio::fs;
+
+use super::FsError;
+
+/// Wrapped [`fs::read`].
+pub(crate) async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, FsError> {
+    let path = path.as_ref();
+    fs::read(path).await.map_err(|source| FsError::Read {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::read_to_string`].
+pub(crate) async fn read_to_string(path: impl AsRef<Path>) -> Result<String, FsError> {
+    let path = path.as_ref();
+    fs::read_to_string(path)
+        .await
+        .map_err(|source| FsError::ReadToString {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::write`].
+pub(crate) async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::write(path, contents)
+        .await
+        .map_err(|source| FsError::Write {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::copy`].
+pub(crate) async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64, FsError> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::copy(from, to).await.map_err(|source| FsError::Copy {
+        from: from.to_path_buf(),
+        to: to.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::create_dir`].
+pub(crate) async fn create_dir(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::create_dir(path)
+        .await
+        .map_err(|source| FsError::CreateDir {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::create_dir_all`].
+pub(crate) async fn create_dir_all(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::create_dir_all(path)
+        .await
+        .map_err(|source| FsError::CreateDirAll {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::remove_file`].
+pub(crate) async fn remove_file(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::remove_file(path)
+        .await
+        .map_err(|source| FsError::RemoveFile {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::remove_dir_all`].
+pub(crate) async fn remove_dir_all(path: impl AsRef<Path>) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::remove_dir_all(path)
+        .await
+        .map_err(|source| FsError::RemoveDirAll {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::read_dir`].
+pub(crate) async fn read_dir(path: impl AsRef<Path>) -> Result<tokio::fs::ReadDir, FsError> {
+    let path = path.as_ref();
+    fs::read_dir(path).await.map_err(|source| FsError::ReadDir {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Wrapped [`fs::metadata`].
+pub(crate) async fn metadata(path: impl AsRef<Path>) -> Result<std::fs::Metadata, FsError> {
+    let path = path.as_ref();
+    fs::metadata(path)
+        .await
+        .map_err(|source| FsError::Metadata {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::rename`].
+pub(crate) async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), FsError> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::rename(from, to)
+        .await
+        .map_err(|source| FsError::Rename {
+            from: from.to_path_buf(),
+            to: to.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::set_permissions`].
+pub(crate) async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> Result<(), FsError> {
+    let path = path.as_ref();
+    fs::set_permissions(path, perm)
+        .await
+        .map_err(|source| FsError::SetPermissions {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::File::open`].
+pub(crate) async fn open(path: impl AsRef<Path>) -> Result<fs::File, FsError> {
+    let path = path.as_ref();
+    fs::File::open(path)
+        .await
+        .map_err(|source| FsError::FileOpen {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Wrapped [`fs::File::create`].
+pub(crate) async fn create(path: impl AsRef<Path>) -> Result<fs::File, FsError> {
+    let path = path.as_ref();
+    fs::File::create(path)
+        .await
+        .map_err(|source| FsError::FileCreate {
+            path: path.to_path_buf(),
+            source,
+        })
+}

--- a/lux-lib/src/fs/tokio.rs
+++ b/lux-lib/src/fs/tokio.rs
@@ -1,8 +1,8 @@
-use std::{fs::Permissions, path::Path};
-
-use tokio::fs;
-
 use super::FsError;
+#[cfg(unix)]
+use std::fs::Permissions;
+use std::path::Path;
+use tokio::fs;
 
 /// Wrapped [`fs::read`].
 pub(crate) async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, FsError> {
@@ -25,7 +25,10 @@ pub(crate) async fn read_to_string(path: impl AsRef<Path>) -> Result<String, FsE
 }
 
 /// Wrapped [`fs::write`].
-pub(crate) async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), FsError> {
+pub(crate) async fn write(
+    path: impl AsRef<Path>,
+    contents: impl AsRef<[u8]>,
+) -> Result<(), FsError> {
     let path = path.as_ref();
     fs::write(path, contents)
         .await
@@ -44,17 +47,6 @@ pub(crate) async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result
         to: to.to_path_buf(),
         source,
     })
-}
-
-/// Wrapped [`fs::create_dir`].
-pub(crate) async fn create_dir(path: impl AsRef<Path>) -> Result<(), FsError> {
-    let path = path.as_ref();
-    fs::create_dir(path)
-        .await
-        .map_err(|source| FsError::CreateDir {
-            path: path.to_path_buf(),
-            source,
-        })
 }
 
 /// Wrapped [`fs::create_dir_all`].
@@ -124,7 +116,11 @@ pub(crate) async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Resu
 }
 
 /// Wrapped [`fs::set_permissions`].
-pub(crate) async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> Result<(), FsError> {
+#[cfg(unix)]
+pub(crate) async fn set_permissions(
+    path: impl AsRef<Path>,
+    perm: Permissions,
+) -> Result<(), FsError> {
     let path = path.as_ref();
     fs::set_permissions(path, perm)
         .await

--- a/lux-lib/src/git/utils.rs
+++ b/lux-lib/src/git/utils.rs
@@ -1,16 +1,14 @@
-use std::io;
-
-use crate::git::url::RemoteGitUrl;
+use crate::{fs, git::url::RemoteGitUrl};
 use git2::{AutotagOption, Cred, FetchOptions, RemoteCallbacks, Repository};
 use itertools::Itertools;
 use miette::Diagnostic;
-use tempfile::tempdir;
 use thiserror::Error;
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum GitError {
-    #[error("error creating temporary directory to checkout git repositotory: {0}")]
-    CreateTempDir(io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("error initializing temporary bare git repository to fetch metadata: {0}")]
     BareRepoInit(git2::Error),
     #[error("error initializing remote repository '{0}' to fetch metadata: {1}")]
@@ -43,7 +41,7 @@ pub(crate) fn latest_semver_tag_or_commit_sha(
 
 #[tracing::instrument(level = "trace")]
 fn latest_semver_tag(url: &RemoteGitUrl) -> Result<Option<String>, GitError> {
-    let temp_dir = tempdir().map_err(GitError::CreateTempDir)?;
+    let temp_dir = fs::tempfile::tempdir()?;
 
     let url_str = url.to_string();
     let repo = Repository::init_bare(&temp_dir).map_err(GitError::BareRepoInit)?;
@@ -82,7 +80,7 @@ fn latest_semver_tag(url: &RemoteGitUrl) -> Result<Option<String>, GitError> {
 }
 
 fn latest_commit_sha(url: &RemoteGitUrl) -> Result<Option<String>, GitError> {
-    let temp_dir = tempdir().map_err(GitError::CreateTempDir)?;
+    let temp_dir = fs::tempfile::tempdir()?;
     let url_str = url.to_string();
     let repo = Repository::init_bare(&temp_dir).map_err(GitError::BareRepoInit)?;
     let mut remote = repo

--- a/lux-lib/src/lib.rs
+++ b/lux-lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod config;
+pub mod fs;
 pub mod git;
 pub mod hash;
 pub mod lockfile;

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 use url::Url;
 
 use crate::config::tree::RockLayoutConfig;
+use crate::fs;
 use crate::package::{
     PackageName, PackageReq, PackageSpec, PackageVersion, PackageVersionReq,
     PackageVersionReqError, RemotePackageTypeFilterSpec,
@@ -781,10 +782,9 @@ pub struct WorkspaceLockfile<P: LockfilePermissions> {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum LockfileError {
-    #[error("error loading lockfile: {0}")]
-    Load(io::Error),
-    #[error("error creating lockfile: {0}")]
-    Create(io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("error parsing lockfile from JSON: {0}")]
     ParseJson(serde_json::Error),
     #[error("error writing lockfile to JSON: {0}")]
@@ -835,10 +835,11 @@ check the source URL, then rerun the command with `lx --no-lock` to update the h
 
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
-#[error("error flushing the lockfile ({filepath}):\n{cause}")]
+#[error("error flushing the lockfile ({})", .filepath.display())]
+#[diagnostic(help("make sure the parent directory is writeable"))]
 pub struct FlushLockfileError {
-    filepath: String,
-    cause: io::Error,
+    filepath: PathBuf,
+    source: io::Error,
 }
 
 /// A specification for syncing a list of packages with a lockfile
@@ -971,13 +972,13 @@ impl<P: LockfilePermissions> Lockfile<P> {
 
     fn flush(&self) -> Result<(), FlushLockfileError> {
         let content = serde_json::to_string_pretty(&self).map_err(|err| FlushLockfileError {
-            filepath: self.filepath.to_string_lossy().to_string(),
-            cause: io::Error::other(err),
+            filepath: self.filepath.to_path_buf(),
+            source: io::Error::other(err),
         })?;
 
-        std::fs::write(&self.filepath, content).map_err(|err| FlushLockfileError {
-            filepath: self.filepath.to_string_lossy().to_string(),
-            cause: err,
+        fs::sync::write(&self.filepath, content).map_err(|err| FlushLockfileError {
+            filepath: self.filepath.to_path_buf(),
+            source: io::Error::other(err),
         })
     }
 }
@@ -1048,7 +1049,7 @@ impl<P: LockfilePermissions> WorkspaceLockfile<P> {
     fn flush(&self) -> io::Result<()> {
         let content = serde_json::to_string_pretty(&self)?;
 
-        std::fs::write(&self.filepath, content)?;
+        fs::sync::write(&self.filepath, content).map_err(io::Error::other)?;
 
         Ok(())
     }
@@ -1073,10 +1074,18 @@ impl Lockfile<ReadOnly> {
                 };
                 let json_str =
                     serde_json::to_string(&empty_lockfile).map_err(LockfileError::WriteJson)?;
-                write!(file, "{json_str}").map_err(LockfileError::Create)?;
+                write!(file, "{json_str}").map_err(|source| fs::FsError::Write {
+                    path: filepath.to_path_buf(),
+                    source,
+                })?;
             }
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
-            Err(err) => return Err(LockfileError::Create(err)),
+            Err(source) => {
+                return Err(LockfileError::Fs(fs::FsError::FileOpen {
+                    path: filepath.to_path_buf(),
+                    source,
+                }))
+            }
         }
 
         Self::load(filepath, Some(&rock_layout))
@@ -1089,7 +1098,7 @@ impl Lockfile<ReadOnly> {
         filepath: PathBuf,
         expected_rock_layout: Option<&RockLayoutConfig>,
     ) -> Result<Lockfile<ReadOnly>, LockfileError> {
-        let content = std::fs::read_to_string(&filepath).map_err(LockfileError::Load)?;
+        let content = fs::sync::read_to_string(&filepath)?;
         let mut lockfile: Lockfile<ReadOnly> =
             serde_json::from_str(&content).map_err(LockfileError::ParseJson)?;
         lockfile.filepath = filepath;
@@ -1131,8 +1140,8 @@ impl Lockfile<ReadOnly> {
         let mut writeable_lockfile = self.into_temporary();
 
         let result = cb(&mut writeable_lockfile).map_err(|err| FlushLockfileError {
-            filepath: writeable_lockfile.filepath.to_string_lossy().to_string(),
-            cause: io::Error::other(err),
+            filepath: writeable_lockfile.filepath.to_path_buf(),
+            source: io::Error::other(err),
         })?;
 
         writeable_lockfile.flush()?;
@@ -1176,10 +1185,18 @@ impl WorkspaceLockfile<ReadOnly> {
                 };
                 let json_str =
                     serde_json::to_string(&empty_lockfile).map_err(LockfileError::WriteJson)?;
-                write!(file, "{json_str}").map_err(LockfileError::Create)?;
+                write!(file, "{json_str}").map_err(|source| fs::FsError::Write {
+                    path: filepath.to_path_buf(),
+                    source,
+                })?;
             }
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
-            Err(err) => return Err(LockfileError::Create(err)),
+            Err(source) => {
+                return Err(LockfileError::Fs(fs::FsError::FileOpen {
+                    path: filepath.to_path_buf(),
+                    source,
+                }))
+            }
         }
 
         Self::load(filepath)
@@ -1188,7 +1205,7 @@ impl WorkspaceLockfile<ReadOnly> {
     /// Load a `ProjectLockfile`, failing if none exists.
     #[tracing::instrument(level = "trace")]
     pub fn load(filepath: PathBuf) -> Result<WorkspaceLockfile<ReadOnly>, LockfileError> {
-        let content = std::fs::read_to_string(&filepath).map_err(LockfileError::Load)?;
+        let content = fs::sync::read_to_string(&filepath)?;
         let mut lockfile: WorkspaceLockfile<ReadOnly> =
             serde_json::from_str(&content).map_err(LockfileError::ParseJson)?;
 

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -14,6 +14,7 @@ use crate::build::external_dependency::to_lib_name;
 use crate::build::external_dependency::ExternalDependencyInfo;
 use crate::build::utils::{c_lib_extension, format_path};
 use crate::config::external_deps::ExternalDependencySearchConfig;
+use crate::fs;
 use crate::lua_rockspec::ExternalDependencySpec;
 use crate::lua_version::LuaVersion;
 use crate::lua_version::LuaVersionUnset;
@@ -402,7 +403,7 @@ pub fn detect_installed_lua_version() -> Option<LuaVersion> {
 }
 
 fn find_lua_executable(bin_path: &Path, version: &LuaVersion) -> Option<PathBuf> {
-    std::fs::read_dir(bin_path).ok().and_then(|entries| {
+    fs::sync::read_dir(bin_path).ok().and_then(|entries| {
         let bin_files = entries
             .filter_map(Result::ok)
             .map(|entry| entry.path().to_path_buf())
@@ -467,7 +468,7 @@ fn is_lua_lib_name(name: &str, lua_version: &LuaVersion) -> bool {
 }
 
 fn get_lua_lib_name(lib_dir: &Path, lua_version: &LuaVersion) -> Option<String> {
-    std::fs::read_dir(lib_dir)
+    fs::sync::read_dir(lib_dir)
         .ok()
         .and_then(|entries| {
             entries

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -22,10 +22,9 @@ use crate::{
     rockspec::Rockspec,
     tree::{self, InstallTree, TreeError},
 };
-use crate::{lockfile::RemotePackageSourceUrl, rockspec::LuaVersionCompatibility};
+use crate::{fs, lockfile::RemotePackageSourceUrl, rockspec::LuaVersionCompatibility};
 use bytes::Bytes;
 use miette::Diagnostic;
-use tempfile::tempdir;
 use thiserror::Error;
 
 use super::rock_manifest::RockManifestError;
@@ -35,6 +34,9 @@ use super::rock_manifest::RockManifestError;
 pub enum InstallBinaryRockError {
     #[error("IO operation failed: {0}")]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
@@ -150,7 +152,7 @@ where
         match self.tree.lockfile()?.get(&package.id()) {
             Some(package) if self.behaviour == BuildBehaviour::NoForce => Ok(package.clone()),
             _ => {
-                let unpack_dir = tempdir()?;
+                let unpack_dir = fs::tempfile::tempdir()?;
                 let cursor = Cursor::new(self.rock_bytes);
                 let mut zip = zip::ZipArchive::new(cursor)?;
                 zip.extract(&unpack_dir)?;
@@ -163,7 +165,7 @@ where
                 if !rock_manifest_file.is_file() {
                     return Err(InstallBinaryRockError::RockManifestNotFound);
                 }
-                let rock_manifest_content = tokio::fs::read_to_string(rock_manifest_file).await?;
+                let rock_manifest_content = fs::tokio::read_to_string(rock_manifest_file).await?;
                 let output_paths = match self.entry_type {
                     tree::EntryType::Entrypoint => self.tree.entrypoint(&package)?,
                     tree::EntryType::DependencyOnly => self.tree.dependency(&package)?,
@@ -206,8 +208,8 @@ where
                     package.version()
                 ));
                 if rockspec_path.is_file() {
-                    tokio::fs::copy(&rockspec_path, output_paths.rockspec_path()).await?;
-                    tokio::fs::remove_file(&rockspec_path).await?;
+                    fs::tokio::copy(&rockspec_path, output_paths.rockspec_path()).await?;
+                    fs::tokio::remove_file(&rockspec_path).await?;
                 }
                 Ok(package)
             }
@@ -228,11 +230,11 @@ async fn install_manifest_entries<T>(
             recursive_copy_dir(&src_path, &target).await?;
         } else if src_path.is_file() {
             if let Some(target_parent_dir) = target.parent() {
-                tokio::fs::create_dir_all(target_parent_dir).await?;
+                fs::tokio::create_dir_all(target_parent_dir).await?;
             }
-            tokio::fs::copy(src.join(relative_src_path), target).await?;
+            fs::tokio::copy(src.join(relative_src_path), target).await?;
         } else {
-            let metadata = tokio::fs::metadata(&src_path).await?;
+            let metadata = fs::tokio::metadata(&src_path).await?;
             return Err(InstallBinaryRockError::NotAFileOrDirectory(
                 src_path.to_string_lossy().to_string(),
                 metadata,

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -6,13 +6,13 @@ use std::{
     path::{Path, PathBuf},
     process::ExitStatus,
 };
-use tempfile::tempdir;
 use thiserror::Error;
 use tokio::process::Command;
 
 use crate::{
     build::{self, BuildError},
     config::Config,
+    fs,
     lua_installation::LuaInstallation,
     lua_version::{LuaVersion, LuaVersionUnset},
     operations::UnpackError,
@@ -66,8 +66,11 @@ pub enum LuaRocksError {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum LuaRocksInstallError {
-    #[error(transparent)]
+    #[error("IO error occurred while trying to install luarocks")]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Tree(#[from] TreeError),
@@ -89,14 +92,14 @@ pub enum ExecLuaRocksError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
-    #[error("could not write luarocks config at '{path}'")]
-    #[diagnostic(help("make sure Lux has write access to the parent directory"))]
-    WriteLuarocksConfigError { path: PathBuf, source: io::Error },
     #[error("could not substitute '$(LUA_LIBDIR)' and '$(LUA_INCDIR)' variables in the luarocks config template")]
     #[diagnostic(forward(0))]
     VariableSubstitutionInConfig(#[from] VariableSubstitutionError),
     #[error("failed to run luarocks")]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("error setting up luarocks paths")]
     #[diagnostic(forward(0))]
     Paths(#[from] PathsError),
@@ -190,7 +193,7 @@ impl LuaRocksInstallation {
         }
         let cursor = Cursor::new(response);
         let mime_type = infer::get(cursor.get_ref()).map(|file_type| file_type.mime_type());
-        let unpack_dir = tempdir()?;
+        let unpack_dir = fs::tempfile::tempdir()?;
         operations::unpack(
             mime_type,
             cursor,
@@ -200,7 +203,7 @@ impl LuaRocksInstallation {
         )
         .await?;
         let luarocks_exe = unpack_dir.path().join(file_name).join(LUAROCKS_EXE);
-        tokio::fs::copy(luarocks_exe, &self.tree.bin().join(LUAROCKS_EXE)).await?;
+        fs::tokio::copy(luarocks_exe, &self.tree.bin().join(LUAROCKS_EXE)).await?;
 
         Ok(())
     }
@@ -213,7 +216,7 @@ impl LuaRocksInstallation {
         dest_dir: &Path,
         lua: &LuaInstallation,
     ) -> Result<(), ExecLuaRocksError> {
-        std::fs::create_dir_all(dest_dir)?;
+        fs::sync::create_dir_all(dest_dir)?;
         let dest_dir_str = dest_dir.to_slash_lossy().to_string();
         let rockspec_path_str = rockspec_path.to_slash_lossy().to_string();
         let args = vec![
@@ -235,7 +238,7 @@ impl LuaRocksInstallation {
     ) -> Result<(), ExecLuaRocksError> {
         let luarocks_paths = Paths::new(&self.tree)?;
         // Ensure a pure environment so we can do parallel builds
-        let temp_dir = tempdir()?;
+        let temp_dir = fs::tempfile::tempdir()?;
         let lua_version_str = match lua.version {
             LuaVersion::Lua51 | LuaVersion::LuaJIT => "5.1",
             LuaVersion::Lua52 | LuaVersion::LuaJIT52 => "5.2",
@@ -260,12 +263,7 @@ variables = {{
         let luarocks_config_content =
             variables::substitute(&[lua, &self.config], &luarocks_config_content)?;
         let luarocks_config = temp_dir.path().join("luarocks-config.lua");
-        std::fs::write(luarocks_config.clone(), luarocks_config_content).map_err(|source| {
-            ExecLuaRocksError::WriteLuarocksConfigError {
-                path: luarocks_config.to_path_buf(),
-                source,
-            }
-        })?;
+        fs::sync::write(luarocks_config.clone(), luarocks_config_content)?;
         let luarocks_bin = self.tree.bin().join(LUAROCKS_EXE);
         if !luarocks_bin.is_file() {
             return Err(ExecLuaRocksError::LuarocksBinNotFound(luarocks_bin));

--- a/lux-lib/src/luarocks/rock_manifest.rs
+++ b/lux-lib/src/luarocks/rock_manifest.rs
@@ -259,6 +259,8 @@ pub(crate) struct RockManifestRoot {
 
 #[cfg(test)]
 mod tests {
+    use crate::fs;
+
     use super::*;
 
     #[tokio::test]
@@ -336,7 +338,7 @@ rock_manifest = {
     pub async fn regression_http_rock_manifest_from_lua() {
         let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources/test/http-0.4-0-rock_manifest");
-        let content = String::from_utf8(tokio::fs::read(manifest).await.unwrap()).unwrap();
+        let content = String::from_utf8(fs::tokio::read(manifest).await.unwrap()).unwrap();
         RockManifest::new(&content).unwrap();
     }
 }

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -5,9 +5,11 @@ use std::path::{Path, PathBuf};
 use std::string::FromUtf8Error;
 use std::time::SystemTime;
 use thiserror::Error;
-use tokio::fs::{File, OpenOptions};
+use tokio::fs::OpenOptions;
+use tokio::io;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use tokio::{fs, io};
+
+use crate::fs;
 use tracing::span;
 use url::Url;
 use zip::ZipArchive;
@@ -18,8 +20,11 @@ use crate::lua_version::{LuaVersion, LuaVersionUnset};
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum ManifestFromServerError {
-    #[error(transparent)]
+    #[error("IO error occured while fetching the manifest")]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("failed to pull manifest:\n{0}")]
     #[diagnostic(help(
         r#"check your network connection and server configuration.
@@ -67,35 +72,45 @@ pub(super) async fn get_manifest(
             .bytes()
             .await?;
         let manifest = String::from_utf8(manifest_bytes.to_vec())?;
-        tokio::fs::write(&target, &manifest).await?;
+        fs::tokio::write(&target, &manifest).await?;
         Ok(manifest)
     } else {
         let manifest_bytes = response.error_for_status()?.bytes().await?;
         let mut archive = ZipArchive::new(std::io::Cursor::new(manifest_bytes))
             .map_err(|err| ManifestFromServerError::ZipRead(url.clone(), err))?;
 
-        let temp = tempfile::tempdir()?;
+        let temp = fs::tempfile::tempdir()?;
 
         archive
             .extract_unwrapped_root_dir(&temp, zip::read::root_dir_common_filter)
             .map_err(|err| ManifestFromServerError::ZipExtract(url.clone(), err))?;
 
-        let mut extracted_manifest =
-            File::open(temp.path().join(format!("manifest-{manifest_version}"))).await?;
-        let mut target = OpenOptions::new()
+        let extracted_manifest_path = temp.path().join(format!("manifest-{manifest_version}"));
+        let mut extracted_manifest = fs::tokio::open(&extracted_manifest_path).await?;
+        let mut target_file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(true)
             .open(target)
-            .await?;
+            .await
+            .map_err(|source| fs::FsError::FileOpen {
+                path: target.to_path_buf(),
+                source,
+            })?;
 
-        io::copy(&mut extracted_manifest, &mut target).await?;
+        io::copy(&mut extracted_manifest, &mut target_file)
+            .await
+            .map_err(|source| fs::FsError::Copy {
+                from: extracted_manifest_path.to_path_buf(),
+                to: target.to_path_buf(),
+                source,
+            })?;
 
         let mut manifest = String::new();
 
-        target.seek(io::SeekFrom::Start(0)).await?;
-        target.read_to_string(&mut manifest).await?;
+        target_file.seek(io::SeekFrom::Start(0)).await?;
+        target_file.read_to_string(&mut manifest).await?;
 
         Ok(manifest)
     }
@@ -123,7 +138,7 @@ pub(crate) async fn manifest_from_cache_or_server(
     #[cfg(test)]
     let client = crate::reqwest::new_http_client(config)?;
 
-    if let Ok(metadata) = fs::metadata(&cache).await {
+    if let Ok(metadata) = fs::tokio::metadata(&cache).await {
         let last_modified_local: SystemTime = metadata.modified()?;
 
         let response = match client.head(url.clone()).send().await? {
@@ -141,7 +156,7 @@ pub(crate) async fn manifest_from_cache_or_server(
                 return get_manifest(url, manifest_version.clone(), &cache, &client).await;
             }
 
-            return Ok(fs::read_to_string(&cache).await?);
+            return Ok(fs::tokio::read_to_string(&cache).await?);
         }
     }
 
@@ -183,7 +198,7 @@ fn mk_manifest_url(
     Ok(url)
 }
 
-async fn mk_manifest_cache(url: &Url, config: &Config) -> io::Result<PathBuf> {
+async fn mk_manifest_cache(url: &Url, config: &Config) -> Result<PathBuf, fs::FsError> {
     let cache = config.cache_dir().join(
         // Convert the url to a directory name so we don't create too many subdirectories
         url.to_string()
@@ -192,7 +207,7 @@ async fn mk_manifest_cache(url: &Url, config: &Config) -> io::Result<PathBuf> {
     );
     // Ensure all intermediate directories for the cache file are created (e.g. `~/.cache/lux/manifest`)
     if let Some(cache_parent_dir) = cache.parent() {
-        fs::create_dir_all(cache_parent_dir).await?;
+        fs::tokio::create_dir_all(cache_parent_dir).await?;
     }
     Ok(cache)
 }
@@ -207,7 +222,7 @@ mod tests {
     use httptest::{matchers::request, responders::status_code, Expectation, Server};
     use serial_test::serial;
 
-    use crate::config::ConfigBuilder;
+    use crate::{config::ConfigBuilder, fs};
 
     use super::*;
 
@@ -281,14 +296,14 @@ mod tests {
         let server = start_test_server("manifest-5.1".into());
         let mut url_str = server.url_str("/");
         url_str.pop(); // Remove trailing "/"
-        let manifest_content = std::fs::read_to_string(
+        let manifest_content = fs::sync::read_to_string(
             format!("{}/resources/test/manifest-5.1", env!("CARGO_MANIFEST_DIR")).as_str(),
         )
         .unwrap();
         let cache_dir = assert_fs::TempDir::new().unwrap();
         let cache = cache_dir.join("manifest-5.1");
-        fs::write(&cache, &manifest_content).await.unwrap();
-        let _metadata = fs::metadata(&cache).await.unwrap();
+        fs::tokio::write(&cache, &manifest_content).await.unwrap();
+        let _metadata = fs::tokio::metadata(&cache).await.unwrap();
         let config = ConfigBuilder::new()
             .unwrap()
             .cache_dir(Some(cache_dir.to_path_buf()))

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -8,6 +8,7 @@ use std::{
 use crate::{
     build::utils::{self, CCExt},
     config::Config,
+    fs,
     hash::HasIntegrity,
     lua_version::LuaVersion,
     operations::{self, UnpackError},
@@ -18,9 +19,8 @@ use miette::Diagnostic;
 use path_slash::PathExt;
 use ssri::Integrity;
 use target_lexicon::Triple;
-use tempfile::tempdir;
 use thiserror::Error;
-use tokio::{fs, process::Command};
+use tokio::process::Command;
 use tracing::span;
 use url::Url;
 
@@ -52,6 +52,9 @@ pub enum BuildLuaError {
     Request(#[from] reqwest::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Unpack(#[from] UnpackError),
@@ -110,12 +113,7 @@ async fn do_build_luajit(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
     );
     let _enter = span.enter();
 
-    let build_dir = tempdir().map_err(|err| {
-        io::Error::other(format!(
-            "failed to create lua_installation temp directory:\n{}",
-            err
-        ))
-    })?;
+    let build_dir = fs::tempfile::tempdir()?;
     // XXX luajit.org responds with an invalid content-type, so we'll use the github mirror for now.
     // let luajit_url = "https://luajit.org/git/luajit.git";
     let luajit_url = "https://github.com/LuaJIT/LuaJIT.git";
@@ -259,33 +257,20 @@ async fn move_luajit_includes(install_dir: &Path) -> io::Result<()> {
     if !include_subdir.is_dir() {
         return Ok(());
     }
-    let mut dir = fs::read_dir(&include_subdir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to read {}:\n{}",
-            include_subdir.display(),
-            err
-        ))
-    })?;
+    let mut dir = fs::tokio::read_dir(&include_subdir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     while let Some(entry) = dir.next_entry().await? {
         let file_name = entry.file_name();
         let src_path = entry.path();
         let dest_path = include_dir.join(&file_name);
-        fs::copy(&src_path, &dest_path).await.map_err(|err| {
-            io::Error::other(format!(
-                "error copying {} to {}:\n{}",
-                src_path.display(),
-                dest_path.display(),
-                err
-            ))
-        })?;
+        fs::tokio::copy(&src_path, &dest_path)
+            .await
+            .map_err(|err| io::Error::other(err.to_string()))?;
     }
-    fs::remove_dir_all(&include_subdir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to remove {}:\n{}",
-            include_subdir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::remove_dir_all(&include_subdir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     Ok(())
 }
 
@@ -294,29 +279,17 @@ async fn do_build_luajit_msvc(args: BuildLua<'_>, build_dir: &Path) -> Result<()
     let lua_version = args.lua_version;
     let install_dir = args.install_dir;
     let lib_dir = install_dir.join("lib");
-    fs::create_dir_all(&lib_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            lib_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&lib_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     let include_dir = install_dir.join("include");
-    fs::create_dir_all(&include_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            include_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&include_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     let bin_dir = install_dir.join("bin");
-    fs::create_dir_all(&bin_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            bin_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&bin_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
 
     let src_dir = build_dir.join("src");
     let mut msvcbuild = Command::new(src_dir.join("msvcbuild.bat"));
@@ -331,13 +304,9 @@ async fn do_build_luajit_msvc(args: BuildLua<'_>, build_dir: &Path) -> Result<()
     for (k, v) in cl.env() {
         msvcbuild.env(k, v);
     }
-    fs::create_dir_all(&install_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            install_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&install_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     match msvcbuild.output().await {
         Ok(output) if output.status.success() => utils::trace_command_output(&output),
         Ok(output) => {
@@ -357,23 +326,12 @@ async fn do_build_luajit_msvc(args: BuildLua<'_>, build_dir: &Path) -> Result<()
     };
 
     copy_includes(&src_dir, &include_dir).await?;
-    fs::copy(src_dir.join("lua51.lib"), lib_dir.join("luajit.lib"))
+    fs::tokio::copy(src_dir.join("lua51.lib"), lib_dir.join("luajit.lib"))
         .await
-        .map_err(|err| {
-            io::Error::other(format!(
-                "Failed to rename lua51.lib to luajit.lib:\n{}",
-                err
-            ))
-        })?;
-    fs::copy(src_dir.join("luajit.exe"), bin_dir.join("luajit.exe"))
+        .map_err(|err| io::Error::other(err.to_string()))?;
+    fs::tokio::copy(src_dir.join("luajit.exe"), bin_dir.join("luajit.exe"))
         .await
-        .map_err(|err| {
-            io::Error::other(format!(
-                "Failed to install luajit.exe to {}:\n{}",
-                bin_dir.display(),
-                err
-            ))
-        })?;
+        .map_err(|err| io::Error::other(err.to_string()))?;
     Ok(())
 }
 
@@ -386,12 +344,7 @@ async fn do_build_lua(args: BuildLua<'_>) -> Result<(), BuildLuaError> {
     );
     let _enter = span.enter();
 
-    let build_dir = tempdir().map_err(|err| {
-        io::Error::other(format!(
-            "failed to create lua_installation temp directory:\n{}",
-            err
-        ))
-    })?;
+    let build_dir = fs::tempfile::tempdir()?;
 
     let (source_integrity, pkg_version): (Integrity, &str) = unsafe {
         match lua_version {
@@ -541,29 +494,17 @@ async fn do_build_lua_msvc(
     let install_dir = args.install_dir;
 
     let lib_dir = install_dir.join("lib");
-    fs::create_dir_all(&lib_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            lib_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&lib_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     let include_dir = install_dir.join("include");
-    fs::create_dir_all(&include_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            include_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&include_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     let bin_dir = install_dir.join("bin");
-    fs::create_dir_all(&bin_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to create directory {}:\n{}",
-            bin_dir.display(),
-            err
-        ))
-    })?;
+    fs::tokio::create_dir_all(&bin_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
 
     let src_dir = build_dir.join("src");
 
@@ -602,13 +543,9 @@ async fn do_build_lua_msvc(
     cc.define("LUA_BUILD_AS_DLL", None);
 
     let mut lib_c_files = Vec::new();
-    let mut read_dir = fs::read_dir(&src_dir).await.map_err(|err| {
-        io::Error::other(format!(
-            "Failed to read directory {}:\n{}",
-            src_dir.display(),
-            err
-        ))
-    })?;
+    let mut read_dir = fs::tokio::read_dir(&src_dir)
+        .await
+        .map_err(|err| io::Error::other(err.to_string()))?;
     while let Some(entry) = read_dir.next_entry().await? {
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "c")
@@ -737,16 +674,9 @@ async fn copy_includes(src_dir: &Path, include_dir: &Path) -> Result<(), io::Err
     ] {
         let src_file = src_dir.join(f);
         if src_file.is_file() {
-            fs::copy(&src_file, include_dir.join(f))
+            fs::tokio::copy(&src_file, include_dir.join(f))
                 .await
-                .map_err(|err| {
-                    io::Error::other(format!(
-                        "Failed to copy {} to {}:\n{}",
-                        src_file.display(),
-                        include_dir.display(),
-                        err
-                    ))
-                })?;
+                .map_err(|err| io::Error::other(err.to_string()))?;
         }
     }
     Ok(())

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -212,7 +212,7 @@ mod tests {
     use super::*;
 
     use crate::{
-        config::ConfigBuilder, lua_installation::detect_installed_lua_version,
+        config::ConfigBuilder, fs, lua_installation::detect_installed_lua_version,
         lua_version::LuaVersion,
     };
     use assert_fs::prelude::PathCopy;
@@ -228,15 +228,15 @@ mod tests {
         temp_dir.copy_from(&project_root, &["**"]).unwrap();
         let project_root = temp_dir.path();
         let foo_bin_dir = project_root.join("src").join("bin");
-        tokio::fs::create_dir_all(&foo_bin_dir).await.unwrap();
+        fs::tokio::create_dir_all(&foo_bin_dir).await.unwrap();
         let foo_bin_file = foo_bin_dir.join("foo");
-        tokio::fs::write(&foo_bin_file, "print('hello')")
+        fs::tokio::write(&foo_bin_file, "print('hello')")
             .await
             .unwrap();
         let bar_bin_dir = project_root.join("bin");
-        tokio::fs::create_dir_all(&bar_bin_dir).await.unwrap();
+        fs::tokio::create_dir_all(&bar_bin_dir).await.unwrap();
         let bar_bin_file = bar_bin_dir.join("bar");
-        tokio::fs::write(&bar_bin_file, "print('hello')")
+        fs::tokio::write(&bar_bin_file, "print('hello')")
             .await
             .unwrap();
         let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
@@ -271,9 +271,9 @@ mod tests {
         temp_dir.copy_from(&project_root, &["**"]).unwrap();
         let project_root = temp_dir.path();
         let src_dir = project_root.join("src");
-        tokio::fs::create_dir_all(&src_dir).await.unwrap();
+        fs::tokio::create_dir_all(&src_dir).await.unwrap();
         let init_lua_file = src_dir.join("init.lua");
-        tokio::fs::write(&init_lua_file, "print('hello')")
+        fs::tokio::write(&init_lua_file, "print('hello')")
             .await
             .unwrap();
         let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));

--- a/lux-lib/src/operations/dist_bin.rs
+++ b/lux-lib/src/operations/dist_bin.rs
@@ -12,6 +12,7 @@ use walkdir::WalkDir;
 use crate::{
     build::utils::c_dylib_extension,
     config::Config,
+    fs,
     lua_installation::{LuaInstallation, LuaInstallationError},
     lua_rockspec::LuaModule,
     operations::{InstallProject, InstallProjectError},
@@ -70,6 +71,9 @@ Cannot link the following binaries:
     CC(#[from] cc::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("C compilation failed (exit {status}):\nstdout: {stdout}\nstderr: {stderr}")]
     CompilationFailed {
         status: std::process::ExitStatus,
@@ -137,9 +141,9 @@ where
     let lib_root = layout.lib.clone();
     let c_src = generate_c_source(&entrypoint_module, &files, &lib_root).await?;
 
-    let work_dir = tempfile::tempdir()?;
+    let work_dir = fs::tempfile::tempdir()?;
     let c_path = work_dir.path().join(format!("{pkg_name}.static.c"));
-    tokio::fs::write(&c_path, &c_src).await?;
+    fs::tokio::write(&c_path, &c_src).await?;
 
     compile_binary(&c_path, &output, &lua, &files.lib, &work_dir, args.config).await?;
 
@@ -228,7 +232,7 @@ async fn generate_c_source(
     entrypoint_module: &str,
     files: &InstalledFiles,
     lib_root: &Path,
-) -> Result<String, io::Error> {
+) -> Result<String, fs::FsError> {
     let mut out = String::from(C_PREAMBLE);
 
     out.push_str("#ifdef __cplusplus\nextern \"C\" {\n#endif\n");
@@ -239,9 +243,7 @@ async fn generate_c_source(
     out.push_str("#ifdef __cplusplus\n}\n#endif\n\n");
 
     for (i, (_, path)) in files.src.iter().enumerate() {
-        let bytes = tokio::fs::read(path).await.map_err(|err| {
-            io::Error::other(format!("unable to read '{}': {err}", path.display()))
-        })?;
+        let bytes = fs::tokio::read(path).await?;
         let hex = bytes_to_hex(&bytes);
         out.push_str(&format!(
             "static const unsigned char lua_src_{i}[] = {{{hex}}};\n"
@@ -315,7 +317,7 @@ async fn compile_binary(
     let mut build = cc::Build::new();
     let host = target_lexicon::Triple::host().to_string();
 
-    let intermediate_dir = tempfile::tempdir()?;
+    let intermediate_dir = fs::tempfile::tempdir()?;
     build
         .cargo_output(false)
         .cargo_metadata(false)
@@ -501,6 +503,7 @@ mod tests {
     use crate::{config::ConfigBuilder, lua_version::LuaVersion, tree::FlatDistTree};
     #[cfg(target_os = "linux")]
     use crate::{
+        fs,
         lockfile::{LocalPackage, LocalPackageHashes, LockConstraint},
         package::PackageSpec,
         remote_package_source::RemotePackageSource,
@@ -544,7 +547,7 @@ mod tests {
             .child(layout_a.src.strip_prefix(staging.path()).unwrap())
             .create_dir_all()
             .unwrap();
-        tokio::fs::write(layout_a.src.join("foo.lua"), "return {}")
+        fs::tokio::write(layout_a.src.join("foo.lua"), "return {}")
             .await
             .unwrap();
 
@@ -554,14 +557,14 @@ mod tests {
             .child(layout_b.src.strip_prefix(staging.path()).unwrap())
             .create_dir_all()
             .unwrap();
-        tokio::fs::write(layout_b.src.join("bar.lua"), "return {}")
+        fs::tokio::write(layout_b.src.join("bar.lua"), "return {}")
             .await
             .unwrap();
         staging
             .child(layout_b.lib.strip_prefix(staging.path()).unwrap())
             .create_dir_all()
             .unwrap();
-        tokio::fs::write(
+        fs::tokio::write(
             layout_b.lib.join(format!("bar.{}", c_dylib_extension())),
             "",
         )

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Cursor, Read},
+    io::{Cursor, Read},
     path::PathBuf,
     string::FromUtf8Error,
 };
@@ -13,6 +13,7 @@ use url::{ParseError, Url};
 
 use crate::{
     config::Config,
+    fs,
     git::GitSource,
     lockfile::RemotePackageSourceUrl,
     lua_rockspec::{LuaRockspecError, RemoteLuaRockspec, RockSourceSpec},
@@ -336,9 +337,9 @@ pub enum SearchAndDownloadError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     DownloadRockspec(#[from] DownloadRockspecError),
-    #[error("io operation failed: {0}")]
-    #[diagnostic(help("check that the destination directory exists and is writable."))]
-    Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("UTF-8 conversion failed: {0}")]
     #[diagnostic(help(
         r#"the server returned a response that is not valid UTF-8.
@@ -475,7 +476,7 @@ async fn download_src_rock_to_file(
 ) -> Result<DownloadedPackedRock, SearchAndDownloadError> {
     let rock = search_and_download_src_rock(package_req, package_db, config).await?;
     let full_rock_name = mk_packed_rock_name(&rock.name, &rock.version, "src.rock");
-    tokio::fs::write(
+    fs::tokio::write(
         destination_dir
             .map(|dest| dest.join(&full_rock_name))
             .unwrap_or_else(|| full_rock_name.clone().into()),
@@ -577,13 +578,18 @@ pub(crate) async fn unpack_rockspec(
                 .eq(&rockspec_file_name)
         })
         .ok_or(SearchAndDownloadError::RockspecNotFoundInPackedRock(
-            rockspec_file_name,
+            rockspec_file_name.to_string(),
         ))?;
     let mut rockspec_file = zip
         .by_index(rockspec_index)
         .map_err(|err| SearchAndDownloadError::ZipExtract(rock.file_name.clone(), err))?;
     let mut content = String::new();
-    rockspec_file.read_to_string(&mut content)?;
+    rockspec_file
+        .read_to_string(&mut content)
+        .map_err(|source| fs::FsError::ReadToString {
+            path: PathBuf::from(&rockspec_file_name),
+            source,
+        })?;
     let rockspec = RemoteLuaRockspec::new(&content)
         .map_err(|err| SearchAndDownloadError::Rockspec(Box::new(err)))?;
     Ok(rockspec)

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -5,9 +5,9 @@ use crate::git::GitSource;
 use crate::hash::HasIntegrity;
 use crate::lockfile::RemotePackageSourceUrl;
 use crate::lua_rockspec::RockSourceSpec;
-use crate::operations;
 use crate::package::PackageSpec;
 use crate::rockspec::Rockspec;
+use crate::{fs, operations};
 use auth_git2::{GitAuthenticator, Prompter};
 use bon::Builder;
 use git2::build::RepoBuilder;
@@ -15,12 +15,10 @@ use git2::{FetchOptions, RemoteCallbacks};
 use miette::Diagnostic;
 use remove_dir_all::remove_dir_all;
 use ssri::Integrity;
-use std::fs::File;
 use std::io;
 use std::io::Cursor;
 use std::io::Read;
 use std::path::Path;
-use std::path::PathBuf;
 use thiserror::Error;
 use tracing::span;
 
@@ -114,19 +112,9 @@ pub enum FetchSrcError {
     CleanGitDir(io::Error),
     #[error("unable to compute hash:\n{0}")]
     Hash(io::Error),
-    #[error("unable to copy {src} to {dest}:\n{err}")]
-    #[diagnostic(help("check that the source exists and the destination is writable."))]
-    CopyDir {
-        src: PathBuf,
-        dest: PathBuf,
-        err: io::Error,
-    },
-    #[error("unable to open {file}:\n{err}")]
-    #[diagnostic(help("check that the file exists and is readable."))]
-    FileOpen { file: PathBuf, err: io::Error },
-    #[error("unable to read {file}:\n{err}")]
-    #[diagnostic(help("check that the file exists and is readable."))]
-    FileRead { file: PathBuf, err: io::Error },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 /// A rocks package source fetcher, providing fine-grained control
@@ -305,24 +293,15 @@ async fn do_fetch_src<R: Rockspec>(
             tracing::debug!(message = format!("📋 Copying {}", path.display()).as_str());
 
             let hash = if path.is_dir() {
-                recursive_copy_dir(&path.to_path_buf(), dest_dir)
-                    .await
-                    .map_err(|err| FetchSrcError::CopyDir {
-                        src: path.to_path_buf(),
-                        dest: dest_dir.to_path_buf(),
-                        err,
-                    })?;
+                recursive_copy_dir(&path.to_path_buf(), dest_dir).await?;
                 dest_dir.hash().map_err(FetchSrcError::Hash)?
             } else {
-                let mut file = File::open(path).map_err(|err| FetchSrcError::FileOpen {
-                    file: path.clone(),
-                    err,
-                })?;
+                let mut file = fs::sync::open(path)?;
                 let mut buffer = Vec::new();
                 file.read_to_end(&mut buffer)
-                    .map_err(|err| FetchSrcError::FileRead {
-                        file: path.clone(),
-                        err,
+                    .map_err(|source| fs::FsError::Read {
+                        path: path.to_path_buf(),
+                        source,
                     })?;
                 let mime_type = infer::get(&buffer).map(|file_type| file_type.mime_type());
                 let file_name = path

--- a/lux-lib/src/operations/fetch_vendored.rs
+++ b/lux-lib/src/operations/fetch_vendored.rs
@@ -1,9 +1,7 @@
-use std::{
-    io,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use crate::{
+    fs,
     lockfile::RemotePackageSourceUrl,
     lua_rockspec::{LuaRockspecError, RemoteLuaRockspec},
     operations::{DownloadedRockspec, RemoteRockDownload},
@@ -30,22 +28,20 @@ pub enum FetchVendoredError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Search(#[from] SearchError),
-    #[error("could not find a vendored RockSpec for package {0} in vendor directory {1}.")]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
+    #[error("could not find a vendored RockSpec for package '{0}' in vendor directory '{1}'.")]
     RockspecNotFound(PackageSpec, String),
-    #[error("could not read vendored RockSpec content at {rockspec_path}:\n{err}")]
-    ReadRockspecContent {
-        rockspec_path: String,
-        err: io::Error,
-    },
-    #[error("could not parse vendored RockSpec {rockspec_path}:\n{err}")]
+    #[error("could not parse vendored RockSpec '{rockspec_path}'")]
     ParseRockspec {
         rockspec_path: String,
-        err: LuaRockspecError,
+        source: LuaRockspecError,
     },
     #[error("could not find a source or .rock archive for {0} in vendor directory {1}.")]
     PackageNotFound(PackageSpec, String),
     #[error("unable to read binary rock: {0}:\n{1}")]
-    ReadBinaryRock(String, io::Error),
+    ReadBinaryRock(String, fs::FsError),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -90,7 +86,7 @@ async fn do_fetch_vendored_rock(
             },
         }),
         VendoredPackage::BinaryRock(path) => {
-            let packed_rock = tokio::fs::read(&path)
+            let packed_rock = fs::tokio::read(&path)
                 .await
                 .map_err(|err| {
                     FetchVendoredError::ReadBinaryRock(path.to_slash_lossy().to_string(), err)
@@ -127,16 +123,11 @@ async fn load_vendored_rockspec(
             vendor_dir.to_slash_lossy().to_string(),
         ));
     }
-    let rockspec_content = tokio::fs::read_to_string(&rockspec_path)
-        .await
-        .map_err(|err| FetchVendoredError::ReadRockspecContent {
-            rockspec_path: rockspec_path.to_slash_lossy().to_string(),
-            err,
-        })?;
+    let rockspec_content = fs::tokio::read_to_string(&rockspec_path).await?;
     let rockspec = RemoteLuaRockspec::new(&rockspec_content).map_err(|err| {
         FetchVendoredError::ParseRockspec {
             rockspec_path: rockspec_path.to_slash_lossy().to_string(),
-            err,
+            source: err,
         }
     })?;
     Ok(rockspec)

--- a/lux-lib/src/operations/gen_luarc.rs
+++ b/lux-lib/src/operations/gen_luarc.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::fs;
 use crate::lockfile::LocalPackageLockType;
 use crate::tree::InstallTree;
 use crate::workspace::Workspace;
@@ -12,13 +13,14 @@ use path_slash::PathBufExt;
 use pathdiff::diff_paths;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
-use tokio::fs;
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum GenLuaRcError {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
@@ -29,8 +31,6 @@ pub enum GenLuaRcError {
     Serialize(String),
     #[error("failed to deserialize luarc content:\n{0}")]
     Deserialize(String),
-    #[error("failed to write {0}:\n{1}")]
-    Write(PathBuf, io::Error),
 }
 
 #[derive(Builder)]
@@ -78,7 +78,7 @@ async fn do_generate_luarc(args: GenLuaRc<'_>) -> Result<(), GenLuaRcError> {
     let luarc_path = workspace.luarc_path(config);
 
     // read the existing .luarc file or initialise a new one if it doesn't exist
-    let luarc_content = fs::read_to_string(&luarc_path)
+    let luarc_content = fs::tokio::read_to_string(&luarc_path)
         .await
         .unwrap_or_else(|_| "{}".into());
 
@@ -111,9 +111,7 @@ async fn do_generate_luarc(args: GenLuaRc<'_>) -> Result<(), GenLuaRcError> {
 
     let luarc_content = update_luarc_content(&luarc_content, library_dirs)?;
 
-    fs::write(&luarc_path, luarc_content)
-        .await
-        .map_err(|err| GenLuaRcError::Write(luarc_path, err))?;
+    fs::tokio::write(&luarc_path, luarc_content).await?;
 
     Ok(())
 }

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -1,5 +1,6 @@
 use crate::build::utils;
 use crate::build::utils::c_dylib_extension;
+use crate::fs;
 use crate::lockfile::LocalPackage;
 use crate::luarocks;
 use crate::luarocks::rock_manifest::DirOrFileEntry;
@@ -25,7 +26,6 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
-use tempfile::tempdir;
 use thiserror::Error;
 use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
@@ -60,6 +60,9 @@ where
 pub enum PackError {
     Zip(#[from] zip::result::ZipError),
     Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     Walkdir(#[from] walkdir::Error),
     #[error("expected a `package.rockspec` in the package root.")]
     MissingRockspec,
@@ -78,7 +81,7 @@ async fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let temp_file_name = format!("{}-{}.{}.part", package.name(), package.version(), suffix);
     let temp_output_path = args.dest_dir.join(temp_file_name);
     let output_path = args.dest_dir.join(file_name);
-    let file = File::create(&temp_output_path)?;
+    let file = fs::sync::create(&temp_output_path)?;
     let mut zip = ZipWriter::new(file);
 
     let lua_entries = add_rock_entries(&mut zip, &layout.src, "lua".into())?;
@@ -86,16 +89,16 @@ async fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let doc_entries = add_rock_entries(&mut zip, &layout.doc, "doc".into())?;
     let conf_entries = add_rock_entries(&mut zip, &layout.conf, "conf".into())?;
     // We copy entries from `etc` to the root directory, as luarocks doesn't have an etc directory.
-    let temp_root_dir = tempdir()?;
+    let temp_root_dir = fs::tempfile::tempdir()?;
     utils::recursive_copy_dir(&layout.etc, temp_root_dir.path()).await?;
     // prevent duplicate doc and conf entries
     let doc = temp_root_dir.path().join("doc");
     if doc.is_dir() {
-        tokio::fs::remove_dir_all(&doc).await?;
+        fs::tokio::remove_dir_all(&doc).await?;
     }
     let conf = temp_root_dir.path().join("conf");
     if conf.is_dir() {
-        tokio::fs::remove_dir_all(&conf).await?;
+        fs::tokio::remove_dir_all(&conf).await?;
     }
     // luarocks expects a <package>-<version>.rockspec,
     // so we copy it the package.rockspec to our temporary root directory and rename it
@@ -104,7 +107,7 @@ async fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     }
     let packed_rockspec_name = format!("{}-{}.rockspec", &package.name(), &package.version());
     let renamed_rockspec_entry = temp_root_dir.path().join(packed_rockspec_name);
-    tokio::fs::copy(layout.rockspec_path(), &renamed_rockspec_entry).await?;
+    fs::tokio::copy(layout.rockspec_path(), &renamed_rockspec_entry).await?;
     let root_entries = add_rock_entries(&mut zip, temp_root_dir.path(), "".into())?;
     let mut bin_entries = HashMap::new();
     for relative_binary_path in package.spec.binaries() {
@@ -141,7 +144,7 @@ async fn do_pack(args: Pack) -> Result<PathBuf, PackError> {
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
     zip.start_file("rock_manifest", options)?;
     zip.write_all(manifest_str.as_bytes())?;
-    tokio::fs::rename(&temp_output_path, &output_path).await?;
+    fs::tokio::rename(&temp_output_path, &output_path).await?;
     Ok(output_path)
 }
 
@@ -192,7 +195,7 @@ fn add_rock_entry(
     let relative_path: PathBuf = unsafe {
         pathdiff::diff_paths(source_dir.join(file.clone()), source_dir).unwrap_unchecked()
     };
-    let mut f = File::open(file)?;
+    let mut f = fs::sync::open(file)?;
     let mut buffer = Vec::new();
     f.read_to_end(&mut buffer)?;
     let digest = md5::compute(&buffer);

--- a/lux-lib/src/operations/pin.rs
+++ b/lux-lib/src/operations/pin.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use crate::{
+    fs,
     lockfile::{FlushLockfileError, LocalPackageId, PinnedState},
     package::PackageSpec,
     tree::{InstallTree, Tree, TreeError},
@@ -39,12 +40,9 @@ pub enum PinError {
     #[error("cannot change pin state of {rock}, because it is not an entrypoint")]
     #[diagnostic(help("Lux does not allow pinning dependencies, as doing so could break the version requirement in a future update."))]
     NotAnEntrypoint { rock: PackageSpec },
-    #[error("error reading directory '{dir}'")]
-    #[diagnostic(help("make sure Lux has write access to the directory"))]
-    ReadDir { dir: String, source: io::Error },
-    #[error("error creating directory '{dir}'")]
-    #[diagnostic(help("make sure Lux has write access to the parent directory"))]
-    CreateDir { dir: String, source: io::Error },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 pub fn set_pinned_state(
@@ -73,11 +71,7 @@ pub fn set_pinned_state(
 
     let old_package = package.clone();
     let package_root = tree.root_for(&package);
-    let items = std::fs::read_dir(&package_root)
-        .map_err(|source| PinError::ReadDir {
-            dir: package_root.to_string_lossy().to_string(),
-            source,
-        })?
+    let items = fs::sync::read_dir(&package_root)?
         .filter_map(Result::ok)
         .map(|dir| dir.path())
         .collect_vec();
@@ -93,10 +87,7 @@ pub fn set_pinned_state(
 
     let new_root = tree.root_for(&package);
 
-    std::fs::create_dir_all(&new_root).map_err(|source| PinError::CreateDir {
-        dir: new_root.to_string_lossy().to_string(),
-        source,
-    })?;
+    fs::sync::create_dir_all(&new_root)?;
 
     fs_extra::move_items(&items, new_root, &CopyOptions::new())?;
 

--- a/lux-lib/src/operations/run_lua.rs
+++ b/lux-lib/src/operations/run_lua.rs
@@ -184,6 +184,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::fs;
     use assert_fs::prelude::{PathChild, PathCreateDir};
     use assert_fs::TempDir;
     use path_slash::PathBufExt;
@@ -196,7 +197,7 @@ mod tests {
         lua_dir.create_dir_all().unwrap();
         let lux_file = lua_dir.child("lux.lua").to_path_buf();
         let lux_path_expr = lua_dir.child("?.lua").to_path_buf();
-        tokio::fs::write(&lux_file, "return true").await.unwrap();
+        fs::tokio::write(&lux_file, "return true").await.unwrap();
         let package_path =
             PackagePath::from_str(lux_path_expr.to_slash_lossy().to_string().as_str()).unwrap();
         let package_cpath = PackagePath::default();

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -4,6 +4,7 @@ use super::{Install, InstallError, PackageInstallSpec, RemoveError, Uninstall};
 use crate::{
     build::BuildBehaviour,
     config::Config,
+    fs,
     lockfile::{
         FlushLockfileError, LocalPackage, LocalPackageLockType, LockfileIntegrityError,
         SyncStrategy,
@@ -128,8 +129,9 @@ pub enum SyncError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     FlushLockfile(#[from] FlushLockfileError),
-    #[error("failed to create install tree at {0}:\n{1}")]
-    FailedToCreateDirectory(String, io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Tree(#[from] TreeError),
@@ -173,9 +175,7 @@ async fn do_sync(
         LocalPackageLockType::Test => args.workspace.test_tree(args.config)?,
         LocalPackageLockType::Build => args.workspace.build_tree(args.config)?,
     };
-    std::fs::create_dir_all(tree.root()).map_err(|err| {
-        SyncError::FailedToCreateDirectory(tree.root().to_string_lossy().to_string(), err)
-    })?;
+    fs::sync::create_dir_all(tree.root())?;
 
     let mut workspace_lockfile = args.workspace.lockfile()?.write_guard();
     let dest_lockfile = tree.lockfile()?;

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -3,6 +3,7 @@ use std::{io, ops::Deref, path::PathBuf, process::Command};
 use super::{
     BuildWorkspace, BuildWorkspaceError, Install, InstallError, PackageInstallSpec, Sync, SyncError,
 };
+use crate::fs;
 use crate::tree::InstallTree;
 use crate::workspace::{WorkspaceError, WorkspaceTreeError};
 use crate::{
@@ -99,7 +100,8 @@ pub enum RunTestsError {
         help: Option<String>,
     },
     #[error(transparent)]
-    Io(#[from] io::Error),
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Project(#[from] ProjectError),
@@ -206,13 +208,13 @@ async fn run_project_tests(
         // by initialising empty HOME and XDG base directory paths
         let home = test_tree.root().join("home");
         let xdg = home.join("xdg");
-        let _ = tokio::fs::remove_dir_all(&home).await;
+        let _ = fs::tokio::remove_dir_all(&home).await;
         let xdg_config_home = xdg.join("config");
-        tokio::fs::create_dir_all(&xdg_config_home).await?;
+        fs::tokio::create_dir_all(&xdg_config_home).await?;
         let xdg_state_home = xdg.join("local").join("state");
-        tokio::fs::create_dir_all(&xdg_state_home).await?;
+        fs::tokio::create_dir_all(&xdg_state_home).await?;
         let xdg_data_home = xdg.join("local").join("share");
-        tokio::fs::create_dir_all(&xdg_data_home).await?;
+        fs::tokio::create_dir_all(&xdg_data_home).await?;
         command = command
             .env("HOME", home)
             .env("XDG_CONFIG_HOME", xdg_config_home)
@@ -331,7 +333,7 @@ mod tests {
     use std::path::Path;
 
     use crate::{
-        config::ConfigBuilder, lua_installation::detect_installed_lua_version,
+        config::ConfigBuilder, fs, lua_installation::detect_installed_lua_version,
         lua_version::LuaVersion,
     };
 
@@ -358,7 +360,7 @@ mod tests {
         let workspace_root = temp_dir.path();
         let workspace = Workspace::from(workspace_root).unwrap().unwrap();
         let tree_root = workspace.root().to_path_buf().join(".lux");
-        let _ = tokio::fs::remove_dir_all(&tree_root).await;
+        let _ = fs::tokio::remove_dir_all(&tree_root).await;
 
         let lua_version = detect_installed_lua_version().or(Some(LuaVersion::Lua51));
 

--- a/lux-lib/src/operations/uninstall.rs
+++ b/lux-lib/src/operations/uninstall.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use crate::fs;
 use crate::lockfile::{FlushLockfileError, LocalPackage, LocalPackageId};
 use crate::lua_version::{LuaVersion, LuaVersionUnset};
 use crate::tree::{InstallTree, TreeError};
@@ -15,7 +16,9 @@ use tracing::{span, Instrument};
 pub enum RemoveError {
     #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
-    Io(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Tree(#[from] TreeError),
@@ -114,19 +117,19 @@ async fn remove_package(package: LocalPackage, tree: Tree) -> Result<(), RemoveE
     let _enter = span.enter();
 
     let rock_layout = tree.installed_rock_layout(&package)?;
-    tokio::fs::remove_dir_all(&rock_layout.etc).await?;
-    tokio::fs::remove_dir_all(&rock_layout.rock_path).await?;
+    fs::tokio::remove_dir_all(&rock_layout.etc).await?;
+    fs::tokio::remove_dir_all(&rock_layout.rock_path).await?;
 
     for relative_binary_path in package.spec.binaries() {
         if let Some(binary_file_name) = relative_binary_path.file_name() {
             let binary_path = tree.bin().join(binary_file_name);
             if binary_path.is_file() {
-                tokio::fs::remove_file(binary_path).await?;
+                fs::tokio::remove_file(binary_path).await?;
             }
 
             let unwrapped_binary_path = tree.unwrapped_bin().join(binary_file_name);
             if unwrapped_binary_path.is_file() {
-                tokio::fs::remove_file(unwrapped_binary_path).await?;
+                fs::tokio::remove_file(unwrapped_binary_path).await?;
             }
         }
     }

--- a/lux-lib/src/operations/unpack.rs
+++ b/lux-lib/src/operations/unpack.rs
@@ -1,3 +1,4 @@
+use crate::fs;
 use async_recursion::async_recursion;
 use flate2::read::GzDecoder;
 use itertools::Itertools;
@@ -11,17 +12,19 @@ use std::io::Seek;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
-use tokio::fs;
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum UnpackError {
-    #[error("failed to unpack source: {0}")]
+    #[error("failed to unpack source")]
     Io(#[from] io::Error),
-    #[error("failed to unpack zip source: {0}")]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
+    #[error("failed to unpack zip source")]
     Zip(#[from] zip::result::ZipError),
     #[error("source returned HTML - it may have been moved or deleted")]
     SourceMovedOrDeleted,
-    #[error("rockspec source has unsupported file type {0}")]
+    #[error("rockspec source has unsupported file type '{0}'")]
     UnsupportedFileType(String),
     #[error("could not determine mimetype of rockspec source")]
     UnknownMimeType,
@@ -83,7 +86,7 @@ where
                     if path.components().count() > 0 {
                         let dest = dest_dir.join(path);
                         if let Some(dest_parent_dir) = dest.parent() {
-                            std::fs::create_dir_all(dest_parent_dir)?;
+                            fs::sync::create_dir_all(dest_parent_dir).map_err(io::Error::other)?;
                         }
                         entry.unpack(dest)?;
                     }
@@ -129,7 +132,7 @@ where
                     dest_dir,
                 )
                 .await?;
-                fs::remove_file(nested_archive_path).await?;
+                fs::tokio::remove_file(nested_archive_path).await?;
             }
         }
     }
@@ -166,7 +169,8 @@ fn is_single_tar_directory<R: Read + Seek + Send>(reader: R) -> io::Result<bool>
 }
 
 fn get_single_archive_entry(dir: &Path) -> Result<Option<(PathBuf, Option<&str>)>, io::Error> {
-    let entries = std::fs::read_dir(dir)?
+    let entries = fs::sync::read_dir(dir)
+        .map_err(io::Error::other)?
         .filter_map(Result::ok)
         .filter_map(|f| {
             let f = f.path();

--- a/lux-lib/src/operations/vendor.rs
+++ b/lux-lib/src/operations/vendor.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Cursor},
+    io::Cursor,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -9,15 +9,15 @@ use bytes::Bytes;
 use futures::StreamExt;
 use itertools::Itertools;
 use miette::Diagnostic;
-use path_slash::PathExt;
 use strum::IntoEnumIterator;
 use thiserror::Error;
-use tokio::{fs::File, io::AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 use tracing::{span, Instrument};
 
 use crate::{
     build::{RemotePackageSourceSpec, SrcRockSource},
     config::Config,
+    fs,
     lockfile::{LocalPackageLockType, ReadOnly},
     lua_rockspec::RemoteLuaRockspec,
     operations::{
@@ -77,16 +77,11 @@ pub enum VendorError {
     #[error("failed to resolve dependencies:\n{0}")]
     #[diagnostic(forward(0))]
     ResolveDependencies(#[from] ResolveDependenciesError),
-    #[error("failed to delete vendor directory {0}:\n{1}")]
-    DeleteVendorDir(String, io::Error),
-    #[error("failed to create vendor directory {0}:\n{1}")]
-    CreateVendorDir(String, io::Error),
-    #[error("failed to create {0}:\n{1}")]
-    CreateSrcRock(String, io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("failed to vendor Lua RockSpec:\n{0}")]
     LuaRockSpec(String),
-    #[error("failed to write Lua RockSpec {0}:\n{1}")]
-    WriteLuaRockSpec(String, io::Error),
     #[error("failed to unpack src.rock:\n{0}")]
     #[diagnostic(forward(0))]
     Unpack(#[from] UnpackError),
@@ -132,11 +127,7 @@ async fn do_vendor_dependencies(args: Vendor<'_>) -> Result<(), VendorError> {
     }
 
     if !no_delete && vendor_dir.exists() {
-        tokio::fs::remove_dir_all(&vendor_dir)
-            .await
-            .map_err(|err| {
-                VendorError::DeleteVendorDir(vendor_dir.to_slash_lossy().to_string(), err)
-            })?;
+        fs::tokio::remove_dir_all(&vendor_dir).await?;
     }
 
     vendor_sources(Arc::new(vendor_dir), config.clone(), all_packages).await
@@ -297,11 +288,7 @@ async fn vendor_rockspec_sources(
 
     let package_vendor_dir = vendor_dir.join(&package_version_str);
 
-    tokio::fs::create_dir_all(&package_vendor_dir)
-        .await
-        .map_err(|err| {
-            VendorError::CreateVendorDir(package_vendor_dir.to_slash_lossy().to_string(), err)
-        })?;
+    fs::tokio::create_dir_all(&package_vendor_dir).await?;
 
     let rockspec_lua_content = rockspec
         .to_lua_remote_rockspec_string()
@@ -309,11 +296,7 @@ async fn vendor_rockspec_sources(
 
     let rockspec_file_name = format!("{}-{}.rockspec", package, version);
     let rockspec_path = vendor_dir.join(rockspec_file_name);
-    tokio::fs::write(&rockspec_path, rockspec_lua_content)
-        .await
-        .map_err(|err| {
-            VendorError::WriteLuaRockSpec(rockspec_path.to_slash_lossy().to_string(), err)
-        })?;
+    fs::tokio::write(&rockspec_path, rockspec_lua_content).await?;
 
     match source_spec {
         RemotePackageSourceSpec::SrcRock(SrcRockSource {
@@ -353,19 +336,16 @@ async fn vendor_binary_rock(
 
     let file_name = format!("{}@{}.rock", package, version);
 
-    tokio::fs::create_dir_all(&vendor_dir)
-        .await
-        .map_err(|err| {
-            VendorError::CreateVendorDir(vendor_dir.to_slash_lossy().to_string(), err)
-        })?;
+    fs::tokio::create_dir_all(&vendor_dir).await?;
 
     let dest_file = vendor_dir.join(&file_name);
-    let mut file = File::create(&dest_file)
-        .await
-        .map_err(|err| VendorError::CreateSrcRock(dest_file.to_slash_lossy().to_string(), err))?;
+    let mut file = fs::tokio::create(&dest_file).await?;
     file.write_all(&packed_rock)
         .await
-        .map_err(|err| VendorError::CreateSrcRock(dest_file.to_slash_lossy().to_string(), err))?;
+        .map_err(|source| fs::FsError::Write {
+            path: dest_file.to_path_buf(),
+            source,
+        })?;
 
     Ok(())
 }

--- a/lux-lib/src/project/mod.rs
+++ b/lux-lib/src/project/mod.rs
@@ -13,6 +13,8 @@ use std::{
 use thiserror::Error;
 use toml_edit::{DocumentMut, Item};
 
+use crate::fs;
+
 use crate::{
     config::Config,
     git::{
@@ -90,12 +92,9 @@ where
 #[non_exhaustive]
 #[error(transparent)]
 pub enum ProjectError {
-    #[error("error reading project TOML at '{toml_path}'")]
-    #[diagnostic(help("ensure the file exists and is readable."))]
-    ReadProjectTOML {
-        toml_path: String,
-        source: io::Error,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[diagnostic(transparent)]
     Project(#[from] LocalProjectTomlValidationError),
     #[diagnostic(transparent)]
@@ -126,6 +125,9 @@ pub enum IntoRemoteRockspecError {
 pub enum ProjectEditError {
     #[error(transparent)]
     Io(#[from] tokio::io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     Toml(#[from] toml_edit::TomlError),
     #[error("error parsing {PROJECT_TOML} after edit. This is probably a bug.")]
@@ -180,6 +182,9 @@ pub enum PinError {
     TomlDe(#[from] TomlDeError),
     #[error(transparent)]
     Io(#[from] tokio::io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 /// A newtype for the project root directory.
@@ -227,12 +232,7 @@ impl Project {
 
         if start.as_ref().join(PROJECT_TOML).exists() {
             let project_toml_path = start.as_ref().join(PROJECT_TOML);
-            let toml_content = std::fs::read_to_string(&project_toml_path).map_err(|source| {
-                ProjectError::ReadProjectTOML {
-                    toml_path: project_toml_path.to_string_lossy().to_string(),
-                    source,
-                }
-            })?;
+            let toml_content = fs::sync::read_to_string(&project_toml_path)?;
             let root = start.as_ref();
 
             let mut project = Project {
@@ -293,9 +293,9 @@ impl Project {
 
     pub fn extra_rockspec(&self) -> Result<Option<PartialLuaRockspec>, PartialRockspecError> {
         if self.extra_rockspec_path().exists() {
-            Ok(Some(PartialLuaRockspec::new(&std::fs::read_to_string(
-                self.extra_rockspec_path(),
-            )?)?))
+            Ok(Some(PartialLuaRockspec::new(
+                &fs::sync::read_to_string(self.extra_rockspec_path()).map_err(io::Error::other)?,
+            )?))
         } else {
             Ok(None)
         }
@@ -311,7 +311,7 @@ impl Project {
         package_db: &RemotePackageDB,
     ) -> Result<(), ProjectEditError> {
         let mut project_toml =
-            toml_edit::DocumentMut::from_str(&tokio::fs::read_to_string(self.toml_path()).await?)?;
+            toml_edit::DocumentMut::from_str(&fs::tokio::read_to_string(self.toml_path()).await?)?;
 
         prepare_dependency_tables(&mut project_toml);
         let table = match dependencies {
@@ -351,7 +351,7 @@ impl Project {
         };
 
         let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
+        fs::tokio::write(self.toml_path(), &toml_content).await?;
         self.toml = PartialProjectToml::new(
             self.toml_path().to_str().unwrap_or("<lux.toml>"),
             &toml_content,
@@ -366,7 +366,7 @@ impl Project {
         dependencies: LuaDependencyType<&RemoteGitUrlShorthand>,
     ) -> Result<(), ProjectEditError> {
         let mut project_toml =
-            toml_edit::DocumentMut::from_str(&tokio::fs::read_to_string(self.toml_path()).await?)?;
+            toml_edit::DocumentMut::from_str(&fs::tokio::read_to_string(self.toml_path()).await?)?;
 
         prepare_dependency_tables(&mut project_toml);
         let table = match dependencies {
@@ -402,7 +402,7 @@ impl Project {
         }
 
         let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
+        fs::tokio::write(self.toml_path(), &toml_content).await?;
         self.toml = PartialProjectToml::new(
             self.toml_path().to_str().unwrap_or("<lux.toml>"),
             &toml_content,
@@ -417,7 +417,7 @@ impl Project {
         dependencies: DependencyType<&PackageName>,
     ) -> Result<(), ProjectEditError> {
         let mut project_toml =
-            toml_edit::DocumentMut::from_str(&tokio::fs::read_to_string(self.toml_path()).await?)?;
+            toml_edit::DocumentMut::from_str(&fs::tokio::read_to_string(self.toml_path()).await?)?;
 
         prepare_dependency_tables(&mut project_toml);
         let table = match dependencies {
@@ -448,7 +448,7 @@ impl Project {
         };
 
         let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
+        fs::tokio::write(self.toml_path(), &toml_content).await?;
         self.toml = PartialProjectToml::new(
             self.toml_path().to_str().unwrap_or("<lux.toml>"),
             &toml_content,
@@ -464,7 +464,7 @@ impl Project {
         package_db: &RemotePackageDB,
     ) -> Result<(), ProjectEditError> {
         let mut project_toml =
-            toml_edit::DocumentMut::from_str(&tokio::fs::read_to_string(self.toml_path()).await?)?;
+            toml_edit::DocumentMut::from_str(&fs::tokio::read_to_string(self.toml_path()).await?)?;
 
         prepare_dependency_tables(&mut project_toml);
         let table = match dependencies {
@@ -538,7 +538,7 @@ impl Project {
         }
 
         let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
+        fs::tokio::write(self.toml_path(), &toml_content).await?;
         self.toml = PartialProjectToml::new(
             self.toml_path().to_str().unwrap_or("<lux.toml>"),
             &toml_content,
@@ -597,7 +597,7 @@ impl Project {
         pin: PinnedState,
     ) -> Result<(), PinError> {
         let mut project_toml =
-            toml_edit::DocumentMut::from_str(&tokio::fs::read_to_string(self.toml_path()).await?)
+            toml_edit::DocumentMut::from_str(&fs::tokio::read_to_string(self.toml_path()).await?)
                 .map_err(|source| PinError::ParseTomlEdit {
                 toml_path: self.toml_path().to_slash_lossy().to_string(),
                 source,
@@ -675,7 +675,7 @@ impl Project {
         }
 
         let toml_content = project_toml.to_string();
-        tokio::fs::write(self.toml_path(), &toml_content).await?;
+        fs::tokio::write(self.toml_path(), &toml_content).await?;
         self.toml = PartialProjectToml::new(
             self.toml_path().to_str().unwrap_or("<lux.toml>"),
             &toml_content,
@@ -740,6 +740,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        fs,
         lua_rockspec::ExternalDependencySpec,
         manifest::{Manifest, ManifestMetadata},
         package::PackageReq,
@@ -929,7 +930,7 @@ mod tests {
         let cargo_dir = project_root.child(".cargo");
         cargo_dir.create_dir_all().unwrap();
         let cargo_config = cargo_dir.join("config.toml");
-        tokio::fs::write(&cargo_config, "").await.unwrap();
+        fs::tokio::write(&cargo_config, "").await.unwrap();
         let project_files = project_files(&project_root);
         assert!(project_files.contains(&cargo_config.to_path_buf()));
     }

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -1,5 +1,6 @@
 //! Structs and utilities for `lux.toml`
 
+use crate::fs;
 use crate::git::shorthand::RemoteGitUrlShorthand;
 use crate::git::GitSource;
 use crate::hash::HasIntegrity;
@@ -270,7 +271,7 @@ pub struct PartialProjectToml {
 impl HasIntegrity for PartialProjectToml {
     fn hash(&self) -> io::Result<Integrity> {
         let toml_file = self.project_root.join(PROJECT_TOML);
-        let content = std::fs::read_to_string(&toml_file)?;
+        let content = fs::sync::read_to_string(&toml_file).map_err(io::Error::other)?;
         Ok(Integrity::from(&content))
     }
 }
@@ -860,6 +861,9 @@ fn validate_generated_lua(lua_str: &str) -> Result<(), ProjectTomlError> {
 pub enum ProjectTomlIntegrityError {
     LuaRockspecError(#[from] LuaRockspecError),
     IoError(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
 }
 
 impl HasIntegrity for LocalProjectToml {

--- a/lux-lib/src/tree/dist.rs
+++ b/lux-lib/src/tree/dist.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, io, path::PathBuf};
 use super::{InstallTree, RockLayout, Tree, TreeError};
 use crate::{
     config::{tree::RockLayoutConfig, Config},
+    fs,
     lockfile::{LocalPackage, Lockfile, ReadOnly},
     lua_version::LuaVersion,
     package::{PackageName, PackageVersion},
@@ -68,19 +69,19 @@ impl Drop for FlatDistTree {
     fn drop(&mut self) {
         let build_tree_dir = &self.0.build_tree_dir;
         if build_tree_dir.is_dir() {
-            let _ = std::fs::remove_dir_all(build_tree_dir);
+            let _ = fs::sync::remove_dir_all(build_tree_dir);
         }
         let package_rockspec = self.root().join("package.rockspec");
         if package_rockspec.is_file() {
-            let _ = std::fs::remove_file(&package_rockspec);
+            let _ = fs::sync::remove_file(&package_rockspec);
         }
         let lockfile = self.lockfile_path();
         if lockfile.is_file() {
-            let _ = std::fs::remove_file(&lockfile);
+            let _ = fs::sync::remove_file(&lockfile);
         }
         let etc_dir = self.root().join("etc");
         if etc_dir.is_dir() {
-            let _ = std::fs::remove_dir_all(etc_dir);
+            let _ = fs::sync::remove_dir_all(etc_dir);
         }
     }
 }

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     build::utils::format_path,
     config::{tree::RockLayoutConfig, Config},
+    fs,
     lockfile::{LocalPackage, LocalPackageId, Lockfile, LockfileError, OptState, ReadOnly},
     lua_version::LuaVersion,
     package::{PackageName, PackageReq},
@@ -78,10 +79,9 @@ pub struct Tree {
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum TreeError {
-    #[error("unable to create directory {0}:\n{1}")]
-    CreateDir(String, io::Error),
-    #[error("unable to write to {0}:\n{1}")]
-    WriteFile(String, io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
@@ -164,20 +164,15 @@ impl Tree {
         let path_with_version = root.join(version.to_string());
 
         // Ensure that the root and the version directory exist.
-        std::fs::create_dir_all(&path_with_version).map_err(|err| {
-            TreeError::CreateDir(path_with_version.to_string_lossy().to_string(), err)
-        })?;
+        fs::sync::create_dir_all(&path_with_version)?;
 
         // In case the tree is in a git repository, we tell git to ignore it.
         let gitignore_file = root.join(".gitignore");
-        std::fs::write(&gitignore_file, "*").map_err(|err| {
-            TreeError::WriteFile(gitignore_file.to_string_lossy().to_string(), err)
-        })?;
+        fs::sync::write(&gitignore_file, "*")?;
 
         // Ensure that the bin directory exists.
         let bin_dir = path_with_version.join("bin");
-        std::fs::create_dir_all(&bin_dir)
-            .map_err(|err| TreeError::CreateDir(bin_dir.to_string_lossy().to_string(), err))?;
+        fs::sync::create_dir_all(&bin_dir)?;
 
         let lockfile_path = root.join(LOCKFILE_NAME);
         let rock_layout_config = if lockfile_path.is_file() {
@@ -247,15 +242,15 @@ impl InstallTree for Tree {
 
     fn entrypoint(&self, package: &LocalPackage) -> io::Result<RockLayout> {
         let rock_layout = self.entrypoint_layout(package);
-        std::fs::create_dir_all(&rock_layout.lib)?;
-        std::fs::create_dir_all(&rock_layout.src)?;
+        fs::sync::create_dir_all(&rock_layout.lib).map_err(io::Error::other)?;
+        fs::sync::create_dir_all(&rock_layout.src).map_err(io::Error::other)?;
         Ok(rock_layout)
     }
 
     fn dependency(&self, package: &LocalPackage) -> io::Result<RockLayout> {
         let rock_layout = self.dependency_layout(package);
-        std::fs::create_dir_all(&rock_layout.lib)?;
-        std::fs::create_dir_all(&rock_layout.src)?;
+        fs::sync::create_dir_all(&rock_layout.lib).map_err(io::Error::other)?;
+        fs::sync::create_dir_all(&rock_layout.src).map_err(io::Error::other)?;
         Ok(rock_layout)
     }
 

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::{
     config::Config,
+    fs,
     lockfile::{LockfileError, ReadOnly, WorkspaceLockfile},
     lua_rockspec::LuaVersionError,
     lua_version::LuaVersion,
@@ -85,6 +86,9 @@ pub enum WorkspaceError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Lockfile(#[from] LockfileError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
     #[error("package must be specified in a multi-project workspace")]
     #[diagnostic(help(
         r#"this workspace contains multiple projects.
@@ -293,11 +297,7 @@ impl Workspace {
         }
         if start.as_ref().join(WORKSPACE_TOML).exists() {
             let toml_path = start.as_ref().join(WORKSPACE_TOML);
-            let toml_content =
-                std::fs::read_to_string(&toml_path).map_err(|err| WorkspaceError::ReadLuxTOML {
-                    toml_path: toml_path.to_string_lossy().to_string(),
-                    source: err,
-                })?;
+            let toml_content = fs::sync::read_to_string(&toml_path)?;
             let root = start.as_ref();
             let toml_obj: Option<toml::Table> = toml::from_str(&toml_content).ok();
             if toml_obj.is_some_and(|toml| toml.contains_key("workspace")) {
@@ -329,12 +329,7 @@ impl Workspace {
         ) {
             Ok(Some(path)) => {
                 if let Some(root) = path.parent() {
-                    let toml_content = std::fs::read_to_string(&path).map_err(|err| {
-                        WorkspaceError::ReadLuxTOML {
-                            toml_path: path.to_string_lossy().to_string(),
-                            source: err,
-                        }
-                    })?;
+                    let toml_content = fs::sync::read_to_string(&path)?;
                     let toml_obj: Option<toml::Table> = toml::from_str(&toml_content).ok();
                     if toml_obj.is_some_and(|toml| toml.contains_key("workspace")) {
                         Ok(Some(Self::from_toml(&toml_content, root)?))
@@ -411,7 +406,7 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ConfigBuilder;
+    use crate::{config::ConfigBuilder, fs};
     use std::path::PathBuf;
 
     use assert_fs::prelude::*;
@@ -466,7 +461,7 @@ mod tests {
 [workspace]
 members = [ "glob:projects/*" ]
 "#;
-        tokio::fs::write(&workspace_toml_file, workspace_toml_content)
+        fs::tokio::write(&workspace_toml_file, workspace_toml_content)
             .await
             .unwrap();
 


### PR DESCRIPTION
This PR has 2 commits:

- A smaller one that adds `std::fs` and `tokio::fs` wrappers and an `FsError` type with more useful error messages and miette diagnostics.
- A large refactor that replaces `std::fs` and `tokio::fs` calls with our wrapper functions.