### PR TITLE
build(nix): don't disable libgit vendoring

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -29,7 +29,6 @@
 
     env = {
       # disable vendored packages
-      LIBGIT2_NO_VENDOR = 1;
       LIBSSH2_SYS_USE_PKG_CONFIG = 1;
       LUX_SKIP_IMPURE_TESTS = 1;
     };


### PR DESCRIPTION
The git2 crate check for a minimum libgit2 version, which is currently outdated in nixpkgs.
So this PR allows git2 to vendor libgit2.