### PR TITLE
fix: move RockLayoutConfigLua constructors to Config module

### DIFF
--- a/lux-lua/src/config.rs
+++ b/lux-lua/src/config.rs
@@ -1,8 +1,8 @@
-use lux_lib::config::ConfigBuilder;
+use lux_lib::config::{tree::RockLayoutConfig, ConfigBuilder};
 use mlua::ExternalResult;
 use mlua_extras::typed::{Type, Typed, TypedDataMethods, TypedUserData};
 
-use crate::lua_impls::{ConfigBuilderLua, ConfigLua};
+use crate::lua_impls::{ConfigBuilderLua, ConfigLua, RockLayoutConfigLua};
 
 const DEFAULT_USER_AGENT: &str = concat!("lux-lua/", env!("CARGO_PKG_VERSION"));
 
@@ -37,6 +37,14 @@ if present, or otherwise by instantiating the default config"#,
         );
         methods.add_function("new", |_, ()| {
             ConfigBuilder::new().map(ConfigBuilderLua).into_lua_err()
+        });
+        methods.document("Instantiate the default rock layout config");
+        methods.add_function("default_rock_layout", |_, ()| {
+            Ok(RockLayoutConfigLua(RockLayoutConfig::default()))
+        });
+        methods.document("Instantiate the a rock layout for Neovim plugins");
+        methods.add_function("nvim_rock_layout", |_, ()| {
+            Ok(RockLayoutConfigLua(RockLayoutConfig::new_nvim_layout()))
         });
     }
     fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -1112,16 +1112,6 @@ impl FromLua for RockLayoutConfigLua {
 }
 
 impl TypedUserData for RockLayoutConfigLua {
-    fn add_methods<M: TypedDataMethods<Self>>(methods: &mut M) {
-        methods.document("Instantiate the default rock layout");
-        methods.add_function("new", |_, ()| {
-            Ok(RockLayoutConfigLua(RockLayoutConfig::default()))
-        });
-        methods.document("Instantiate the a rock layout for Neovim plugins");
-        methods.add_function("new_nvim_layout", |_, ()| {
-            Ok(RockLayoutConfigLua(RockLayoutConfig::new_nvim_layout()))
-        });
-    }
     fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {
         docs.add("Template configuration for a rock's tree layout");
     }


### PR DESCRIPTION
It's impossible to call these constructors from the Lua API.