### PR TITLE
fix(error-reporting): don't embed error source in error messages

### DIFF
--- a/lux-lib/src/build/command.rs
+++ b/lux-lib/src/build/command.rs
@@ -46,7 +46,7 @@ pub enum CommandError {
         err: shell_words::ParseError,
         command: String,
     },
-    #[error("cannot find a shell to execute the command:\n{0}")]
+    #[error("cannot find a shell to execute the command")]
     ShellNotFoundError(#[from] which::Error),
     #[error("error executing command:\n{command}\n\nerror: {err}")]
     Io { err: io::Error, command: String },

--- a/lux-lib/src/build/luarocks.rs
+++ b/lux-lib/src/build/luarocks.rs
@@ -25,10 +25,10 @@ pub enum LuarocksBuildError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
-    #[error("error instantiating luarocks compatibility layer:\n{0}")]
+    #[error("error instantiating luarocks compatibility layer")]
     #[diagnostic(forward(0))]
     LuaRocksError(#[from] LuaRocksError),
-    #[error("error running 'luarocks make':\n{0}")]
+    #[error("error running 'luarocks make'")]
     #[diagnostic(forward(0))]
     ExecLuaRocksError(#[from] ExecLuaRocksError),
     #[error(transparent)]
@@ -36,7 +36,7 @@ pub enum LuarocksBuildError {
     Tree(#[from] TreeError),
     #[error("{0}")] // We don't know the concrete error type
     Rockspec(String),
-    #[error("error installing luarocks compatibility layer:\n{0}")]
+    #[error("error installing luarocks compatibility layer")]
     #[diagnostic(forward(0))]
     LuaVersion(#[from] LuaVersionError),
 }

--- a/lux-lib/src/build/make.rs
+++ b/lux-lib/src/build/make.rs
@@ -37,8 +37,8 @@ pub enum MakeError {
         stdout: String,
         stderr: String,
     },
-    #[error("failed to run `make` step: {0}")]
-    Io(io::Error),
+    #[error("failed to run `make` step")]
+    Io(#[source] io::Error),
     #[error("failed to run `make` step: '{0}' command not found!")]
     #[diagnostic(help("run `lx debug toolchains` to check available build tools."))]
     CommandNotFound(String),

--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -119,31 +119,31 @@ where
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum BuildError {
-    #[error("builtin build failed: {0}")]
+    #[error("builtin build failed")]
     #[diagnostic(forward(0))]
     Builtin(#[from] BuiltinBuildError),
-    #[error("cmake build failed: {0}")]
+    #[error("cmake build failed")]
     #[diagnostic(forward(0))]
     CMake(#[from] CMakeError),
-    #[error("make build failed: {0}")]
+    #[error("make build failed")]
     #[diagnostic(forward(0))]
     Make(#[from] MakeError),
-    #[error("command build failed: {0}")]
+    #[error("command build failed")]
     #[diagnostic(forward(0))]
     Command(#[from] CommandError),
-    #[error("rust-mlua build failed: {0}")]
+    #[error("rust-mlua build failed")]
     #[diagnostic(forward(0))]
     Rust(#[from] RustError),
-    #[error("treesitter-parser build failed: {0}")]
+    #[error("treesitter-parser build failed")]
     #[diagnostic(forward(0))]
     TreesitterBuild(#[from] TreesitterBuildError),
-    #[error("luarocks build failed: {0}")]
+    #[error("luarocks build failed")]
     #[diagnostic(forward(0))]
     LuarocksBuild(#[from] LuarocksBuildError),
-    #[error("building from rock source failed: {0}")]
+    #[error("building from rock source failed")]
     #[diagnostic(forward(0))]
     SourceBuild(#[from] SourceBuildError),
-    #[error("IO operation failed: {0}")]
+    #[error("IO operation failed")]
     Io(#[from] io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -182,10 +182,10 @@ check the source, then rerun the command with `--no-lock` to update the hash."#
         expected: Integrity,
         actual: Integrity,
     },
-    #[error("failed to unpack src.rock:\n{0}")]
+    #[error("failed to unpack src.rock")]
     #[diagnostic(forward(0))]
     UnpackSrcRock(UnpackError),
-    #[error("failed to fetch rock source:\n{0}")]
+    #[error("failed to fetch rock source")]
     #[diagnostic(forward(0))]
     FetchSrcError(#[from] FetchSrcError),
     #[error("failed to install binary '{file_name}'")]

--- a/lux-lib/src/build/source.rs
+++ b/lux-lib/src/build/source.rs
@@ -36,25 +36,25 @@ pub enum SourceBuildError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaRockspec(#[from] LuaRockspecError),
-    #[error("builtin build failed: {0}")]
+    #[error("builtin build failed")]
     #[diagnostic(forward(0))]
     Builtin(#[from] BuiltinBuildError),
-    #[error("cmake build failed: {0}")]
+    #[error("cmake build failed")]
     #[diagnostic(forward(0))]
     CMake(#[from] CMakeError),
-    #[error("make build failed: {0}")]
+    #[error("make build failed")]
     #[diagnostic(forward(0))]
     Make(#[from] MakeError),
-    #[error("command build failed: {0}")]
+    #[error("command build failed")]
     #[diagnostic(forward(0))]
     Command(#[from] CommandError),
-    #[error("rust-mlua build failed: {0}")]
+    #[error("rust-mlua build failed")]
     #[diagnostic(forward(0))]
     Rust(#[from] RustError),
-    #[error("treesitter-parser build failed: {0}")]
+    #[error("treesitter-parser build failed")]
     #[diagnostic(forward(0))]
     TreesitterBuild(#[from] TreesitterBuildError),
-    #[error("cannot build from a project source that requires a luarocks build backend: {0}")]
+    #[error("cannot build from a project source that requires a luarocks build backend: '{0}'")]
     #[diagnostic(help(
         r#"lux does not support building from source with a luarocks build backend.
 Use a pre-built rock or a different build backend."#

--- a/lux-lib/src/build/treesitter_parser.rs
+++ b/lux-lib/src/build/treesitter_parser.rs
@@ -18,12 +18,12 @@ pub enum TreesitterBuildError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaVersionUnset(#[from] LuaVersionUnset),
-    #[error("invalid TREE_SITTER_LANGUAGE_VERSION: {0}")]
+    #[error("invalid TREE_SITTER_LANGUAGE_VERSION")]
     #[diagnostic(help(
         "check the value of the TREE_SITTER_LANGUAGE_VERSION environment variable."
     ))]
     ParseAbiVersion(#[from] ParseIntError),
-    #[error("error generating tree-sitter grammar: {0}")]
+    #[error("error generating tree-sitter grammar")]
     #[diagnostic(help("check the grammar source files for errors."))]
     Generate(#[from] GenerateError),
     #[error("error compiling the tree-sitter grammar: {0}")]

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -142,7 +142,7 @@ ensure the C compiler has access to the required include paths."#
 if no C compiler was found, run `lx debug toolchains` to verify your build tools."#
     ))]
     Compilation(#[from] cc::Error),
-    #[error("error compiling C files (linking failed):\n{0}")]
+    #[error("error compiling C files (linking failed)")]
     #[diagnostic(forward(0))]
     Link(#[from] LinkCModulesError),
 }
@@ -310,19 +310,19 @@ pub enum CompileCModulesError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
-    #[error("failed to compile intermediates from C modules: {0}")]
+    #[error("failed to compile intermediates from C modules")]
     #[diagnostic(help(
         r#"check the compiler output above for missing headers or syntax errors.
 ensure the C compiler has access to the required include paths."#
     ))]
-    CompileIntermediates(cc::Error),
-    #[error("error compiling C modules (compilation failed):\n{0}")]
+    CompileIntermediates(#[source] cc::Error),
+    #[error("error compiling C modules (compilation failed)")]
     #[diagnostic(help(
         r#"check the compiler output above for details.
 if no C compiler was found, run `lx debug toolchains` to verify your build tools."#
     ))]
     Compilation(#[from] cc::Error),
-    #[error("error compiling C modules (linking failed):\n{0}")]
+    #[error("error compiling C modules (linking failed)")]
     #[diagnostic(forward(0))]
     Link(#[from] LinkCModulesError),
     #[error(transparent)]
@@ -333,14 +333,14 @@ if no C compiler was found, run `lx debug toolchains` to verify your build tools
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum LinkCModulesError {
-    #[error("IO operation failed while linking C modules:\n{0}")]
+    #[error("IO operation failed while linking C modules")]
     Io(#[from] io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
     #[error(transparent)]
     CC(#[from] cc::Error),
-    #[error("error compiling C modules (output validation failed): {0}")]
+    #[error("error compiling C modules (output validation failed)")]
     #[diagnostic(forward(0))]
     OutputValidation(#[from] OutputValidationError),
     #[error("compiling C modules succeeded, but the expected library {0} was not created")]

--- a/lux-lib/src/git/url.rs
+++ b/lux-lib/src/git/url.rs
@@ -15,7 +15,7 @@ pub struct RemoteGitUrl {
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum RemoteGitUrlParseError {
-    #[error("error parsing git URL:\n{0}")]
+    #[error("error parsing git URL")]
     GitUrlParse(#[from] url::ParseError),
     #[error("unsupported git remote scheme {scheme} in URL {url}")]
     UnsupportedRemoteScheme { scheme: String, url: Url },

--- a/lux-lib/src/git/utils.rs
+++ b/lux-lib/src/git/utils.rs
@@ -9,15 +9,15 @@ pub enum GitError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
-    #[error("error initializing temporary bare git repository to fetch metadata: {0}")]
-    BareRepoInit(git2::Error),
-    #[error("error initializing remote repository '{0}' to fetch metadata: {1}")]
-    RemoteInit(String, git2::Error),
-    #[error("error fetching from remote repository '{0}': {1}")]
-    RemoteFetch(String, git2::Error),
-    #[error("error listing remote refs for '{0}': {1}")]
-    RemoteList(String, git2::Error),
-    #[error("could not determine latest tag or commit sha for {0}")]
+    #[error("error initializing temporary bare git repository to fetch metadata")]
+    BareRepoInit(#[source] git2::Error),
+    #[error("error initializing remote repository '{0}' to fetch metadata")]
+    RemoteInit(String, #[source] git2::Error),
+    #[error("error fetching from remote repository '{0}'")]
+    RemoteFetch(String, #[source] git2::Error),
+    #[error("error listing remote refs for '{0}'")]
+    RemoteList(String, #[source] git2::Error),
+    #[error("could not determine latest tag or commit sha for '{0}'")]
     NoTagOrCommitSha(String),
 }
 

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -551,7 +551,7 @@ impl From<PackageVersionReq> for LockConstraint {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum LockConstraintParseError {
-    #[error("Invalid constraint in LuaPackage: {0}")]
+    #[error("Invalid constraint in LuaPackage")]
     #[diagnostic(forward(0))]
     LockConstraintParseError(#[from] PackageVersionReqError),
 }
@@ -785,10 +785,10 @@ pub enum LockfileError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
-    #[error("error parsing lockfile from JSON: {0}")]
-    ParseJson(serde_json::Error),
-    #[error("error writing lockfile to JSON: {0}")]
-    WriteJson(serde_json::Error),
+    #[error("error parsing lockfile from JSON")]
+    ParseJson(#[source] serde_json::Error),
+    #[error("error writing lockfile to JSON")]
+    WriteJson(#[source] serde_json::Error),
     #[error("attempt load to a lockfile that does not match the expected rock layout.")]
     MismatchedRockLayout,
 }

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -91,7 +91,7 @@ pub enum DetectLuaVersionError {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum LuaInstallationError {
-    #[error("could not find a Lua installation and failed to build Lua from source:\n{0}")]
+    #[error("could not find a Lua installation and failed to build Lua from source")]
     #[diagnostic(forward(0))]
     Build(#[from] BuildLuaError),
     #[error(transparent)]

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -74,19 +74,19 @@ try reducing the number of dependencies or simplifying build instructions.
     },
     #[error("{}copy_directories cannot contain the rockspec name", ._0.as_ref().map(|p| format!("{p}: ")).unwrap_or_default())]
     CopyDirectoriesContainRockspecName(Option<String>),
-    #[error("cannot create Lua rockspec with off-spec dependency: {0}")]
+    #[error("cannot create Lua rockspec with off-spec dependency")]
     #[diagnostic(
         code(lux_lib::lua_rockspec::off_spec_dependency),
         url("https://lux.lumen-labs.org/reference/lux-toml#dependencies")
     )]
     OffSpecDependency(PackageName),
-    #[error("cannot create Lua rockspec with off-spec build dependency: {0}")]
+    #[error("cannot create Lua rockspec with off-spec build dependency")]
     #[diagnostic(
         code(lux_lib::lua_rockspec::off_spec_build_dependency),
         url("https://lux.lumen-labs.org/reference/lux-toml#dependencies")
     )]
     OffSpecBuildDependency(PackageName),
-    #[error("cannot create Lua rockspec with off-spec test dependency: {0}")]
+    #[error("cannot create Lua rockspec with off-spec test dependency")]
     #[diagnostic(
         code(lux_lib::lua_rockspec::off_spec_test_dependency),
         url("https://lux.lumen-labs.org/reference/lux-toml#dependencies")
@@ -680,7 +680,7 @@ where
 
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
-#[error("invalid rockspec format: {0}")]
+#[error("invalid rockspec format")]
 pub struct InvalidRockspecFormat(String);
 
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/lux-lib/src/lua_rockspec/partial.rs
+++ b/lux-lib/src/lua_rockspec/partial.rs
@@ -40,7 +40,7 @@ pub enum PartialRockspecError {
     FuelLimitExceeded,
     #[error("field '{0}' should not be declared in extra.rockspec")]
     ExtraneousField(String),
-    #[error("error while parsing rockspec: {0}")]
+    #[error("error while parsing rockspec")]
     Lua(#[from] ottavino::ExternError),
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -259,7 +259,7 @@ const LUAROCKS_BUILD_RULES_URL: &str =
 
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
-#[error("failed to parse source url: {0}")]
+#[error("failed to parse source url")]
 pub enum SourceUrlError {
     Io(#[from] io::Error),
     Git(#[from] RemoteGitUrlParseError),

--- a/lux-lib/src/lua_rockspec/test_spec.rs
+++ b/lux-lib/src/lua_rockspec/test_spec.rs
@@ -38,7 +38,7 @@ pub enum TestSpecDecodeError {
 pub enum TestSpecError {
     #[error("could not auto-detect the test spec. Please add one to your lux.toml")]
     NoTestSpecDetected,
-    #[error("project validation failed:\n{0}")]
+    #[error("project validation failed")]
     #[diagnostic(forward(0))]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
 }

--- a/lux-lib/src/lua_version/mod.rs
+++ b/lux-lib/src/lua_version/mod.rs
@@ -37,7 +37,7 @@ pub enum LuaVersion {
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum LuaVersionError {
-    #[error("unsupported Lua version: {0}")]
+    #[error("unsupported Lua version: '{0}'")]
     UnsupportedLuaVersion(PackageVersion),
 }
 

--- a/lux-lib/src/luarocks/install_binary_rock.rs
+++ b/lux-lib/src/luarocks/install_binary_rock.rs
@@ -32,7 +32,7 @@ use super::rock_manifest::RockManifestError;
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum InstallBinaryRockError {
-    #[error("IO operation failed: {0}")]
+    #[error("IO operation failed")]
     Io(#[from] io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -49,7 +49,7 @@ pub enum InstallBinaryRockError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaVersionError(#[from] LuaVersionError),
-    #[error("failed to unpack packed rock: {0}")]
+    #[error("failed to unpack packed rock")]
     Zip(#[from] zip::result::ZipError),
     #[error("rock_manifest not found. Cannot install rock files that were packed using LuaRocks version 1")]
     RockManifestNotFound,

--- a/lux-lib/src/luarocks/rock_manifest.rs
+++ b/lux-lib/src/luarocks/rock_manifest.rs
@@ -25,9 +25,9 @@ pub(crate) struct RockManifest {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum RockManifestError {
-    #[error("could not parse rock_manifest: {0}")]
+    #[error("could not parse rock_manifest")]
     Piccolo(#[from] ottavino::ExternError),
-    #[error("could not deserialize rock_manifest: {0}")]
+    #[error("could not deserialize rock_manifest")]
     Serde(#[from] ottavino_util::serde::de::Error),
     #[error("rock_manifest exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
     #[diagnostic(help(

--- a/lux-lib/src/manifest/metadata.rs
+++ b/lux-lib/src/manifest/metadata.rs
@@ -26,9 +26,9 @@ impl<'de> serde::Deserialize<'de> for ManifestMetadata {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum ManifestLuaError {
-    #[error("failed to parse Lua manifest:\n{0}")]
+    #[error("failed to parse Lua manifest")]
     ExecutionError(#[from] ottavino::ExternError),
-    #[error("failed to deserialize Lua manifest:\n{0}")]
+    #[error("failed to deserialize Lua manifest")]
     DeserializationError(#[from] ottavino_util::serde::de::Error),
     #[error("manifest exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
     #[diagnostic(help(

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -24,13 +24,13 @@ pub enum ManifestFromServerError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
-    #[error("failed to pull manifest:\n{0}")]
+    #[error("failed to pull manifest")]
     #[diagnostic(help(
         r#"check your network connection and server configuration.
 if the issue persists, the server may be temporarily unavailable."#
     ))]
     Request(#[from] reqwest::Error),
-    #[error("failed to parse manifest:\n{0}")]
+    #[error("failed to parse manifest")]
     #[diagnostic(help(
         r#"the server returned a manifest that is not valid UTF-8.
 check your network connection and server configuration.
@@ -38,16 +38,16 @@ if you are using a custom server, make sure it returns correctly formatted manif
 "#
     ))]
     FromUtf8(#[from] FromUtf8Error),
-    #[error("invalidate date received from server:\n{0}")]
+    #[error("invalidate date received from server")]
     InvalidDate(#[from] httpdate::Error),
-    #[error("non-ASCII characters returned in response header:\n{0}")]
+    #[error("non-ASCII characters returned in response header")]
     InvalidHeader(#[from] ToStrError),
-    #[error("error parsing manifest URL:\n{0}")]
+    #[error("error parsing manifest URL")]
     Url(#[from] url::ParseError),
-    #[error("failed to read manifest archive {0}:\n{1}")]
-    ZipRead(Url, zip::result::ZipError),
-    #[error("failed to unzip manifest file {0}:\n{1}")]
-    ZipExtract(Url, zip::result::ZipError),
+    #[error("failed to read manifest archive '{0}'")]
+    ZipRead(Url, #[source] zip::result::ZipError),
+    #[error("failed to unzip manifest file '{0}'")]
+    ZipExtract(Url, #[source] zip::result::ZipError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaVersion(#[from] LuaVersionUnset),

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -41,19 +41,19 @@ pub enum BuildWorkspaceError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaRocksInstall(#[from] LuaRocksInstallError),
-    #[error("error installind dependencies:\n{0}")]
+    #[error("error installind dependencies")]
     #[diagnostic(forward(0))]
     InstallDependencies(InstallError),
-    #[error("error installind build dependencies:\n{0}")]
+    #[error("error installind build dependencies")]
     #[diagnostic(forward(0))]
     InstallBuildDependencies(InstallError),
-    #[error("syncing dependencies with the project lockfile failed.\nUse --no-lock to force a new build.\n\n{0}")]
+    #[error("syncing dependencies with the project lockfile failed")]
     #[diagnostic(forward(0))]
     SyncDependencies(SyncError),
-    #[error("syncing build dependencies with the project lockfile failed.\nUse --no-lock to force a new build.\n\n{0}")]
+    #[error("syncing build dependencies with the project lockfile failed")]
     #[diagnostic(forward(0))]
     SyncBuildDependencies(SyncError),
-    #[error("error building project:\n{0}")]
+    #[error("error building the workspace")]
     #[diagnostic(forward(0))]
     Build(#[from] BuildError),
 }

--- a/lux-lib/src/operations/dist_bin.rs
+++ b/lux-lib/src/operations/dist_bin.rs
@@ -52,7 +52,7 @@ use miette::Diagnostic;
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum DistProjectBinError {
-    #[error("error installing project:\n{0}")]
+    #[error("error installing project")]
     #[diagnostic(forward(0))]
     InstallProject(#[from] InstallProjectError),
     #[error(transparent)]

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -190,19 +190,19 @@ impl RemoteRockDownload {
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum DownloadRockspecError {
-    #[error("failed to download rockspec: {0}")]
+    #[error("failed to download rockspec")]
     #[diagnostic(help(
         "check your network connection and verify the package exists on the server."
     ))]
     Request(#[from] reqwest::Error),
-    #[error("failed to convert rockspec response: {0}")]
+    #[error("failed to convert rockspec response")]
     #[diagnostic(help(
         r#"the server returned a response that is not valid UTF-8.
 check your network connection and server configuration.
 if the issue persists, the server may be temporarily unavailable."#
     ))]
     ResponseConversion(#[from] FromUtf8Error),
-    #[error("error initialising remote package DB:\n{0}")]
+    #[error("error initialising remote package DB")]
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error(transparent)]
@@ -339,7 +339,7 @@ pub enum SearchAndDownloadError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),
-    #[error("UTF-8 conversion failed: {0}")]
+    #[error("UTF-8 conversion failed")]
     #[diagnostic(help(
         r#"the server returned a response that is not valid UTF-8.
 check your network connection and server configuration.
@@ -349,7 +349,7 @@ if the issue persists, the server may be temporarily unavailable."#
     #[error(transparent)]
     #[diagnostic(transparent)]
     Rockspec(Box<LuaRockspecError>),
-    #[error("error initialising remote package DB:\n{0}")]
+    #[error("error initialising remote package DB")]
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("failed to read packed rock {0}:\n{1}")]
@@ -398,7 +398,7 @@ for local dependencies, use `path` in your lux.toml."#
         url("https://lux.lumen-labs.org/reference/lux-toml#local-dependencies")
     )]
     NonURLSource,
-    #[error("client error:\n{0}")]
+    #[error("client error")]
     #[diagnostic(help(
         "check your network connection and verify the package exists on the server."
     ))]
@@ -425,12 +425,12 @@ async fn search_and_download_src_rock(
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum DownloadSrcRockError {
-    #[error("failed to download source rock: {0}")]
+    #[error("failed to download source rock")]
     #[diagnostic(help(
         "check your network connection and verify the package exists on the server."
     ))]
     Request(#[from] reqwest::Error),
-    #[error("failed to parse source rock URL: {0}")]
+    #[error("failed to parse source rock URL")]
     Parse(#[from] ParseError),
 }
 

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -107,10 +107,10 @@ where
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum FetchSrcError {
-    #[error("failed to clone rock source:\n{0}")]
+    #[error("failed to clone rock source")]
     #[diagnostic(help("check your network connection and verify the git URL is correct."))]
     GitClone(#[from] git2::Error),
-    #[error("failed to parse git URL:\n{0}")]
+    #[error("failed to parse git URL")]
     #[diagnostic(forward(0))]
     GitUrlParse(#[from] RemoteGitUrlParseError),
     #[error(transparent)]
@@ -122,13 +122,13 @@ pub enum FetchSrcError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     FetchSrcRock(#[from] FetchSrcRockError),
-    #[error("unable to remove the '.git' directory:\n{0}")]
+    #[error("unable to remove the '.git' directory")]
     #[diagnostic(help(
         "check that no process is using the directory and you have write permissions."
     ))]
-    CleanGitDir(io::Error),
-    #[error("unable to compute hash:\n{0}")]
-    Hash(io::Error),
+    CleanGitDir(#[source] io::Error),
+    #[error("unable to compute hash")]
+    Hash(#[source] io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Fs(#[from] fs::FsError),

--- a/lux-lib/src/operations/install/mod.rs
+++ b/lux-lib/src/operations/install/mod.rs
@@ -132,7 +132,7 @@ type InstallWorkerOutput = Result<(LocalPackageId, (LocalPackage, tree::EntryTyp
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum InstallError {
-    #[error("unable to resolve dependencies:\n{0}")]
+    #[error("unable to resolve dependencies")]
     #[diagnostic(forward(0))]
     ResolveDependencies(#[from] ResolveDependenciesError),
     #[error(transparent)]
@@ -150,21 +150,21 @@ pub enum InstallError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     WorkspaceTree(#[from] WorkspaceTreeError),
-    #[error("error instantiating LuaRocks compatibility layer:\n{0}")]
+    #[error("error instantiating LuaRocks compatibility layer")]
     #[diagnostic(forward(0))]
     LuaRocks(#[from] LuaRocksError),
-    #[error("error installing LuaRocks compatibility layer:\n{0}")]
+    #[error("error installing LuaRocks compatibility layer")]
     #[diagnostic(forward(0))]
     LuaRocksInstall(#[from] LuaRocksInstallError),
     #[error("failed to build {0}: {1}")]
     Build(PackageName, BuildError),
-    #[error("failed to install build depencency {0}:\n{1}")]
-    BuildDependency(PackageName, BuildError),
-    #[error("error initialising remote package DB:\n{0}")]
+    #[error("failed to install build depencency {0}")]
+    BuildDependency(PackageName, #[source] BuildError),
+    #[error("error initialising remote package DB")]
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
-    #[error("failed to install pre-built rock {0}:\n{1}")]
-    InstallBinaryRock(PackageName, InstallBinaryRockError),
+    #[error("failed to install pre-built rock {0}")]
+    InstallBinaryRock(PackageName, #[source] InstallBinaryRockError),
     #[error("cannot install duplicate entrypoints:\n{0}")]
     DuplicateEntrypoints(PackageNameList),
     #[error("install worker panicked")]

--- a/lux-lib/src/operations/install_project.rs
+++ b/lux-lib/src/operations/install_project.rs
@@ -35,13 +35,13 @@ pub enum InstallProjectError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LuaRocksInstall(#[from] LuaRocksInstallError),
-    #[error("error installind dependencies:\n{0}")]
+    #[error("error installind dependencies")]
     #[diagnostic(forward(0))]
     InstallDependencies(InstallError),
-    #[error("error installind build dependencies:\n{0}")]
+    #[error("error installind build dependencies")]
     #[diagnostic(forward(0))]
     InstallBuildDependencies(InstallError),
-    #[error("error building project:\n{0}")]
+    #[error("error building project")]
     #[diagnostic(forward(0))]
     Build(#[from] BuildError),
 }

--- a/lux-lib/src/operations/pack.rs
+++ b/lux-lib/src/operations/pack.rs
@@ -56,7 +56,7 @@ where
 }
 
 #[derive(Error, Debug, Diagnostic)]
-#[error("failed to pack rock: {0}")]
+#[error("failed to pack rock")]
 pub enum PackError {
     Zip(#[from] zip::result::ZipError),
     Io(#[from] io::Error),

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -35,8 +35,8 @@ pub enum ResolveDependenciesError {
     CyclicDependency(DependencyCycle),
     #[error("error processing resolved dependency:\n{0}")]
     ChannelSend(String),
-    #[error("error fetching vendored dependency {0}:\n{1}")]
-    FetchVendored(PackageReq, FetchVendoredError),
+    #[error("error fetching vendored dependency '{0}'")]
+    FetchVendored(PackageReq, #[source] FetchVendoredError),
 }
 
 #[derive(Debug)]

--- a/lux-lib/src/operations/run_lua.rs
+++ b/lux-lib/src/operations/run_lua.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum RunLuaError {
-    #[error("error running lua: {0}")]
+    #[error("error running lua")]
     #[diagnostic(forward(0))]
     LuaBinary(#[from] LuaBinaryError),
     #[error("failed to run {lua_cmd}: {source}")]

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -159,7 +159,7 @@ pub enum SyncError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LocalProjectTomlValidationError(#[from] LocalProjectTomlValidationError),
-    #[error("failed to generate `.luarc.json`:\n{0}")]
+    #[error("failed to generate `.luarc.json`")]
     #[diagnostic(forward(0))]
     GenLuaRc(#[from] GenLuaRcError),
 }

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -247,7 +247,7 @@ async fn run_project_tests(
 }
 
 #[derive(Error, Debug, Diagnostic)]
-#[error("error installing test dependencies: {0}")]
+#[error("error installing test dependencies")]
 #[diagnostic(forward(0))]
 pub enum InstallTestDependenciesError {
     WorkspaceTree(#[from] WorkspaceTreeError),

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -25,16 +25,16 @@ pub enum UpdateError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     RockConstraintUnsatisfied(#[from] RockConstraintUnsatisfied),
-    #[error("failed to update rock: {0}")]
+    #[error("failed to update rock")]
     #[diagnostic(forward(0))]
     Install(#[from] InstallError),
-    #[error("failed to remove old rock: {0}")]
+    #[error("failed to remove old rock")]
     #[diagnostic(forward(0))]
     Remove(#[from] RemoveError),
-    #[error("error initialising remote package DB:\n{0}")]
+    #[error("error initialising remote package DB")]
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
-    #[error("error loading the workspace:\n{0}")]
+    #[error("error loading the workspace")]
     #[diagnostic(forward(0))]
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
@@ -45,10 +45,10 @@ pub enum UpdateError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Tree(#[from] TreeError),
-    #[error("error initialising the workspace install tree:\n{0}")]
+    #[error("error initialising the workspace install tree")]
     #[diagnostic(forward(0))]
     WorkspaceTree(#[from] WorkspaceTreeError),
-    #[error("error syncing the workspace install tree:\n{0}")]
+    #[error("error syncing the workspace install tree")]
     #[diagnostic(forward(0))]
     Sync(#[from] SyncError),
 }

--- a/lux-lib/src/operations/vendor.rs
+++ b/lux-lib/src/operations/vendor.rs
@@ -68,13 +68,13 @@ pub enum VendorError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Workspace(#[from] WorkspaceError),
-    #[error("project validation failed:\n{0}")]
+    #[error("project validation failed")]
     #[diagnostic(forward(0))]
     LocalProjectTomlValidation(#[from] LocalProjectTomlValidationError),
-    #[error("error initialising remote package DB:\n{0}")]
+    #[error("error initialising remote package DB")]
     #[diagnostic(forward(0))]
     RemotePackageDB(#[from] RemotePackageDBError),
-    #[error("failed to resolve dependencies:\n{0}")]
+    #[error("failed to resolve dependencies")]
     #[diagnostic(forward(0))]
     ResolveDependencies(#[from] ResolveDependenciesError),
     #[error(transparent)]
@@ -82,10 +82,10 @@ pub enum VendorError {
     Fs(#[from] fs::FsError),
     #[error("failed to vendor Lua RockSpec:\n{0}")]
     LuaRockSpec(String),
-    #[error("failed to unpack src.rock:\n{0}")]
+    #[error("failed to unpack src.rock")]
     #[diagnostic(forward(0))]
     Unpack(#[from] UnpackError),
-    #[error("failed to fetch rock source:\n{0}")]
+    #[error("failed to fetch rock source")]
     #[diagnostic(forward(0))]
     FetchSrc(#[from] FetchSrcError),
 }

--- a/lux-lib/src/package/mod.rs
+++ b/lux-lib/src/package/mod.rs
@@ -305,7 +305,7 @@ impl DisplayAsLuaKV for BuildDependencies<'_> {
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum PackageReqParseError {
-    #[error("could not parse dependency name from {0}")]
+    #[error("could not parse dependency name from '{0}'")]
     InvalidDependencyName(String),
     #[error("could not parse version requirement in '{str}': {error}")]
     InvalidPackageVersionReq {

--- a/lux-lib/src/package/version.rs
+++ b/lux-lib/src/package/version.rs
@@ -142,7 +142,7 @@ pub enum PackageVersionParseError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Specrev(#[from] SpecrevParseError),
-    #[error("failed to parse version: {0}")]
+    #[error("failed to parse version")]
     Version(#[from] Error),
 }
 

--- a/lux-lib/src/project/gen.rs
+++ b/lux-lib/src/project/gen.rs
@@ -55,13 +55,13 @@ pub enum GenerateSourceError {
     MissingReleaseUrl(String),
     #[error("need a `source.dev` (dev/scm URL) in lux.toml for dev versions.")]
     MissingDevUrl(String),
-    #[error("error substituting project source variables:\n{0}")]
+    #[error("error substituting project source variables")]
     #[diagnostic(forward(0))]
     VariableSubstitution(#[from] VariableSubstitutionError),
-    #[error("error parsing source URL from template:\n{0}")]
+    #[error("error parsing source URL from template")]
     #[diagnostic(forward(0))]
     SourceUrl(#[from] SourceUrlError),
-    #[error("error generating git source URL:\n{0}")]
+    #[error("error generating git source URL")]
     Git(#[from] git2::Error),
     #[error("refusing to generate nondeterministic rockspec with git source.\nSupply a `source.tag` parameter.")]
     NonDeterministicGitSource,
@@ -186,9 +186,9 @@ pub(crate) struct PackageVersionTemplate(Option<PackageVersion>);
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum GenerateVersionError {
-    #[error("error generating version from git repository metadata:\n{0}")]
+    #[error("error generating version from git repository metadata")]
     Git(#[from] git2::Error),
-    #[error("error parsing version from git ref:\n{0}")]
+    #[error("error parsing version from git ref")]
     #[diagnostic(forward(0))]
     PackageVersionParse(#[from] PackageVersionParseError),
 }

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -139,10 +139,10 @@ where
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum ProjectTomlError {
-    #[error("error generating rockspec source:\n{0}")]
+    #[error("error generating rockspec source")]
     #[diagnostic(forward(0))]
     GenerateSource(#[from] GenerateSourceError),
-    #[error("error generating rockspec version:\n{0}")]
+    #[error("error generating rockspec version")]
     #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
     #[error("generated rockspec exceeds computational limit of {ROCKSPEC_FUEL_LIMIT} steps")]
@@ -169,10 +169,10 @@ pub enum LocalProjectTomlValidationError {
   lua = ">=5.1""#
     ))]
     NoLuaVersion,
-    #[error("could not decode the test spec:\n:{0}")]
+    #[error("could not decode the test spec")]
     #[diagnostic(forward(0))]
     TestSpecError(#[from] TestSpecDecodeError),
-    #[error("could not decode the build spec:\n:{0}")]
+    #[error("could not decode the build spec")]
     #[diagnostic(forward(0))]
     BuildSpecInternal(#[from] BuildSpecInternalError),
     #[error(transparent)]
@@ -180,7 +180,7 @@ pub enum LocalProjectTomlValidationError {
     PlatformValidation(#[from] PlatformValidationError),
     #[error("{}copy_directories cannot contain a rockspec name", ._0.as_ref().map(|p| format!("{p}: ")).unwrap_or_default())]
     CopyDirectoriesContainRockspecName(Option<String>),
-    #[error("could not decode the source spec:\n:{0}")]
+    #[error("could not decode the source spec")]
     #[diagnostic(forward(0))]
     RockSource(#[from] RockSourceError),
     #[error("duplicate dependencies: {0}")]
@@ -208,20 +208,20 @@ pub enum LocalProjectTomlValidationError {
         "#
     )]
     DependenciesContainLua,
-    #[error("error generating rockspec source:\n{0}")]
+    #[error("error generating rockspec source")]
     #[diagnostic(forward(0))]
     GenerateSource(#[from] GenerateSourceError),
-    #[error("error generating rockspec version:\n{0}")]
+    #[error("error generating rockspec version")]
     #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
 }
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum RemoteProjectTomlValidationError {
-    #[error("error generating rockspec source:\n{0}")]
+    #[error("error generating rockspec source")]
     #[diagnostic(forward(0))]
     GenerateSource(#[from] GenerateSourceError),
-    #[error("error generating rockspec version:\n{0}")]
+    #[error("error generating rockspec version")]
     #[diagnostic(forward(0))]
     GenerateVersion(#[from] GenerateVersionError),
     #[error(transparent)]

--- a/lux-lib/src/remote_package_db/mod.rs
+++ b/lux-lib/src/remote_package_db/mod.rs
@@ -39,7 +39,7 @@ pub enum SearchError {
     RockNotFound(PackageReq),
     #[error("no rock that matches '{0}' found in the lockfile.")]
     RockNotFoundInLockfile(PackageReq),
-    #[error("error when pulling manifest:\n{0}")]
+    #[error("error when pulling manifest")]
     #[diagnostic(forward(0))]
     Manifest(#[from] ManifestError),
 }

--- a/lux-lib/src/upload/mod.rs
+++ b/lux-lib/src/upload/mod.rs
@@ -58,7 +58,7 @@ pub struct VersionCheckResponse {
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 pub enum ToolCheckError {
-    #[error("error parsing tool check URL:\n{0}")]
+    #[error("error parsing tool check URL")]
     #[diagnostic(help("check your server configuration"))]
     ParseError(#[from] url::ParseError),
     #[error("error sending HTTP request")]


### PR DESCRIPTION
It's redundant if there's a `#[from]` or `#[source]` macro. Miette will display the thiserror source errors too.