### PR TITLE
feat(build): `release` and `dev` profiles

### DIFF
--- a/lux-cli/src/lib.rs
+++ b/lux-cli/src/lib.rs
@@ -149,6 +149,11 @@ pub struct Cli {
     #[arg(long, value_name = "variable", visible_short_alias = 'v', value_parser = parse_key_val::<String, String>)]
     pub variables: Option<Vec<(String, String)>>,
 
+    /// The build profile to use when compiling packages.{n}
+    /// Default: `release`.
+    #[arg(long, value_enum, value_name = "profile")]
+    pub profile: Option<lux_lib::config::build::Profile>,
+
     /// Display verbose output of commands executed, enabling DEBUG logs.{n}
     /// To enable TRACE logs, set RUST_LOG=trace.
     #[arg(long)]
@@ -454,14 +459,17 @@ impl Commands {
     /// if present and running a workspace command.
     pub fn config(&self) -> Result<ConfigBuilder> {
         let config = ConfigBuilder::new()?;
-        if let Some(workspace_config) = self
-            .workspace()?
-            .map(|ws| ws.config())
-            .transpose()
-            .into_diagnostic()?
-            .flatten()
-        {
-            Ok(config.merge(workspace_config))
+        if let Some(workspace) = self.workspace()? {
+            let config = if let Some(workspace_config) = workspace.config()? {
+                config.merge(workspace_config)
+            } else {
+                config
+            };
+            if let Self::Dist(_) = self {
+                Ok(config)
+            } else {
+                Ok(config.default_build_profile(lux_lib::config::build::Profile::Dev))
+            }
         } else {
             Ok(config)
         }

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -1,6 +1,7 @@
 use super::utils::c_dylib_extension;
 use crate::build::backend::{BuildBackend, BuildInfo, RunBuildArgs};
 use crate::build::utils;
+use crate::config::build;
 use crate::fs;
 use crate::lua_version::{LuaVersion, LuaVersionUnset};
 use crate::tree::InstallTree;
@@ -61,7 +62,11 @@ impl BuildBackend for RustMluaBuildSpec {
             .chain(std::iter::once(lua_feature.into()))
             .join(",");
         let target_dir_arg = format!("--target-dir={}", self.target_path.display());
-        let mut build_args = vec!["build", "--release", &target_dir_arg];
+        let mut build_args = vec!["build"];
+        if config.build_profile() == build::Profile::Release {
+            build_args.push("--release");
+        }
+        build_args.push(&target_dir_arg);
         if !self.default_features {
             build_args.push("--no-default-features");
         }
@@ -69,7 +74,10 @@ impl BuildBackend for RustMluaBuildSpec {
         build_args.push(&features);
         build_args.extend(self.cargo_extra_args.iter().map(|arg| arg.as_str()));
         {
-            let span = info_span!("Compiling rust-mlua module");
+            let span = info_span!(
+                "Compiling rust-mlua module",
+                profile = config.build_profile().to_string()
+            );
             match config
                 .wrapped_command("cargo", build_args)
                 .current_dir(build_dir)
@@ -89,8 +97,18 @@ impl BuildBackend for RustMluaBuildSpec {
             }
         }
         fs::tokio::create_dir_all(&output_paths.lib).await?;
-        if let Err(err) =
-            install_rust_libs(self.modules, &self.target_path, build_dir, output_paths).await
+        let profile_dir = match config.build_profile() {
+            build::Profile::Release => "release",
+            build::Profile::Dev => "debug",
+        };
+        if let Err(err) = install_rust_libs(
+            self.modules,
+            &self.target_path,
+            build_dir,
+            output_paths,
+            profile_dir,
+        )
+        .await
         {
             cleanup(output_paths).await;
             return Err(err.into());
@@ -110,9 +128,10 @@ async fn install_rust_libs(
     target_path: &Path,
     build_dir: &Path,
     output_paths: &RockLayout,
+    profile_dir: &str,
 ) -> Result<(), fs::FsError> {
     for (module, rust_lib) in modules {
-        let src = build_dir.join(target_path).join("release").join(rust_lib);
+        let src = build_dir.join(target_path).join(profile_dir).join(rust_lib);
         let mut dst: PathBuf = output_paths.lib.join(module);
         dst.set_extension(c_dylib_extension());
         fs::tokio::copy(&src, &dst).await?;

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -22,7 +22,7 @@ use std::{
 use target_lexicon::Triple;
 use thiserror::Error;
 use tokio::process::Command;
-use tracing::span;
+use tracing::{info_span, span};
 use which::which;
 
 #[cfg(unix)]
@@ -149,7 +149,6 @@ if no C compiler was found, run `lx debug toolchains` to verify your build tools
 /// Compiles a set of C files into a single dynamic library and places them under `{target_dir}/{target_file}`.
 /// # Panics
 /// Panics if no parent or no filename can be determined for the target path.
-#[tracing::instrument(name = "Compiling C files", skip_all)]
 pub(crate) async fn compile_c_files(
     files: &Vec<PathBuf>,
     target_module: &LuaModule,
@@ -158,6 +157,11 @@ pub(crate) async fn compile_c_files(
     external_dependencies: &HashMap<String, ExternalDependencyInfo>,
     config: &Config,
 ) -> Result<(), CompileCFilesError> {
+    let span = info_span!(
+        "Compiling C files",
+        profile = config.build_profile().to_string()
+    );
+    let _enter = span.enter();
     let target = target_dir.join(target_module.to_lib_path());
     let target_parent_dir = target.parent().unwrap_or_else(|| {
         unreachable!(
@@ -194,7 +198,7 @@ pub(crate) async fn compile_c_files(
                 .values()
                 .filter_map(|dep| dep.include_dir.as_ref()),
         )
-        .opt_level(3)
+        .opt_level(config.build_profile().opt_level())
         .out_dir(intermediate_dir);
 
     let compiler = build.try_get_compiler()?;
@@ -347,7 +351,6 @@ pub enum LinkCModulesError {
 /// Compiles a set of C files (with extra metadata) to a given destination.
 /// # Panics
 /// Panics if no filename for the target path can be determined.
-#[tracing::instrument(name = "Compiling C modules", skip_all)]
 pub(crate) async fn compile_c_modules(
     data: &ModulePaths,
     source_dir: &Path,
@@ -357,6 +360,11 @@ pub(crate) async fn compile_c_modules(
     external_dependencies: &HashMap<String, ExternalDependencyInfo>,
     config: &Config,
 ) -> Result<(), CompileCModulesError> {
+    let span = info_span!(
+        "Compiling C modules",
+        profile = config.build_profile().to_string()
+    );
+    let _enter = span.enter();
     let target = target_dir.join(target_module.to_lib_path());
 
     let target_parent_dir = target.parent().unwrap_or_else(|| {
@@ -420,7 +428,7 @@ pub(crate) async fn compile_c_modules(
                 .values()
                 .filter_map(|dep| dep.include_dir.as_ref()),
         )
-        .opt_level(3)
+        .opt_level(config.build_profile().opt_level())
         .out_dir(intermediate_dir);
 
     let compiler = build.try_get_compiler()?;

--- a/lux-lib/src/config/build.rs
+++ b/lux-lib/src/config/build.rs
@@ -1,8 +1,12 @@
 use serde::{Deserialize, Serialize};
+use strum_macros::Display;
 
 /// Configuration for the build process.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(super) struct BuildConfig {
+    /// The build profile to use when compiling packages.
+    /// Default: [`BuildProfile::Release`]
+    pub(super) profile: Option<Profile>,
     /// Command prefix with which to wrap all build commands.
     ///
     /// If set, every command spawned by the build backends is invoked as
@@ -11,4 +15,24 @@ pub(super) struct BuildConfig {
     /// If unset, no wrapping is performed.
     #[serde(default)]
     pub(super) runner: Vec<String>,
+}
+
+/// The build profile to use when compiling packages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Display)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum Profile {
+    Release,
+    Dev,
+}
+
+impl Profile {
+    /// The C compiler optimization level for this profile.
+    pub fn opt_level(self) -> u32 {
+        match self {
+            Self::Release => 3,
+            Self::Dev => 0,
+        }
+    }
 }

--- a/lux-lib/src/config/mod.rs
+++ b/lux-lib/src/config/mod.rs
@@ -58,6 +58,7 @@ pub struct Config {
     max_jobs: usize,
     variables: HashMap<String, String>,
     external_deps: ExternalDependencySearchConfig,
+
     build: BuildConfig,
     entrypoint_layout: RockLayoutConfig,
 
@@ -243,6 +244,15 @@ impl Config {
         }
     }
 
+    /// The build profile to use when compiling packages.
+    pub(crate) fn build_profile(&self) -> build::Profile {
+        self.build
+            .profile
+            .as_ref()
+            .cloned()
+            .unwrap_or(build::Profile::Release)
+    }
+
     /// Variable names, mapped to their values.
     /// Lux populates variables in the `lux.toml` and in RockSpecs
     /// with these before building.
@@ -377,6 +387,7 @@ pub struct ConfigBuilder {
     external_deps: ExternalDependencySearchConfig,
     #[serde(default)]
     build: BuildConfig,
+
     #[serde(default)]
     entrypoint_layout: RockLayoutConfig,
     user_agent: Option<String>,
@@ -678,6 +689,30 @@ impl ConfigBuilder {
         Self {
             build: BuildConfig {
                 runner: runner.unwrap_or(self.build.runner),
+                ..self.build
+            },
+            ..self
+        }
+    }
+
+    /// The build profile to use when compiling packages.
+    /// Default: [`BuildProfile::Release`], if not set by [`Self::default_build_profile`].
+    pub fn build_profile(self, profile: Option<build::Profile>) -> Self {
+        Self {
+            build: BuildConfig {
+                profile: profile.or(self.build.profile),
+                ..self.build
+            },
+            ..self
+        }
+    }
+
+    /// set the default build profile to use when compiling packages.
+    pub fn default_build_profile(self, profile: build::Profile) -> Self {
+        Self {
+            build: BuildConfig {
+                profile: self.build.profile.or(Some(profile)),
+                ..self.build
             },
             ..self
         }
@@ -706,7 +741,10 @@ impl ConfigBuilder {
             max_jobs: other.max_jobs.or(self.max_jobs),
             variables: other.variables.or(self.variables),
             external_deps: other.external_deps,
-            build: other.build,
+            build: BuildConfig {
+                profile: other.build.profile.or(self.build.profile),
+                ..other.build
+            },
             entrypoint_layout: other.entrypoint_layout,
             user_agent: other.user_agent.or(self.user_agent),
             generate_luarc: other.generate_luarc.or(self.generate_luarc),

--- a/lux-lib/src/operations/dist_bin.rs
+++ b/lux-lib/src/operations/dist_bin.rs
@@ -337,7 +337,7 @@ async fn compile_binary(
         .warnings(config.verbose())
         .host(&host)
         .target(&host)
-        .opt_level(3)
+        .opt_level(config.build_profile().opt_level())
         .out_dir(&intermediate_dir);
 
     let compiler = build.try_get_compiler()?;


### PR DESCRIPTION
Closes #1712.

- `dev` is the default for local workspace builds.
  It compiles with `-O0` and Cargo's `dev` profile.
- `release` is the default for installs and the `dist`
  commands.
  It compiles with `-O3` and Cargo's `release` profile.