### PR TITLE
fix(build): allow overwriting installed files from read-only vendor dirs

### DIFF
--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -259,9 +259,10 @@ async fn install<R: Rockspec + HasIntegrity, T: InstallTree>(
         for (target, source) in &install_spec.lib {
             let absolute_source = build_dir.join(source);
             let resolved_target = output_paths.lib.join(target);
-            fs::tokio::copy(absolute_source, resolved_target)
+            fs::tokio::copy(&absolute_source, &resolved_target)
                 .instrument(tracing::trace_span!("copying target"))
                 .await?;
+            utils::make_writable(&resolved_target).await?;
         }
     }
     if entry_type.is_entrypoint() {
@@ -296,9 +297,10 @@ async fn install<R: Rockspec + HasIntegrity, T: InstallTree>(
                     .instrument(tracing::trace_span!("creating configuration directory"))
                     .await?;
             }
-            fs::tokio::copy(absolute_source, target)
+            fs::tokio::copy(&absolute_source, &target)
                 .instrument(tracing::trace_span!("copying configuration file"))
                 .await?;
+            utils::make_writable(&target).await?;
         }
     }
     Ok(())

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -76,7 +76,46 @@ pub(crate) fn copy_lua_to_module_path(
     }
 
     fs::sync::copy(source, &target)?;
+    make_writable_sync(&target)?;
 
+    Ok(())
+}
+
+/// Ensures the file at `path` is writable by its owner, so that it can be
+/// overwritten on a later install, even when the source is read-only
+/// (e.g. a vendored rock in a read-only Nix store).
+#[cfg(unix)]
+pub(crate) async fn make_writable(path: &Path) -> Result<(), fs::FsError> {
+    let mut perms = fs::tokio::metadata(path).await?.permissions();
+    perms.set_mode(perms.mode() | 0o200);
+    fs::tokio::set_permissions(path, perms).await?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn make_writable(_path: &Path) -> Result<(), fs::FsError> {
+    Ok(())
+}
+
+/// See [`make_writable`].
+#[cfg(unix)]
+pub(crate) fn make_writable_sync(path: &Path) -> Result<(), fs::FsError> {
+    let mut perms = std::fs::metadata(path)
+        .map_err(|source| fs::FsError::Metadata {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .permissions();
+    perms.set_mode(perms.mode() | 0o200);
+    std::fs::set_permissions(path, perms).map_err(|source| fs::FsError::SetPermissions {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn make_writable_sync(_path: &Path) -> Result<(), fs::FsError> {
     Ok(())
 }
 
@@ -92,7 +131,8 @@ pub(crate) async fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(),
             if let Some(parent) = target.parent() {
                 fs::tokio::create_dir_all(parent).await?;
             }
-            fs::tokio::copy(&file, target).await?;
+            fs::tokio::copy(&file, &target).await?;
+            make_writable(&target).await?;
         }
     }
     Ok(())
@@ -700,6 +740,7 @@ async fn install_wrapped_binary(
     fs::tokio::create_dir_all(&unwrapped_bin_dir).await?;
     let unwrapped_bin = unwrapped_bin_dir.join(target);
     fs::tokio::copy(source, &unwrapped_bin).await?;
+    make_writable(&unwrapped_bin).await?;
 
     #[cfg(target_family = "unix")]
     let target = tree.bin().join(target);

--- a/lux-lib/tests/test.rs
+++ b/lux-lib/tests/test.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::path::PathBuf;
 
 use assert_fs::prelude::PathCopy;


### PR DESCRIPTION
When copying from a nix-vendored directory, the source filesystem is read-only.