### PR TITLE
fix(error-reporting)!: propagate integrity error diagnostics

### DIFF
--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -175,7 +175,7 @@ pub enum BuildError {
     )]
     #[diagnostic(help(
         r#"the source may have been modified or a tag may have been moved.
-check the source, then rerun the command with `lx --no-lock` to update the hash."#
+check the source, then rerun the command with `--no-lock` to update the hash."#
     ))]
     SourceIntegrityMismatch {
         src: String,

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -805,7 +805,7 @@ pub enum LockfileIntegrityError {
     )]
     #[diagnostic(help(
         r#"the maintainer may have force-uploaded a different rockspec.
-check the rockspec source, then rerun the command with `lx --no-lock` to update the hash.
+check the rockspec source, then rerun the command with `--no-lock` to update the hash.
 "#
     ))]
     RockspecIntegrityMismatch {

--- a/lux-lib/src/operations/build_lua.rs
+++ b/lux-lib/src/operations/build_lua.rs
@@ -74,7 +74,7 @@ pub enum BuildLuaError {
     )]
     #[diagnostic(help(
         r#"the source may have been modified or a tag may have been moved.
-check the source, then rerun the command with `lx --no-lock` to update the hash."#
+check the source, then rerun the command with `--no-lock` to update the hash."#
     ))]
     SourceIntegrityMismatch {
         src: String,

--- a/lux-lib/src/operations/install/mod.rs
+++ b/lux-lib/src/operations/install/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         build_dependencies_to_install, PackageInstallData, Resolve, ResolveDependenciesError,
     },
     package::{PackageName, PackageNameList, PackageReq},
-    remote_package_db::{RemotePackageDB, RemotePackageDBError, RemotePackageDbIntegrityError},
+    remote_package_db::{RemotePackageDB, RemotePackageDBError},
     rockspec::Rockspec,
     tree::{self, InstallTree, Tree, TreeError},
     workspace::{Workspace, WorkspaceTreeError},
@@ -165,12 +165,6 @@ pub enum InstallError {
     RemotePackageDB(#[from] RemotePackageDBError),
     #[error("failed to install pre-built rock {0}:\n{1}")]
     InstallBinaryRock(PackageName, InstallBinaryRockError),
-    #[error("integrity error for package '{package}'")]
-    Integrity {
-        package: PackageName,
-        #[diagnostic_source]
-        err: RemotePackageDbIntegrityError,
-    },
     #[error("cannot install duplicate entrypoints:\n{0}")]
     DuplicateEntrypoints(PackageNameList),
     #[error("install worker panicked")]

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -145,7 +145,7 @@ pub enum SyncError {
     Integrity {
         package: PackageName,
         #[diagnostic_source]
-        err: LockfileIntegrityError,
+        source: LockfileIntegrityError,
     },
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -283,9 +283,9 @@ async fn do_sync(
         for (_, package) in &to_add {
             install_tree_lockfile
                 .validate_integrity(package)
-                .map_err(|err| SyncError::Integrity {
+                .map_err(|source| SyncError::Integrity {
                     package: package.name().clone(),
-                    err,
+                    source,
                 })?;
         }
     }


### PR DESCRIPTION
Breaking for lux-lib, because this also removes an unused error variant.

Also changes `lx --no-lock` suggestions to just `--no-lock` because there's no top-level `--no-lock` flag.