### PR TITLE
feat: support detached workspace trees

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -92,7 +92,8 @@ async fn main() -> Result<()> {
                 .map(|duration| Duration::from_secs(duration as u64)),
         )
         .max_jobs(cli.max_jobs)
-        .user_tree(cli.tree)
+        .user_tree(cli.tree.clone())
+        .workspace_tree(cli.tree)
         .variables(
             cli.variables
                 .map(|variables| variables.into_iter().collect()),

--- a/lux-cli/src/config.rs
+++ b/lux-cli/src/config.rs
@@ -71,6 +71,9 @@ to initialise a config file.
         }
         ConfigCmd::Show => {
             let cfg: ConfigBuilder = config.into();
+            // NOTE: We want `lx --tree=<tree> config --current` to display
+            // a config with the user tree set, but not the workspace tree.
+            let cfg = cfg.workspace_tree(None);
             print!("{}", toml::to_string(&cfg).into_diagnostic()?);
         }
     }

--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -119,7 +119,8 @@ pub struct Cli {
     #[arg(long, value_name = "ver")]
     pub lua_version: Option<LuaVersion>,
 
-    /// Which tree to operate on.
+    /// Which tree to operate on.{n}
+    /// In a workspace, this can be used to specify a detached workspace tree.
     #[arg(long, value_name = "tree")]
     pub tree: Option<PathBuf>,
 
@@ -365,8 +366,9 @@ pub enum Commands {
     /// ensuring all packages are installed correctly.
     Sync(SyncProject),
 }
+
 impl Commands {
-    /// For project commands, try to determine the project's Lua version.
+    /// For workspace commands, try to determine the project's Lua version.
     ///
     /// Returns [`None`]:
     /// - if the project does not have an exact Lua version
@@ -409,7 +411,7 @@ impl Commands {
                 Some(PackageOrRockspec::RockSpec(_)) => None,
                 None => project_lua_version(&None),
             },
-            // project commands without a --package flag
+            // workspace commands without a --package flag
             Self::Check(_)
             | Self::Exec(_)
             | Self::Info(_)

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -43,6 +43,7 @@ pub struct Config {
     lua_dir: Option<PathBuf>,
     lua_version: Option<LuaVersion>,
     user_tree: PathBuf,
+    workspace_tree_root: Option<PathBuf>,
     verbose: bool,
     /// Don't display progress bars
     no_progress: bool,
@@ -101,6 +102,14 @@ impl Config {
         }
     }
 
+    /// Create a copy of this config with the specified workspace tree root
+    pub fn with_workspace_tree_root(self, tree: Option<PathBuf>) -> Self {
+        Self {
+            workspace_tree_root: tree,
+            ..self
+        }
+    }
+
     /// The luarocks repository server
     pub fn server(&self) -> &Url {
         &self.server
@@ -155,6 +164,11 @@ impl Config {
     /// If installing packages for a project, use `Project::tree` instead.
     pub fn user_tree(&self, version: LuaVersion) -> Result<Tree, TreeError> {
         Tree::new(self.user_tree.clone(), version, self)
+    }
+
+    /// The detached workspace tree root, if set.
+    pub(crate) fn workspace_tree_root(&self) -> Option<&PathBuf> {
+        self.workspace_tree_root.as_ref()
     }
 
     /// Whether to display verbose output of commands executed
@@ -318,6 +332,7 @@ pub struct ConfigBuilder {
     namespace: Option<String>,
     lua_version: Option<LuaVersion>,
     user_tree: Option<PathBuf>,
+    workspace_tree: Option<PathBuf>,
     lua_dir: Option<PathBuf>,
     cache_dir: Option<PathBuf>,
     data_dir: Option<PathBuf>,
@@ -423,6 +438,15 @@ impl ConfigBuilder {
     pub fn user_tree(self, tree: Option<PathBuf>) -> Self {
         Self {
             user_tree: tree.or(self.user_tree),
+            ..self
+        }
+    }
+
+    /// Which tree to operate on when in a workspace
+    /// Default: A `.lux` directory in the workspace root.
+    pub fn workspace_tree(self, tree: Option<PathBuf>) -> Self {
+        Self {
+            workspace_tree: tree.or(self.workspace_tree),
             ..self
         }
     }
@@ -586,6 +610,7 @@ impl ConfigBuilder {
             lua_dir: self.lua_dir,
             lua_version,
             user_tree,
+            workspace_tree_root: self.workspace_tree,
             verbose: self.verbose.unwrap_or(false),
             no_progress: self.no_progress.unwrap_or(false),
             no_prompt: self.no_prompt.unwrap_or(false),
@@ -625,6 +650,7 @@ impl From<Config> for ConfigBuilder {
             lua_dir: value.lua_dir,
             lua_version: value.lua_version,
             user_tree: Some(value.user_tree),
+            workspace_tree: value.workspace_tree_root,
             verbose: Some(value.verbose),
             no_progress: Some(value.no_progress),
             no_prompt: Some(value.no_prompt),

--- a/lux-lib/src/workspace/mod.rs
+++ b/lux-lib/src/workspace/mod.rs
@@ -254,11 +254,11 @@ impl Workspace {
         lua_version: LuaVersion,
         config: &Config,
     ) -> Result<Tree, WorkspaceTreeError> {
-        Ok(Tree::new(
-            self.default_tree_root_dir(),
-            lua_version,
-            config,
-        )?)
+        let root_dir = config
+            .workspace_tree_root()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(self.default_tree_root_dir());
+        Ok(Tree::new(root_dir, lua_version, config)?)
     }
 
     pub(crate) fn default_tree_root_dir(&self) -> PathBuf {


### PR DESCRIPTION
Closes #1762.

Passing `--tree <tree>` to a workspace subcommand detaches the workspace tree.