### PR TITLE
fix(fetch)!: include ignore files when copying file sources

### DIFF
--- a/lux-lib/src/fs/tokio.rs
+++ b/lux-lib/src/fs/tokio.rs
@@ -1,8 +1,10 @@
 use super::FsError;
 #[cfg(unix)]
 use std::fs::Permissions;
+use std::io;
 use std::path::Path;
 use tokio::fs;
+use walkdir::WalkDir;
 
 /// Wrapped [`fs::read`].
 pub(crate) async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, FsError> {
@@ -47,6 +49,39 @@ pub(crate) async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result
         to: to.to_path_buf(),
         source,
     })
+}
+
+/// Recursively copies the contents of `src` into `dest`, including hidden files,
+/// but skipping VCS directories such as `.git`.
+pub(crate) async fn copy_dir_contents(
+    src: impl AsRef<Path>,
+    dest: impl AsRef<Path>,
+) -> Result<(), FsError> {
+    let src = src.as_ref();
+    let dest = dest.as_ref();
+    for path in WalkDir::new(src)
+        .into_iter()
+        .filter_entry(|entry| {
+            !matches!(
+                entry.file_name().to_string_lossy().to_string().as_str(),
+                ".git" | ".jj" | ".hg" | "_darcs" | ".svn" | ".bzr"
+            )
+        })
+        .filter_map(Result::ok)
+        .filter_map(|entry| entry.file_type().is_file().then(|| entry.into_path()))
+    {
+        let relative = path.strip_prefix(src).map_err(|source| FsError::Copy {
+            from: path.to_path_buf(),
+            to: dest.to_path_buf(),
+            source: io::Error::other(source),
+        })?;
+        let target = dest.join(relative);
+        if let Some(parent) = target.parent() {
+            create_dir_all(parent).await?;
+        }
+        copy(&path, &target).await?;
+    }
+    Ok(())
 }
 
 /// Wrapped [`fs::create_dir_all`].

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -1,4 +1,3 @@
-use crate::build::utils::recursive_copy_dir;
 use crate::config::Config;
 use crate::git::url::RemoteGitUrlParseError;
 use crate::git::GitSource;
@@ -359,7 +358,7 @@ async fn fetch_src_impl<R: Rockspec>(
             tracing::debug!(message = format!("📋 Copying {}", path.display()).as_str());
 
             let hash = if path.is_dir() {
-                recursive_copy_dir(&path.to_path_buf(), dest_dir).await?;
+                fs::tokio::copy_dir_contents(path, dest_dir).await?;
                 dest_dir.hash().await.map_err(FetchSrcError::Hash)?
             } else {
                 let mut file = fs::sync::open(path)?;


### PR DESCRIPTION
This ensures that we end up with the same hash as a vendored nix source.