### PR TITLE
feat(lsp)!: allow setting port file via `LUX_LSP_PORT_FILE`

### DIFF
--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -70,7 +70,7 @@ pub struct Config {
 
 impl Config {
     /// Lux application directories
-    fn project_dirs() -> Result<ProjectDirs, NoValidHomeDirectory> {
+    pub(crate) fn project_dirs() -> Result<ProjectDirs, NoValidHomeDirectory> {
         directories::ProjectDirs::from("org", "lumenlabs", "lux").ok_or(NoValidHomeDirectory)
     }
 

--- a/lux-lib/src/progress/mod.rs
+++ b/lux-lib/src/progress/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::Config,
     progress::client::{LspClient, CLIENT},
     workspace::Workspace,
 };
@@ -7,8 +8,26 @@ use std::{path::PathBuf, sync::Arc};
 pub mod client;
 pub mod layer;
 
+const LUX_LSP_PORT_FILE: &str = "LUX_LSP_PORT_FILE";
+
 pub fn lsp_port_path(workspace: &Workspace) -> PathBuf {
-    workspace.root().join(".lux").join("lsp-port")
+    match std::env::var(LUX_LSP_PORT_FILE) {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            tracing::debug!("{LUX_LSP_PORT_FILE} not set.");
+            match Config::project_dirs()
+                .ok()
+                .and_then(|p| p.runtime_dir().map(|p| p.to_path_buf()))
+            {
+                // On Linux & BSD, this is /run/user/<uid>/lux/lsp-port
+                Some(runtime_dir) => runtime_dir.join("lsp-port"),
+                None => {
+                    tracing::debug!("No runtime directory. Falling back to workspace root");
+                    workspace.root().join(".lux").join("lsp-port")
+                }
+            }
+        }
+    }
 }
 
 pub fn set_connection(workspace: &Workspace) {

--- a/lux-lsp/src/main.rs
+++ b/lux-lsp/src/main.rs
@@ -162,8 +162,11 @@ impl LanguageServer for Backend {
             .log_message(MessageType::INFO, "lx-lsp initialized")
             .await;
 
-        #[allow(clippy::unwrap_used)]
-        let workspace = self.workspace.lock().unwrap().clone();
+        let workspace = self
+            .workspace
+            .lock()
+            .unwrap_or_else(|err| unreachable!("we don't panic while holding the mutex.\n{}", err))
+            .clone();
 
         match workspace {
             Some(ref ws) => {


### PR DESCRIPTION
In Neovim, we can set the `LUX_LSP_PORT_FILE` environment variable to `pathlib.stdpath("run") / lux-lsp`.