### PR TITLE
feat(build): `runner` config to wrap build commands in a sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ The following table provides a brief comparison:
 | Vendor sources for offline use                                                          | :white_check_mark:           | :x:                |
 | Distribute install tree archives                                                        | :white_check_mark:           | :x:                |
 | Distribute static binaries                                                              | :white_check_mark:           | :x:                |
-| Load RockSpecs and LuaRocks manifests with [full sandboxing](https://github.com/kyren/piccolo) | :white_check_mark:       | :x:                |
+| Load RockSpecs and LuaRocks manifests with [full sandboxing](https://github.com/kyren/piccolo) | :white_check_mark:    | :x:                |
+| Sandbox build execution                                                                 | :white_check_mark: [^4]      | :x:                |
 
 [^1]: Supported via a compatibility layer that uses LuaRocks as a backend.
 [^2]: Mostly compatible with the LuaRocks version parser,
@@ -120,6 +121,7 @@ The following table provides a brief comparison:
       To comply with SemVer, we treat anything after the third version component
       (except for the specrev) as a prerelease/build version.
 [^3]: [You Aren't Gonna Need It.](https://martinfowler.com/bliki/Yagni.html)
+[^4]: Opt-in via a `build.runner` config.
 
 ## :package: Packages
 

--- a/lux-lib/src/build/cmake.rs
+++ b/lux-lib/src/build/cmake.rs
@@ -114,11 +114,14 @@ impl BuildBackend for CMakeBuildSpec {
 
         let span = info_span!("CMake");
         spawn_cmake_cmd(
-            Command::new(config.cmake_cmd())
+            config
+                .wrapped_command(
+                    config.cmake_cmd(),
+                    ["-H.".into(), format!("-B{CMAKE_BUILD_FILE}")]
+                        .into_iter()
+                        .chain(args),
+                )
                 .current_dir(build_dir)
-                .arg("-H.")
-                .arg(format!("-B{CMAKE_BUILD_FILE}"))
-                .args(args)
                 .env("PATH", &bin_path)
                 .env("LUA_PATH", &lua_path)
                 .env("LUA_CPATH", &lua_cpath),
@@ -130,12 +133,12 @@ impl BuildBackend for CMakeBuildSpec {
         if self.build_pass {
             let span = info_span!("CMake build pass");
             spawn_cmake_cmd(
-                Command::new(config.cmake_cmd())
+                config
+                    .wrapped_command(
+                        config.cmake_cmd(),
+                        ["--build", CMAKE_BUILD_FILE, "--config", "Release"],
+                    )
                     .current_dir(build_dir)
-                    .arg("--build")
-                    .arg(CMAKE_BUILD_FILE)
-                    .arg("--config")
-                    .arg("Release")
                     .env("PATH", &bin_path)
                     .env("LUA_PATH", &lua_path)
                     .env("LUA_CPATH", &lua_cpath),
@@ -148,14 +151,19 @@ impl BuildBackend for CMakeBuildSpec {
         if self.install_pass && !no_install {
             let span = info_span!("CMake install pass");
             spawn_cmake_cmd(
-                Command::new(config.cmake_cmd())
+                config
+                    .wrapped_command(
+                        config.cmake_cmd(),
+                        [
+                            "--build",
+                            CMAKE_BUILD_FILE,
+                            "--target",
+                            "install",
+                            "--config",
+                            "Release",
+                        ],
+                    )
                     .current_dir(build_dir)
-                    .arg("--build")
-                    .arg(CMAKE_BUILD_FILE)
-                    .arg("--target")
-                    .arg("install")
-                    .arg("--config")
-                    .arg("Release")
                     .env("PATH", &bin_path)
                     .env("LUA_PATH", &lua_path)
                     .env("LUA_CPATH", &lua_cpath),

--- a/lux-lib/src/build/command.rs
+++ b/lux-lib/src/build/command.rs
@@ -6,7 +6,7 @@ use std::{
     process::{ExitStatus, Stdio},
 };
 use thiserror::Error;
-use tokio::process::Command;
+
 use tracing::{info_span, Instrument};
 use which::which;
 
@@ -136,9 +136,8 @@ async fn run_command(
     let (shell, shell_arg) = (which("sh")?, "-c");
 
     let span = info_span!("Running build command", command = substituted_cmd);
-    match Command::new(shell)
-        .arg(shell_arg)
-        .arg(&substituted_cmd)
+    match config
+        .wrapped_command(shell, [shell_arg, &substituted_cmd])
         .current_dir(build_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/lux-lib/src/build/make.rs
+++ b/lux-lib/src/build/make.rs
@@ -7,7 +7,7 @@ use std::{
     process::{ExitStatus, Stdio},
 };
 use thiserror::Error;
-use tokio::process::Command;
+
 use tracing::{info_span, Instrument};
 
 use crate::{
@@ -91,22 +91,22 @@ impl BuildBackend for MakeBuildSpec {
                     Ok(format!("{key}={substituted_value}").trim().to_string())
                 })
                 .try_collect::<_, Vec<_>, Self::Err>()?;
-            let mut cmd = Command::new(config.make_cmd());
+            let mut make_args: Vec<String> = Vec::new();
             if let Some(build_target) = &self.build_target {
-                cmd.arg(build_target);
+                make_args.push(build_target.clone());
             }
-            let span = info_span!("Make build pass");
-            match cmd
-                .current_dir(build_dir)
-                .args(["-f", &self.makefile.to_slash_lossy()])
+            make_args.push("-f".into());
+            make_args.push(self.makefile.to_slash_lossy().into());
+            make_args.extend(build_args);
+            let mut cmd = config.wrapped_command(config.make_cmd(), make_args);
+            cmd.current_dir(build_dir)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
-                .args(build_args)
                 .env("PATH", &bin_path)
                 .env("LUA_PATH", &lua_path)
-                .env("LUA_CPATH", &lua_cpath)
-                .spawn()
-            {
+                .env("LUA_CPATH", &lua_cpath);
+            let span = info_span!("Make build pass");
+            match cmd.spawn() {
                 Ok(child) => match child.wait_with_output().instrument(span).await {
                     Ok(output) if output.status.success() => utils::trace_command_output(&output),
                     Ok(output) => {
@@ -148,11 +148,14 @@ impl BuildBackend for MakeBuildSpec {
                 })
                 .try_collect::<_, Vec<_>, Self::Err>()?;
             let span = info_span!("Make install pass");
-            match Command::new(config.make_cmd())
+            let mut install_cmd_args: Vec<String> = Vec::with_capacity(install_args.len() + 3);
+            install_cmd_args.push(self.install_target.clone());
+            install_cmd_args.push("-f".into());
+            install_cmd_args.push(self.makefile.to_slash_lossy().into());
+            install_cmd_args.extend(install_args);
+            match config
+                .wrapped_command(config.make_cmd(), install_cmd_args)
                 .current_dir(build_dir)
-                .arg(&self.install_target)
-                .args(["-f", &self.makefile.to_slash_lossy()])
-                .args(install_args)
                 .env("PATH", &bin_path)
                 .env("LUA_PATH", &lua_path)
                 .env("LUA_CPATH", &lua_cpath)

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -12,7 +12,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use thiserror::Error;
-use tokio::process::Command;
+
 use tracing::{info_span, Instrument};
 
 #[derive(Error, Debug, Diagnostic)]
@@ -70,9 +70,9 @@ impl BuildBackend for RustMluaBuildSpec {
         build_args.extend(self.cargo_extra_args.iter().map(|arg| arg.as_str()));
         {
             let span = info_span!("Compiling rust-mlua module");
-            match Command::new("cargo")
+            match config
+                .wrapped_command("cargo", build_args)
                 .current_dir(build_dir)
-                .args(build_args)
                 .output()
                 .instrument(span)
                 .await

--- a/lux-lib/src/config/build.rs
+++ b/lux-lib/src/config/build.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the build process.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(super) struct BuildConfig {
+    /// Command prefix with which to wrap all build commands.
+    ///
+    /// If set, every command spawned by the build backends is invoked as
+    /// `runner + [command, arguments...]`.
+    ///
+    /// If unset, no wrapping is performed.
+    #[serde(default)]
+    pub(super) runner: Vec<String>,
+}

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -1,12 +1,15 @@
+use build::BuildConfig;
 use directories::ProjectDirs;
 use external_deps::ExternalDependencySearchConfig;
 use itertools::Itertools;
 
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize, Serializer};
+use std::ffi::OsStr;
 use std::path::Path;
 use std::{collections::HashMap, env, path::PathBuf, time::Duration};
 use thiserror::Error;
+use tokio::process::Command;
 use tree::RockLayoutConfig;
 use url::Url;
 
@@ -18,6 +21,7 @@ use crate::tree::{Tree, TreeError};
 use crate::variables::GetVariableError;
 use crate::{build::utils, variables::HasVariables};
 
+pub mod build;
 pub mod external_deps;
 pub mod tree;
 
@@ -54,6 +58,7 @@ pub struct Config {
     max_jobs: usize,
     variables: HashMap<String, String>,
     external_deps: ExternalDependencySearchConfig,
+    build: BuildConfig,
     entrypoint_layout: RockLayoutConfig,
 
     cache_dir: PathBuf,
@@ -215,6 +220,29 @@ impl Config {
         }
     }
 
+    /// Construct a [`Command`] for the given program and arguments,
+    /// wrapped in the configured [`BuildConfig::runner`], if any.
+    ///
+    /// If no runner is configured, this is equivalent to
+    /// `Command::new(program).args(args)`.
+    pub(crate) fn wrapped_command<P, A>(&self, program: P, args: A) -> Command
+    where
+        P: AsRef<OsStr>,
+        A: IntoIterator,
+        A::Item: AsRef<OsStr>,
+    {
+        if self.build.runner.is_empty() {
+            let mut cmd = Command::new(program);
+            cmd.args(args);
+            cmd
+        } else {
+            let runner = &self.build.runner;
+            let mut cmd = Command::new(&runner[0]);
+            cmd.args(&runner[1..]).arg(program).args(args);
+            cmd
+        }
+    }
+
     /// Variable names, mapped to their values.
     /// Lux populates variables in the `lux.toml` and in RockSpecs
     /// with these before building.
@@ -347,6 +375,8 @@ pub struct ConfigBuilder {
     variables: Option<HashMap<String, String>>,
     #[serde(default)]
     external_deps: ExternalDependencySearchConfig,
+    #[serde(default)]
+    build: BuildConfig,
     #[serde(default)]
     entrypoint_layout: RockLayoutConfig,
     user_agent: Option<String>,
@@ -595,6 +625,64 @@ impl ConfigBuilder {
         }
     }
 
+    /// The command prefix with which to wrap all build commands.
+    ///
+    /// If set, every command spawned by the build backends (`make`, `cmake`,
+    /// `rust-mlua`, `command`, and `luarocks`) is invoked as
+    /// `runner + [command, arguments...]`.
+    ///
+    /// If unset, no wrapping is performed.
+    ///
+    /// # Examples
+    ///
+    /// Use [`bubblewrap`](https://github.com/containers/bubblewrap) to run
+    /// builds in a sandbox with read-only access to the rest of the
+    /// filesystem (Linux):
+    ///
+    /// ```toml
+    /// [build]
+    /// runner = [
+    ///     "bwrap",
+    ///     "--ro-bind", "/", "/",
+    ///     "--dev-bind", "/dev", "/dev",
+    ///     "--proc", "/proc",
+    ///     "--bind", "/tmp", "/tmp",
+    ///     "--bind", "/home/user/.cache/lux", "/home/user/.cache/lux",
+    ///     "--bind", "/home/user/.local/share/lux", "/home/user/.local/share/lux",
+    ///     "--unshare-net",
+    ///     "--new-session",
+    /// ]
+    /// ```
+    ///
+    /// Or use `sandbox-exec` with a seatbelt profile (macOS):
+    ///
+    /// ```text
+    /// (version 1)
+    /// (deny default)
+    /// (allow file-read*)
+    /// (allow process*)
+    /// (allow sysctl-read)
+    /// (allow file-write* (subpath "/tmp") (subpath "/Users/user/Library/Caches/lux") (subpath "/Users/user/.local/share/lux"))
+    /// ```
+    ///
+    /// ```toml
+    /// [build]
+    /// runner = ["sandbox-exec", "-f", "/Users/user/sandbox.sb"]
+    /// ```
+    ///
+    /// The writable directories must cover the places lux writes to during a
+    /// build: the temporary build directory (a tempfile, usually under
+    /// `/tmp`), the install tree (under the data directory), and cache
+    /// directories used by the various build backends.
+    pub fn build_runner(self, runner: Option<Vec<String>>) -> Self {
+        Self {
+            build: BuildConfig {
+                runner: runner.unwrap_or(self.build.runner),
+            },
+            ..self
+        }
+    }
+
     /// Merge with another [`ConfigBuilder`]. The other one takes precedence.
     pub fn merge(self, other: Self) -> Self {
         Self {
@@ -618,6 +706,7 @@ impl ConfigBuilder {
             max_jobs: other.max_jobs.or(self.max_jobs),
             variables: other.variables.or(self.variables),
             external_deps: other.external_deps,
+            build: other.build,
             entrypoint_layout: other.entrypoint_layout,
             user_agent: other.user_agent.or(self.user_agent),
             generate_luarc: other.generate_luarc.or(self.generate_luarc),
@@ -661,6 +750,7 @@ impl ConfigBuilder {
                 .chain(self.variables.unwrap_or_default())
                 .collect(),
             external_deps: self.external_deps,
+            build: self.build,
             entrypoint_layout: self.entrypoint_layout,
             cache_dir,
             data_dir,
@@ -703,6 +793,7 @@ impl From<Config> for ConfigBuilder {
             data_dir: Some(value.data_dir),
             vendor_dir: value.vendor_dir,
             external_deps: value.external_deps,
+            build: value.build,
             entrypoint_layout: value.entrypoint_layout,
             user_agent: Some(value.user_agent),
             generate_luarc: Some(value.generate_luarc),
@@ -771,5 +862,45 @@ where
             serializer.serialize_some(&url_strings)
         }
         None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn wrapped_command_without_runner() {
+        let echo = which::which("echo").unwrap();
+        let config = ConfigBuilder::default().build().unwrap();
+        let output = config
+            .wrapped_command(&echo, ["hello", "world"])
+            .output()
+            .await
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "hello world"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrapped_command_prepends_runner_argv() {
+        let echo = which::which("echo").unwrap();
+        let config = ConfigBuilder::default()
+            .build_runner(Some(vec![echo.to_string_lossy().into(), "--prefix".into()]))
+            .build()
+            .unwrap();
+        let output = config
+            .wrapped_command("world", Vec::<String>::new())
+            .output()
+            .await
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "--prefix world"
+        );
     }
 }

--- a/lux-lib/src/luarocks/luarocks_installation.rs
+++ b/lux-lib/src/luarocks/luarocks_installation.rs
@@ -7,7 +7,6 @@ use std::{
     process::ExitStatus,
 };
 use thiserror::Error;
-use tokio::process::Command;
 
 use crate::{
     build::{self, BuildError},
@@ -268,9 +267,10 @@ variables = {{
         if !luarocks_bin.is_file() {
             return Err(ExecLuaRocksError::LuarocksBinNotFound(luarocks_bin));
         }
-        let output = Command::new(luarocks_bin)
+        let output = self
+            .config
+            .wrapped_command(luarocks_bin, args)
             .current_dir(cwd)
-            .args(args)
             .env("PATH", luarocks_paths.path_prepended().joined())
             .env("LUA_PATH", luarocks_paths.package_path().joined())
             .env("LUA_CPATH", luarocks_paths.package_cpath().joined())


### PR DESCRIPTION
Closes #1313.

This allows us to support build sandboxing without the maintenance burden of having to implement it ourselves.

Example configs:

## Linux - bubblewrap

```toml
[build]
runner = [
  "bwrap",
  "--ro-bind", "/", "/",
  "--dev-bind", "/dev", "/dev",
  "--proc", "/proc",
  "--bind", "/tmp", "/tmp",
  "--bind", "/home/user/.cache/lux", "/home/user/.cache/lux",
  "--bind", "/home/user/.local/share/lux", "/home/user/.local/share/lux",
  "--unshare-net",
  "--new-session",
]
```

## macOS - seatbelt

 ```text
(version 1)
(deny default)
(allow file-read*)
(allow process*)
(allow sysctl-read)
(allow file-write* (subpath "/tmp") (subpath "/Users/user/Library/Caches/lux") (subpath "/Users/user/.local/share/lux"))
```

```toml
[build]
runner = ["sandbox-exec", "-f", "/Users/user/sandbox.sb"]
```