### PR TITLE
feat(fetch): retry downloading rock sources on failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,8 @@ dependencies = [
  "proptest",
  "remove_dir_all",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "semver",
  "serde",
  "serde-enum-str",
@@ -4699,6 +4701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5341,6 +5349,50 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror 2.0.19",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+dependencies = [
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -7562,6 +7614,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -103,6 +103,8 @@ ottavino-util = "0.4.0"
 serde-value = "0.7.0"
 auth-git2 = "0.6.0"
 gag = "1.0.0"
+reqwest-retry = "0.9.1"
+reqwest-middleware = "0.5.2"
 
 [dev-dependencies]
 httptest = { version = "0.16" }

--- a/lux-lib/src/manifest/metadata_from_server.rs
+++ b/lux-lib/src/manifest/metadata_from_server.rs
@@ -10,6 +10,7 @@ use tokio::io;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use crate::fs;
+use crate::reqwest::ClientExt;
 use url::Url;
 use zip::ZipArchive;
 
@@ -30,6 +31,12 @@ pub enum ManifestFromServerError {
 if the issue persists, the server may be temporarily unavailable."#
     ))]
     Request(#[from] reqwest::Error),
+    #[error("failed to pull manifest")]
+    #[diagnostic(help(
+        r#"check your network connection and server configuration.
+if the issue persists, the server may be temporarily unavailable."#
+    ))]
+    RequestMiddleware(#[from] reqwest_middleware::Error),
     #[error("failed to parse manifest")]
     #[diagnostic(help(
         r#"the server returned a manifest that is not valid UTF-8.
@@ -60,10 +67,11 @@ pub(super) async fn get_manifest(
     target: &Path,
     client: &Client,
 ) -> Result<String, ManifestFromServerError> {
-    let response = client.get(url.clone()).send().await?;
+    let response = client.retrying(10).get(url.clone()).send().await?;
     if response.status().is_client_error() {
         let fallback_url = fallback_unzipped_url(&url)?;
         let manifest_bytes = client
+            .retrying(10)
             .get(fallback_url)
             .send()
             .await?

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     remote_package_db::{RemotePackageDB, RemotePackageDBError, SearchError},
     remote_package_source::RemotePackageSource,
+    reqwest::ClientExt,
     rockspec::Rockspec,
 };
 
@@ -430,6 +431,11 @@ pub enum DownloadSrcRockError {
         "check your network connection and verify the package exists on the server."
     ))]
     Request(#[from] reqwest::Error),
+    #[error("failed to download source rock")]
+    #[diagnostic(help(
+        "check your network connection and verify the package exists on the server."
+    ))]
+    RequestMiddleware(#[from] reqwest_middleware::Error),
     #[error("failed to parse source rock URL")]
     Parse(#[from] ParseError),
 }
@@ -531,9 +537,10 @@ async fn download_impl(
     let ext = args.ext;
     let server_url = args.server_url;
     let full_rock_name = mk_packed_rock_name(package.name(), package.version(), ext);
-    tracing::debug!(message = format!("📥 Downloading {full_rock_name}").as_str());
+    tracing::debug!(message = format!("Downloading {full_rock_name}").as_str());
     let url = server_url.join(&full_rock_name)?;
     let response = crate::reqwest::https_client(args.config)?
+        .retrying(3)
         .get(url.clone())
         .send()
         .await?;
@@ -545,6 +552,7 @@ async fn download_impl(
                 let full_rock_name = mk_packed_rock_name(package.name(), package.version(), ext);
                 let url = server_url.join(&full_rock_name)?;
                 crate::reqwest::https_client(args.config)?
+                    .retrying(3)
                     .get(url.clone())
                     .send()
                     .await?

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -6,6 +6,7 @@ use crate::hash::HasIntegrity;
 use crate::lockfile::RemotePackageSourceUrl;
 use crate::lua_rockspec::{RemoteRockSource, RockSourceSpec};
 use crate::package::PackageSpec;
+use crate::reqwest::ClientExt;
 use crate::rockspec::Rockspec;
 use crate::{fs, operations};
 use auth_git2::{GitAuthenticator, Prompter};
@@ -88,6 +89,7 @@ where
             }
             Err(err) => match &fetch.rockspec.source().current_platform().source_spec {
                 RockSourceSpec::Git(_) | RockSourceSpec::Url(_) => {
+                    tracing::warn!("falling back to .src.rock download ({err})");
                     let package = PackageSpec::new(
                         fetch.rockspec.package().clone(),
                         fetch.rockspec.version().clone(),
@@ -122,6 +124,9 @@ pub enum FetchSrcError {
     #[error(transparent)]
     #[diagnostic(help("check your network connection."))]
     Request(#[from] reqwest::Error),
+    #[error(transparent)]
+    #[diagnostic(help("check your network connection."))]
+    RequestMiddleware(#[from] reqwest_middleware::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Unpack(#[from] UnpackError),
@@ -263,11 +268,12 @@ async fn fetch_src_impl<R: Rockspec>(
             }
         }
         RockSourceSpec::Url(url) => {
-            tracing::debug!(message = format!("📥 Downloading {url}").as_str());
+            tracing::debug!(message = format!("Downloading {url}").as_str());
 
             // NOTE: We don't enforce HTTPS when fetching sources because some rockspecs
             // have HTTP URLs in `source.url`.
             let response = crate::reqwest::http_client(config)?
+                .retrying(10)
                 .get(url.clone())
                 .send()
                 .await?
@@ -302,7 +308,7 @@ async fn fetch_src_impl<R: Rockspec>(
             }
         }
         RockSourceSpec::File(path) => {
-            tracing::debug!(message = format!("📋 Copying {}", path.display()).as_str());
+            tracing::debug!(message = format!("Copying {}", path.display()).as_str());
 
             let hash = if path.is_dir() {
                 recursive_copy_dir(&path.to_path_buf(), dest_dir).await?;

--- a/lux-lib/src/reqwest.rs
+++ b/lux-lib/src/reqwest.rs
@@ -1,8 +1,13 @@
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware;
+use reqwest_retry::Jitter;
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 
 use crate::config::Config;
+use crate::reqwest::private::Sealed;
 
 static HTTPS_CLIENT: OnceLock<Client> = OnceLock::new();
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
@@ -35,4 +40,29 @@ pub(crate) fn https_client(config: &Config) -> Result<&Client, reqwest::Error> {
 /// Used in tests and to fetch sources, which may be HTTP URLs.
 pub(crate) fn http_client(config: &Config) -> Result<&Client, reqwest::Error> {
     client(false, config)
+}
+
+impl Sealed for reqwest::Client {}
+
+pub(crate) trait ClientExt: Sealed {
+    fn retrying(&self, count: u32) -> ClientWithMiddleware;
+}
+
+impl ClientExt for reqwest::Client {
+    fn retrying(&self, count: u32) -> ClientWithMiddleware {
+        let retry_policy = ExponentialBackoff::builder()
+            .jitter(Jitter::Full)
+            .retry_bounds(Duration::from_millis(100), Duration::from_secs(2))
+            .build_with_max_retries(count);
+        reqwest_middleware::ClientBuilder::new(
+            // NOTE: cloning reqwest clients is cheap
+            self.clone(),
+        )
+        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+        .build()
+    }
+}
+
+mod private {
+    pub trait Sealed {}
 }


### PR DESCRIPTION
Uses `reqwest-retry` to retry downloading rockspecs, manifests & sources with exponential backoff & jitter.