### PR TITLE
feat!: probe lua versions when specifying --nvim flag

### DIFF
--- a/lux-cli/src/bin/lx.rs
+++ b/lux-cli/src/bin/lx.rs
@@ -16,7 +16,7 @@ use lux_cli::{
 use lux_lib::{
     config::tree::RockLayoutConfig,
     lockfile::PinnedState::{Pinned, Unpinned},
-    lua_version::LuaVersion,
+    lua_installation::nvim_lua_version,
 };
 
 use miette::{IntoDiagnostic, MietteHandlerOpts, Result};
@@ -66,13 +66,7 @@ async fn main() -> Result<()> {
 
     let lua_version = cli
         .lua_version
-        .or({
-            if cli.nvim {
-                Some(LuaVersion::Lua51)
-            } else {
-                None
-            }
-        })
+        .or(if cli.nvim { nvim_lua_version() } else { None })
         .or_else(|| cli.command.lua_version());
 
     let mut config_builder = cli

--- a/lux-lib/src/lua_installation/mod.rs
+++ b/lux-lib/src/lua_installation/mod.rs
@@ -405,6 +405,18 @@ pub fn detect_installed_lua_version() -> Option<LuaVersion> {
         })
 }
 
+/// Determine the Lua version to use with the `--nvim` flag.
+/// Prefers LuaJIT if installed, falling back to Lua 5.1.
+pub fn nvim_lua_version() -> Option<LuaVersion> {
+    if LuaInstallation::probe(&LuaVersion::LuaJIT, &Default::default()).is_some() {
+        Some(LuaVersion::LuaJIT)
+    } else if LuaInstallation::probe(&LuaVersion::Lua51, &Default::default()).is_some() {
+        Some(LuaVersion::Lua51)
+    } else {
+        None
+    }
+}
+
 fn find_lua_executable(bin_path: &Path, version: &LuaVersion) -> Option<PathBuf> {
     fs::sync::read_dir(bin_path).ok().and_then(|entries| {
         let bin_files = entries


### PR DESCRIPTION
Allows us to use the `--nvim` flag with both Lua 5.1 and LuaJIT.