### PR TITLE
fix: Lua installations on non-nixos distros

### DIFF
--- a/lux-lib/src/build/external_dependency.rs
+++ b/lux-lib/src/build/external_dependency.rs
@@ -107,6 +107,12 @@ impl ExternalDependencyInfo {
             } else {
                 info.link_paths.first().cloned()
             };
+            let lib_dir = lib_dir.or_else(|| {
+                pkg_config::get_variable(name, "libdir")
+                    .ok()
+                    .map(PathBuf::from)
+                    .filter(|dir| dir.is_dir())
+            });
             let bin_dir = lib_dir.as_ref().and_then(|lib_dir| {
                 lib_dir
                     .parent()

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -165,6 +165,9 @@ impl LuaInstallation {
             .find_map(Result::ok);
 
         if let Some(info) = &mut dependency_info {
+            if info.include_dir.is_none() || info.lib_dir.is_none() {
+                return None;
+            }
             let bin = info.lib_dir.as_ref().and_then(|lib_dir| {
                 lib_dir
                     .parent()

--- a/lux-lib/src/lua_rockspec/build/mod.rs
+++ b/lux-lib/src/lua_rockspec/build/mod.rs
@@ -727,8 +727,8 @@ impl BuildType {
             | &BuildType::CMake
             | &BuildType::Command
             | &BuildType::None
-            | &BuildType::LuaRock(_)
             | &BuildType::Source => None,
+            BuildType::LuaRock(s) => Some(PackageName::new(format!("luarocks-build-{s}")).into()),
             &BuildType::RustMlua => unsafe {
                 Some(
                     PackageReq::parse("luarocks-build-rust-mlua >= 0.2.6")

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -15,8 +15,9 @@ use crate::{
     lockfile::{
         LocalPackageId, LocalPackageSpec, Lockfile, LockfilePermissions, OptState, PinnedState,
     },
+    lua_rockspec::BuildBackendSpec,
     operations::{FetchVendored, FetchVendoredError},
-    package::{PackageName, PackageReq},
+    package::{PackageName, PackageReq, PackageVersionReqError},
     remote_package_db::RemotePackageDB,
     rockspec::Rockspec,
     tree,
@@ -36,6 +37,9 @@ pub enum ResolveDependenciesError {
     ChannelSend(String),
     #[error("error fetching vendored dependency {0}:\n{1}")]
     FetchVendored(PackageReq, FetchVendoredError),
+    #[error("invalid build type provided: {0}")]
+    #[diagnostic(help("ensure that `luarocks-build-{0}` is available on `luarocks.org`"))]
+    InvalidBuildType(String, #[source] PackageVersionReqError),
 }
 
 #[derive(Debug)]
@@ -189,7 +193,7 @@ where
 
                             // NOTE: We don't need to install build dependencies to install binary rocks.
                             if !matches!(downloaded_rock, RemoteRockDownload::BinaryRock { .. }) {
-                                let build_dependencies = rockspec
+                                let mut build_dependencies = rockspec
                                     .build_dependencies()
                                     .current_platform()
                                     .iter()
@@ -216,6 +220,32 @@ where
                                         .build()
                                     })
                                     .collect_vec();
+
+                                if let Some(BuildBackendSpec::LuaRock(backend)) =
+                                    &rockspec.build().current_platform().build_backend
+                                {
+                                    let full_backend_name = format!("luarocks-build-{backend}");
+                                    let backend_req =
+                                        PackageReq::new(full_backend_name.clone(), None).map_err(
+                                            |err| {
+                                                ResolveDependenciesError::InvalidBuildType(
+                                                    full_backend_name,
+                                                    err,
+                                                )
+                                            },
+                                        )?;
+
+                                    let backend_spec = PackageInstallSpec::new(
+                                        backend_req,
+                                        tree::EntryType::Entrypoint,
+                                    )
+                                    .build_behaviour(build_behaviour)
+                                    .pin(pin)
+                                    .opt(opt)
+                                    .build();
+
+                                    build_dependencies.insert(0, backend_spec);
+                                }
 
                                 // NOTE: We treat transitive regular dependencies of build dependencies
                                 // as build dependencies


### PR DESCRIPTION
There was a bug with `pkg-probe` trimming `-L /usr/include` causing the lua installation detection to fail. This PR fixes that as well as a secondary bug where custom build backends would not be downloaded properly causing a "package not found" error. This is because we invoke `luarocks make` with `--deps-mode none` when running `lx sync`. 