### PR TITLE
fix(lsp): also ignore new trace/debug events produced by the lux-lib progress layers

### DIFF
--- a/lux-lib/src/progress/layer.rs
+++ b/lux-lib/src/progress/layer.rs
@@ -44,6 +44,10 @@ where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, _ctx: Context<'_, S>) {
+        if *attrs.metadata().level() > tracing::Level::INFO {
+            return;
+        }
+
         with_client(|client| {
             let pid = self.next_id();
             if let Ok(mut ids) = self.span_ids.lock() {


### PR DESCRIPTION
We used to do filtering only on `on_event` but we also have to do it for newly produced events. Without this the lux.nvim progress messages are a complete mess of `trace` calls :p
