### PR TITLE
fix(lux-lsp): create port file immediately and clean up code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6504,7 +6504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -74,7 +74,7 @@ vfs = "0.13"
 
 git2 = { workspace = true }
 ignore = { workspace = true }
-tracing = "0.1"
+tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "registry",
 ] }

--- a/lux-lsp/Cargo.toml
+++ b/lux-lsp/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tower-lsp-server = "0.23"
-tracing = "0.1"
+tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "registry",
   "fmt",

--- a/lux-lsp/src/main.rs
+++ b/lux-lsp/src/main.rs
@@ -34,30 +34,28 @@ impl Backend {
 
         let port_path = progress::lsp_port_path(workspace);
 
-        let mut tempfile =
-            TempFile::create(&port_path).wrap_err("failed to create temp file for port")?;
+        let mut port_file = TempFile::create(&port_path).wrap_err("failed to create port file")?;
+        port_file
+            .write_all(port.to_string().as_bytes())
+            .wrap_err("failed to write port to file")?;
 
         tracing::info!("progress listener on 127.0.0.1:{port}");
-
-        tempfile.write_all(port.to_string().as_bytes())?;
 
         let client = self.client.clone();
 
         tokio::spawn(async move {
+            let _port_file = port_file;
+
             loop {
-                tokio::select! {
-                    result = listener.accept() => {
-                        match result {
-                            Ok((stream, addr)) => {
-                                tracing::debug!("progress connection from {addr}");
-                                let client = client.clone();
-                                tokio::spawn(handle_connection(stream, client));
-                            }
-                            Err(e) => {
-                                tracing::error!("accept error: {e}");
-                                break;
-                            }
-                        }
+                match listener.accept().await {
+                    Ok((stream, addr)) => {
+                        tracing::debug!("progress connection from {addr}");
+                        let client = client.clone();
+                        tokio::spawn(handle_connection(stream, client));
+                    }
+                    Err(e) => {
+                        tracing::error!("accept error: {e}");
+                        break;
                     }
                 }
             }
@@ -141,9 +139,9 @@ impl LanguageServer for Backend {
             .map_err(|_| jsonrpc::Error::internal_error())?;
 
         match workspace {
-            Some(ws) => {
+            Some(ref ws) => {
                 if let Ok(mut lock) = self.workspace.lock() {
-                    *lock = Some(ws);
+                    *lock = Some(ws.clone());
                 }
             }
             None => {


### PR DESCRIPTION
kind of an ugly change but necessary: we create a tempfile on the current thread to prevent race conditions, then pass ownership to the tokio task so that the port file exists for the duration of the LSP.