### PR TITLE
feat(lx-new): generate source template

### DIFF
--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -313,7 +313,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
             )?;
 
             let mut source_block =
-                format!("# [source]\n# When publishing, configure the source URL here");
+                "# [source]\n# When publishing, configure the source URL here".to_string();
 
             if is_github_repo {
                 let generated_url = format!(

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -336,7 +336,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
         format!("[source]\nurl = \"{generated_url}\"")
     } else {
         format!(
-                "# [source]\n# url = \"https://github.com/your-username/{}/archive/refs/tags/$(REF).zip\"",
+                "# [source]\n# When publishing, configure the source URL below\n# url = \"https://github.com/your-username/{}/archive/refs/tags/$(REF).zip\"",
                 validated.name
             )
     };

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -325,6 +325,17 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
 
     let rocks_path = validated.target.join(PROJECT_TOML);
 
+    let generated_url = format!(
+        "https://github.com/{}/{}/archive/refs/tags/$(REF).zip",
+        validated.maintainer, validated.name
+    );
+
+    let source = if !generated_url.contains(' ') && url::Url::parse(&generated_url).is_ok() {
+        format!("[source]\nurl = \"{generated_url}\"")
+    } else {
+        String::new()
+    };
+
     std::fs::write(
         &rocks_path,
         format!(
@@ -339,8 +350,7 @@ maintainer = "{maintainer}"
 labels = [ {labels} ]
 {license}
 
-[source]
-url = "https://github.com/<owner>/my-project/archive/refs/tags/$(REF).zip"
+{source}
 
 [dependencies]
 # Add your dependencies here

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -81,6 +81,7 @@ struct NewProjectValidated {
     lua_versions: PackageReq,
     main: SourceDirType,
     license: Option<LicenseId>,
+    is_github_repo: bool,
 }
 
 fn clap_parse_license(s: &str) -> std::result::Result<LicenseId, String> {
@@ -175,6 +176,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
             maintainer,
             name,
             target,
+            is_github_repo: false,
         }),
 
         NewProject {
@@ -188,15 +190,16 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
             target,
         } => {
             eprintln!("Fetching remote repository metadata...");
-            let repo_metadata =
+            let (repo_metadata, is_github_repo) =
                 match github_metadata::get_metadata_for(Some(&target), &config).await {
-                    Ok(value) => value.map_or_else(|| RepoMetadata::default(&target), Ok),
+                    Ok(Some(value)) => Ok((value, true)),
+                    Ok(None) => RepoMetadata::default(&target).map(|m| (m, false)),
                     Err(_) => {
                         tracing::info!(
                             "Could not fetch remote repo metadata, defaulting to empty values."
                         );
 
-                        RepoMetadata::default(&target)
+                        RepoMetadata::default(&target).map(|m| (m, false))
                     }
                 }
                 .into_diagnostic()?;
@@ -317,6 +320,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
                 lua_versions,
                 maintainer,
                 main: main.unwrap_or(SourceDirType::Src),
+                is_github_repo,
             })
         }
     }?;
@@ -325,21 +329,18 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
 
     let rocks_path = validated.target.join(PROJECT_TOML);
 
-    let generated_url = format!(
-        "https://github.com/{}/{}/archive/refs/tags/$(REF).zip",
-        validated.maintainer, validated.name
-    );
+    let mut source = format!("# [source]\n# When publishing, configure the source URL here");
 
-    let source = if url::Url::parse(&generated_url)
-        .is_ok_and(|url| &url.to_string() == &generated_url)
-    {
-        format!("[source]\nurl = \"{generated_url}\"")
-    } else {
-        format!(
-                "# [source]\n# When publishing, configure the source URL below\n# url = \"https://github.com/your-username/{}/archive/refs/tags/$(REF).zip\"",
-                validated.name
-            )
-    };
+    if validated.is_github_repo {
+        let generated_url = format!(
+            "https://github.com/{}/{}/archive/refs/tags/$(REF).zip",
+            validated.maintainer, validated.name
+        );
+
+        if url::Url::parse(&generated_url).is_ok_and(|url| url.as_str() == generated_url) {
+            source = format!("[source]\nurl = \"{generated_url}\"");
+        }
+    }
 
     std::fs::write(
         &rocks_path,

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -339,6 +339,9 @@ maintainer = "{maintainer}"
 labels = [ {labels} ]
 {license}
 
+[source]
+url = "https://github.com/{maintainer}/{package_name}/archive/refs/tags/$(REF).zip"
+
 [dependencies]
 # Add your dependencies here
 # `busted = ">=2.0"`

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -340,7 +340,7 @@ labels = [ {labels} ]
 {license}
 
 [source]
-url = "https://github.com/{maintainer}/{package_name}/archive/refs/tags/$(REF).zip"
+url = "https://github.com/<owner>/my-project/archive/refs/tags/$(REF).zip"
 
 [dependencies]
 # Add your dependencies here

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -330,10 +330,15 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
         validated.maintainer, validated.name
     );
 
-    let source = if !generated_url.contains(' ') && url::Url::parse(&generated_url).is_ok() {
+    let source = if url::Url::parse(&generated_url)
+        .is_ok_and(|url| &url.to_string() == &generated_url)
+    {
         format!("[source]\nurl = \"{generated_url}\"")
     } else {
-        String::new()
+        format!(
+                "# [source]\n# url = \"https://github.com/your-username/{}/archive/refs/tags/v0.1.0.zip\"",
+                validated.name
+            )
     };
 
     std::fs::write(

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -81,7 +81,7 @@ struct NewProjectValidated {
     lua_versions: PackageReq,
     main: SourceDirType,
     license: Option<LicenseId>,
-    is_github_repo: bool,
+    source_block: String,
 }
 
 fn clap_parse_license(s: &str) -> std::result::Result<LicenseId, String> {
@@ -176,7 +176,8 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
             maintainer,
             name,
             target,
-            is_github_repo: false,
+            source_block: "# [source]\n# When publishing, configure the source URL here"
+                .to_string(),
         }),
 
         NewProject {
@@ -311,6 +312,20 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
                 Ok,
             )?;
 
+            let mut source_block =
+                format!("# [source]\n# When publishing, configure the source URL here");
+
+            if is_github_repo {
+                let generated_url = format!(
+                    "https://github.com/{}/{}/archive/refs/tags/$(REF).zip",
+                    maintainer, package_name
+                );
+
+                if url::Url::parse(&generated_url).is_ok_and(|url| url.as_str() == generated_url) {
+                    source_block = format!("[source]\nurl = \"{generated_url}\"");
+                }
+            }
+
             Ok(NewProjectValidated {
                 target,
                 name: package_name,
@@ -320,7 +335,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
                 lua_versions,
                 maintainer,
                 main: main.unwrap_or(SourceDirType::Src),
-                is_github_repo,
+                source_block,
             })
         }
     }?;
@@ -328,19 +343,6 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
     let _ = std::fs::create_dir_all(&validated.target).into_diagnostic();
 
     let rocks_path = validated.target.join(PROJECT_TOML);
-
-    let mut source = format!("# [source]\n# When publishing, configure the source URL here");
-
-    if validated.is_github_repo {
-        let generated_url = format!(
-            "https://github.com/{}/{}/archive/refs/tags/$(REF).zip",
-            validated.maintainer, validated.name
-        );
-
-        if url::Url::parse(&generated_url).is_ok_and(|url| url.as_str() == generated_url) {
-            source = format!("[source]\nurl = \"{generated_url}\"");
-        }
-    }
 
     std::fs::write(
         &rocks_path,
@@ -382,6 +384,7 @@ type = "builtin"
                 .join(", "),
             lua_version_req = validated.lua_versions.version_req(),
             main = validated.main,
+            source = validated.source_block,
         )
         .trim(),
     )

--- a/lux-cli/src/project/new.rs
+++ b/lux-cli/src/project/new.rs
@@ -336,7 +336,7 @@ pub async fn write_project_rockspec(cli_flags: NewProject, config: Config) -> Re
         format!("[source]\nurl = \"{generated_url}\"")
     } else {
         format!(
-                "# [source]\n# url = \"https://github.com/your-username/{}/archive/refs/tags/v0.1.0.zip\"",
+                "# [source]\n# url = \"https://github.com/your-username/{}/archive/refs/tags/$(REF).zip\"",
                 validated.name
             )
     };


### PR DESCRIPTION
Close #1168 

Following: [https://lux.lumen-labs.org/guides/lux-toml/#source](https://lux.lumen-labs.org/guides/lux-toml/#source)

New toml generated from lx-new:
```toml
package = "isvane"
version = "0.1.0"
lua = ">=5.1"

[description]
summary = "testing"
maintainer = "haiqal"
labels = [ "web" ]
license = "MIT"

[source]
url = "https://github.com/haiqal/isvane/archive/refs/tags/$(REF).zip"

[dependencies]
# Add your dependencies here
# `busted = ">=2.0"`

[run]
args = [ "src/main.lua" ]

[build]
type = "builtin"
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/lumen-oss/lux/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
