### PR TITLE
feat(build): `rust-binary` build backend

### DIFF
--- a/lux-lib/src/build/mod.rs
+++ b/lux-lib/src/build/mod.rs
@@ -37,6 +37,7 @@ use make::MakeError;
 
 use miette::Diagnostic;
 use patch::{Patch, PatchError};
+use rust_binary::RustBinaryError;
 use rust_mlua::RustError;
 use source::SourceBuildError;
 use ssri::Integrity;
@@ -50,6 +51,7 @@ mod command;
 mod luarocks;
 mod make;
 mod patch;
+mod rust_binary;
 mod rust_mlua;
 mod source;
 mod treesitter_parser;
@@ -134,6 +136,9 @@ pub enum BuildError {
     #[error("rust-mlua build failed")]
     #[diagnostic(forward(0))]
     Rust(#[from] RustError),
+    #[error("rust-binary build failed")]
+    #[diagnostic(forward(0))]
+    RustBinary(#[from] RustBinaryError),
     #[error("treesitter-parser build failed")]
     #[diagnostic(forward(0))]
     TreesitterBuild(#[from] TreesitterBuildError),
@@ -220,6 +225,9 @@ async fn run_build<R: Rockspec + HasIntegrity, T: InstallTree + Sync>(
             Some(BuildBackendSpec::CMake(cmake_spec)) => cmake_spec.run(args).await?,
             Some(BuildBackendSpec::Command(command_spec)) => command_spec.run(args).await?,
             Some(BuildBackendSpec::RustMlua(rust_mlua_spec)) => rust_mlua_spec.run(args).await?,
+            Some(BuildBackendSpec::RustBinary(rust_binary_spec)) => {
+                rust_binary_spec.run(args).await?
+            }
             Some(BuildBackendSpec::TreesitterParser(treesitter_parser_spec)) => {
                 treesitter_parser_spec.run(args).await?
             }

--- a/lux-lib/src/build/rust_binary.rs
+++ b/lux-lib/src/build/rust_binary.rs
@@ -1,0 +1,111 @@
+use crate::build::backend::{BuildBackend, BuildInfo, RunBuildArgs};
+use crate::build::utils::{self, InstallBinaryError};
+use crate::config::build;
+use crate::fs;
+use crate::lua_rockspec::RustBinaryBuildSpec;
+use crate::tree::InstallTree;
+use miette::Diagnostic;
+use std::io;
+use std::process::ExitStatus;
+use thiserror::Error;
+
+use tracing::Instrument;
+
+#[derive(Error, Debug, Diagnostic)]
+#[non_exhaustive]
+pub enum RustBinaryError {
+    #[error("`cargo install` failed.\nstatus: {status}\nstdout: {stdout}\nstderr: {stderr}")]
+    CargoInstall {
+        status: ExitStatus,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("failed to run `cargo install`")]
+    RustBuild { source: io::Error },
+    #[error("failed to install binary '{file_name}'")]
+    InstallBinary {
+        file_name: String,
+        #[diagnostic_source]
+        source: InstallBinaryError,
+    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Fs(#[from] fs::FsError),
+}
+
+impl BuildBackend for RustBinaryBuildSpec {
+    type Err = RustBinaryError;
+
+    #[tracing::instrument(name = "rust_binary::run", skip_all, level = "debug")]
+    async fn run<T>(self, args: RunBuildArgs<'_, T>) -> Result<BuildInfo, Self::Err>
+    where
+        T: InstallTree,
+    {
+        let config = args.config;
+        let build_dir = args.build_dir;
+
+        let mut install_args = vec!["install", "--root", ".", "--bins"];
+        if config.build_profile() == build::Profile::Dev {
+            install_args.push("--debug");
+        }
+        let features = self.features.join(",");
+        if !features.is_empty() {
+            install_args.push("--features");
+            install_args.push(&features);
+        }
+        install_args.push(&self.binary);
+
+        if let Some(cargo_vendor_dir) = config
+            .vendor_dir()
+            .map(|vendor_dir| vendor_dir.join("cargo"))
+            .filter(|dir| dir.is_dir())
+        {
+            utils::prepare_cargo_vendor_config(config, build_dir, &cargo_vendor_dir).await?;
+            install_args.push("--offline");
+        }
+
+        match config
+            .wrapped_command("cargo", install_args)
+            .current_dir(build_dir)
+            .output()
+            .instrument(tracing::info_span!(
+                "Compiling rust binary",
+                profile = config.build_profile().to_string()
+            ))
+            .await
+        {
+            Ok(output) if output.status.success() => utils::trace_command_output(&output),
+            Ok(output) => {
+                return Err(RustBinaryError::CargoInstall {
+                    status: output.status,
+                    stdout: String::from_utf8_lossy(&output.stdout).into(),
+                    stderr: String::from_utf8_lossy(&output.stderr).into(),
+                });
+            }
+            Err(source) => return Err(RustBinaryError::RustBuild { source }),
+        }
+
+        let binary_name = self.binary.split('@').next().unwrap_or(&self.binary);
+        let binary_path = build_dir.join("bin").join(binary_name);
+        let installed_binary = utils::install_binary(
+            &binary_path,
+            binary_name,
+            args.tree,
+            args.lua,
+            args.deploy,
+            config,
+        )
+        .await
+        .map_err(|source| RustBinaryError::InstallBinary {
+            file_name: binary_name.to_string(),
+            source,
+        })?;
+
+        let binaries = installed_binary
+            .file_name()
+            .map(|file_name| vec![file_name.into()])
+            .unwrap_or_default();
+
+        Ok(BuildInfo { binaries })
+    }
+}

--- a/lux-lib/src/build/rust_mlua.rs
+++ b/lux-lib/src/build/rust_mlua.rs
@@ -9,8 +9,7 @@ use crate::{lua_rockspec::RustMluaBuildSpec, tree::RockLayout};
 use itertools::Itertools;
 use miette::Diagnostic;
 use std::collections::HashMap;
-use std::fs::OpenOptions;
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use thiserror::Error;
@@ -75,37 +74,13 @@ impl BuildBackend for RustMluaBuildSpec {
         build_args.push(&features);
         build_args.extend(self.cargo_extra_args.iter().map(|arg| arg.as_str()));
 
-        match config
+        if let Some(cargo_vendor_dir) = config
             .vendor_dir()
             .map(|vendor_dir| vendor_dir.join("cargo"))
+            .filter(|dir| dir.is_dir())
         {
-            Some(cargo_vendor_dir) if cargo_vendor_dir.is_dir() => {
-                let cargo_config_dir = build_dir.join(".cargo");
-                fs::tokio::create_dir_all(&cargo_config_dir).await?;
-                let cargo_config_path = cargo_config_dir.join("config.toml");
-                if cargo_config_path.exists() {
-                    // NOTE: The source may already ship a `.cargo/config.toml` that is
-                    // read-only (e.g. vendored from a read-only Nix store)
-                    utils::make_writable(&cargo_config_path).await?;
-                }
-                let mut target_file = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&cargo_config_path)
-                    .map_err(|source| fs::FsError::FileOpen {
-                        path: cargo_config_path.to_path_buf(),
-                        source,
-                    })?;
-                write!(&mut target_file,
-                    "[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.vendored-sources]\ndirectory = \"{}\"\n",
-                    cargo_vendor_dir.display()
-                ).map_err(|source| fs::FsError::Write {
-                    path: cargo_config_path.to_path_buf(),
-                    source,
-                })?;
-                build_args.push("--offline");
-            }
-            _ => (),
+            utils::prepare_cargo_vendor_config(config, build_dir, &cargo_vendor_dir).await?;
+            build_args.push("--offline");
         }
 
         {

--- a/lux-lib/src/build/source.rs
+++ b/lux-lib/src/build/source.rs
@@ -16,7 +16,8 @@ use thiserror::Error;
 
 use super::{
     builtin::BuiltinBuildError, cmake::CMakeError, command::CommandError, make::MakeError,
-    rust_mlua::RustError, treesitter_parser::TreesitterBuildError, utils::recursive_copy_dir,
+    rust_binary::RustBinaryError, rust_mlua::RustError, treesitter_parser::TreesitterBuildError,
+    utils::recursive_copy_dir,
 };
 
 #[derive(Error, Debug, Diagnostic)]
@@ -51,6 +52,9 @@ pub enum SourceBuildError {
     #[error("rust-mlua build failed")]
     #[diagnostic(forward(0))]
     Rust(#[from] RustError),
+    #[error("rust-binary build failed")]
+    #[diagnostic(forward(0))]
+    RustBinary(#[from] RustBinaryError),
     #[error("treesitter-parser build failed")]
     #[diagnostic(forward(0))]
     TreesitterBuild(#[from] TreesitterBuildError),
@@ -115,6 +119,11 @@ where
         }
         Some(BuildBackendSpec::RustMlua(rust_mlua_spec)) => {
             rust_mlua_spec
+                .run(args)
+                .await?
+        }
+        Some(BuildBackendSpec::RustBinary(rust_binary_spec)) => {
+            rust_binary_spec
                 .run(args)
                 .await?
         }

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -14,7 +14,8 @@ use path_slash::PathExt;
 use shlex::try_quote;
 use std::{
     collections::HashMap,
-    io,
+    fs::OpenOptions,
+    io::{self, Write},
     path::{Path, PathBuf},
     process::{ExitStatus, Output, Stdio},
     string::FromUtf8Error,
@@ -135,6 +136,42 @@ pub(crate) async fn recursive_copy_dir(src: &PathBuf, dest: &Path) -> Result<(),
             make_writable(&target).await?;
         }
     }
+    Ok(())
+}
+
+/// Points cargo at the vendored sources under [`Config::vendor_dir`]/cargo by
+/// writing a `.cargo/config.toml` in the build directory, if such a directory exists.
+#[tracing::instrument(level = "trace")]
+pub(crate) async fn prepare_cargo_vendor_config(
+    config: &Config,
+    build_dir: &Path,
+    cargo_vendor_dir: &Path,
+) -> Result<(), fs::FsError> {
+    let cargo_config_dir = build_dir.join(".cargo");
+    fs::tokio::create_dir_all(&cargo_config_dir).await?;
+    let cargo_config_path = cargo_config_dir.join("config.toml");
+    if cargo_config_path.exists() {
+        // The source may already ship a `.cargo/config.toml` that is
+        // read-only (e.g. vendored from a read-only Nix store)
+        make_writable(&cargo_config_path).await?;
+    }
+    let mut target_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&cargo_config_path)
+        .map_err(|source| fs::FsError::FileOpen {
+            path: cargo_config_path.to_path_buf(),
+            source,
+        })?;
+    write!(
+        &mut target_file,
+        "[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.vendored-sources]\ndirectory = \"{}\"\n",
+        cargo_vendor_dir.display()
+    )
+    .map_err(|source| fs::FsError::Write {
+        path: cargo_config_path.to_path_buf(),
+        source,
+    })?;
     Ok(())
 }
 

--- a/lux-lib/src/lua_rockspec/build/mod.rs
+++ b/lux-lib/src/lua_rockspec/build/mod.rs
@@ -1,6 +1,7 @@
 mod builtin;
 mod cmake;
 mod make;
+mod rust_binary;
 mod rust_mlua;
 mod tree_sitter;
 
@@ -8,6 +9,7 @@ pub use builtin::{BuiltinBuildSpec, LuaModule, ModulePaths, ModuleSpec, ParseLua
 pub use cmake::*;
 pub use make::*;
 use path_slash::PathBufExt;
+pub use rust_binary::*;
 pub use rust_mlua::*;
 pub use tree_sitter::*;
 
@@ -69,6 +71,8 @@ pub enum BuildSpecInternalError {
     ModulesHaveListElements,
     #[error("no 'modules' specified for the 'rust-mlua' build backend")]
     NoModulesSpecified,
+    #[error("no 'binary' specified for the 'rust-binary' build backend")]
+    NoBinarySpecified,
     #[error("no 'lang' specified for 'treesitter-parser' build backend")]
     NoTreesitterParserLanguageSpecified,
     #[error("invalid 'rust-mlua' modules format")]
@@ -173,6 +177,12 @@ impl BuildSpec {
                     })
                     .collect(),
             })),
+            BuildType::RustBinary => Some(BuildBackendSpec::RustBinary(RustBinaryBuildSpec {
+                binary: internal
+                    .binary
+                    .ok_or(BuildSpecInternalError::NoBinarySpecified)?,
+                features: internal.features.unwrap_or_default(),
+            })),
             BuildType::TreesitterParser => Some(BuildBackendSpec::TreesitterParser(
                 TreesitterParserBuildSpec {
                     lang: internal
@@ -246,6 +256,7 @@ pub enum BuildBackendSpec {
     Command(CommandBuildSpec),
     LuaRock(String),
     RustMlua(RustMluaBuildSpec),
+    RustBinary(RustBinaryBuildSpec),
     TreesitterParser(TreesitterParserBuildSpec),
     /// Build from the source rockspec, if present.
     /// Otherwise, fall back to the builtin build and copy all directories.
@@ -259,9 +270,11 @@ impl BuildBackendSpec {
     pub(crate) fn can_use_build_dependencies(&self) -> bool {
         match self {
             Self::Make(_) | Self::CMake(_) | Self::Command(_) | Self::LuaRock(_) => true,
-            Self::Builtin(_) | Self::RustMlua(_) | Self::TreesitterParser(_) | Self::Source => {
-                false
-            }
+            Self::Builtin(_)
+            | Self::RustMlua(_)
+            | Self::RustBinary(_)
+            | Self::TreesitterParser(_)
+            | Self::Source => false,
         }
     }
 }
@@ -546,6 +559,8 @@ pub(crate) struct BuildSpecInternal {
     #[serde(default)]
     pub(crate) features: Option<Vec<String>>,
     pub(crate) cargo_extra_args: Option<Vec<String>>,
+    #[serde(default)]
+    pub(crate) binary: Option<String>,
     #[serde(default, deserialize_with = "deserialize_map_or_seq")]
     #[display_lua(convert_with = "display_include")]
     pub(crate) include: Option<HashMap<LuaTableKey, PathBuf>>,
@@ -658,6 +673,7 @@ fn override_build_spec_internal(
         default_features: override_opt(&override_spec.default_features, &base.default_features),
         features: override_opt(&override_spec.features, &base.features),
         cargo_extra_args: override_opt(&override_spec.cargo_extra_args, &base.cargo_extra_args),
+        binary: override_opt(&override_spec.binary, &base.binary),
         include: merge_map_opts(&override_spec.include, &base.include),
         lang: override_opt(&override_spec.lang, &base.lang),
         parser: override_opt(&override_spec.parser, &base.parser),
@@ -714,6 +730,8 @@ pub(crate) enum BuildType {
     LuaRock(String),
     #[serde(rename = "rust-mlua")]
     RustMlua,
+    #[serde(rename = "rust-binary")]
+    RustBinary,
     #[serde(rename = "treesitter-parser")]
     TreesitterParser,
     Source,
@@ -732,6 +750,13 @@ impl BuildType {
             &BuildType::RustMlua => unsafe {
                 Some(
                     PackageReq::parse("luarocks-build-rust-mlua >= 0.2.6")
+                        .unwrap_unchecked()
+                        .into(),
+                )
+            },
+            &BuildType::RustBinary => unsafe {
+                Some(
+                    PackageReq::parse("luarocks-build-rust-binary >= 3.0.0")
                         .unwrap_unchecked()
                         .into(),
                 )
@@ -773,6 +798,7 @@ impl Display for BuildType {
             BuildType::None => write!(f, "none"),
             BuildType::LuaRock(s) => write!(f, "{s}"),
             BuildType::RustMlua => write!(f, "rust-mlua"),
+            BuildType::RustBinary => write!(f, "rust-binary"),
             BuildType::TreesitterParser => write!(f, "treesitter-parser"),
             BuildType::Source => write!(f, "source"),
         }

--- a/lux-lib/src/lua_rockspec/build/rust_binary.rs
+++ b/lux-lib/src/lua_rockspec/build/rust_binary.rs
@@ -1,0 +1,9 @@
+/// Specification for building a rock with the `rust-binary` build backend
+#[derive(Debug, PartialEq, Default, Clone)]
+pub struct RustBinaryBuildSpec {
+    /// The name of the binary (or crate) to install, optionally including
+    /// a version specifier (e.g. `foo@1.0.0`).
+    pub binary: String,
+    /// Cargo features to enable when building.
+    pub features: Vec<String>,
+}

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -1672,6 +1672,31 @@ mod tests {
         }
     }
 
+    #[test]
+    pub fn rust_binary_rockspec() {
+        let rockspec_content = "
+    package = 'foo'\n
+    version = 'scm-1'\n
+    source = {\n
+        url = 'https://github.com/lumen-oss/rocks.nvim/archive/1.0.0/rocks.nvim.zip',\n
+    }\n
+    build = {\n
+        type = 'rust-binary',\n
+        binary = 'foo@1.0.0',\n
+        features = {'extra', 'features'},\n
+    }\n
+            ";
+        let rockspec = RemoteLuaRockspec::new(rockspec_content).unwrap();
+        let build_spec = rockspec.local.build.current_platform();
+        if let Some(BuildBackendSpec::RustBinary(build_spec)) = build_spec.build_backend.to_owned()
+        {
+            assert_eq!(build_spec.binary, "foo@1.0.0");
+            assert_eq!(build_spec.features, vec!["extra", "features"]);
+        } else {
+            panic!("Expected RustBinary build backend");
+        }
+    }
+
     #[tokio::test]
     pub async fn regression_ltui() {
         let content = String::from_utf8(

--- a/lux-lib/src/operations/install_rockspec.rs
+++ b/lux-lib/src/operations/install_rockspec.rs
@@ -75,7 +75,9 @@ impl<
                 // Exclude luarocks build backends that we have implemented in lux
                 !matches!(
                     dep.name().to_string().as_str(),
-                    "luarocks-build-rust-mlua" | "luarocks-build-treesitter-parser"
+                    "luarocks-build-rust-mlua"
+                        | "luarocks-build-rust-binary"
+                        | "luarocks-build-treesitter-parser"
                 )
             })
             .filter(|dep| {

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -98,7 +98,9 @@ pub(crate) fn build_dependencies_to_install<R: Rockspec>(rockspec: &R) -> Vec<Pa
         .filter(|dep| {
             !matches!(
                 dep.name().to_string().as_str(),
-                "luarocks-build-rust-mlua" | "luarocks-build-treesitter-parser"
+                "luarocks-build-rust-mlua"
+                    | "luarocks-build-rust-binary"
+                    | "luarocks-build-treesitter-parser"
             )
         })
         .map(|dep| dep.name().clone())

--- a/lux-lib/src/operations/vendor.rs
+++ b/lux-lib/src/operations/vendor.rs
@@ -151,7 +151,7 @@ async fn do_vendor_dependencies(args: Vendor<'_>) -> Result<(), VendorError> {
         .unique_by(|pkg| (pkg.spec.name().clone(), pkg.spec.version().clone()))
         .collect_vec();
 
-    let rust_mlua_deps: Vec<(PackageSpec, Option<PathBuf>)> = all_packages
+    let cargo_deps: Vec<(PackageSpec, Option<PathBuf>)> = all_packages
         .iter()
         .filter_map(|pkg| {
             match pkg
@@ -161,7 +161,7 @@ async fn do_vendor_dependencies(args: Vendor<'_>) -> Result<(), VendorError> {
                 .current_platform()
                 .build_backend
             {
-                Some(BuildBackendSpec::RustMlua(_)) => Some((
+                Some(BuildBackendSpec::RustMlua(_) | BuildBackendSpec::RustBinary(_)) => Some((
                     pkg.spec.to_package(),
                     pkg.downloaded_rock
                         .rockspec()
@@ -182,7 +182,7 @@ async fn do_vendor_dependencies(args: Vendor<'_>) -> Result<(), VendorError> {
     let vendor_dir = Arc::new(vendor_dir);
     vendor_sources(vendor_dir.clone(), config.clone(), all_packages).await?;
     vendor_target_cargo_deps(&vendor_dir, &target, config).await?;
-    for (dep, unpack_dir) in rust_mlua_deps {
+    for (dep, unpack_dir) in cargo_deps {
         vendor_package_cargo_deps(&vendor_dir, &dep, &unpack_dir, config).await?;
     }
     Ok(())
@@ -429,7 +429,7 @@ async fn vendor_target_cargo_deps(
     target: &VendorTarget,
     config: &Config,
 ) -> Result<(), VendorError> {
-    if is_rust_mlua_build_backend(target) {
+    if is_cargo_build_backend(target) {
         match target {
             VendorTarget::Workspace(workspace) => {
                 cargo_vendor(vendor_dir, workspace.root().as_path(), config).await
@@ -492,19 +492,19 @@ async fn vendor_package_cargo_deps(
     Ok(())
 }
 
-fn is_rust_mlua_build_backend(target: &VendorTarget) -> bool {
+fn is_cargo_build_backend(target: &VendorTarget) -> bool {
     match target {
         VendorTarget::Workspace(workspace) => workspace.members().iter().any(|project| {
             project.toml().into_local().is_ok_and(|toml| {
                 matches!(
                     toml.build().current_platform().build_backend.to_owned(),
-                    Some(BuildBackendSpec::RustMlua(_))
+                    Some(BuildBackendSpec::RustMlua(_) | BuildBackendSpec::RustBinary(_))
                 )
             })
         }),
         VendorTarget::Rockspec(rockspec) => matches!(
             rockspec.build().current_platform().build_backend.to_owned(),
-            Some(BuildBackendSpec::RustMlua(_))
+            Some(BuildBackendSpec::RustMlua(_) | BuildBackendSpec::RustBinary(_))
         ),
     }
 }

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -30,7 +30,7 @@ use lux_lib::{
         LuaModule, LuaScriptTestSpec, MakeBuildSpec, ModulePaths, ModuleSpec, PartialLuaRockspec,
         PartialOverride, PerPlatform, PlatformIdentifier, PlatformOverridable, PlatformSupport,
         RemoteLuaRockspec, RemoteRockSource, RockDescription, RockSourceSpec, RockspecFormat,
-        RustMluaBuildSpec, TestSpec, TreesitterParserBuildSpec,
+        RustBinaryBuildSpec, RustMluaBuildSpec, TestSpec, TreesitterParserBuildSpec,
     },
     lua_version::LuaVersion,
     operations::{DownloadedRockspec, PackageInstallSpec, SyncReport},
@@ -686,6 +686,7 @@ impl IntoLua for BuildBackendSpecLua {
             BuildBackendSpec::Command(spec) => CommandBuildSpecLua(spec).into_lua(lua),
             BuildBackendSpec::LuaRock(s) => s.into_lua(lua),
             BuildBackendSpec::RustMlua(spec) => RustMluaBuildSpecLua(spec).into_lua(lua),
+            BuildBackendSpec::RustBinary(spec) => RustBinaryBuildSpecLua(spec).into_lua(lua),
             BuildBackendSpec::TreesitterParser(spec) => {
                 TreesitterParserBuildSpecLua(spec).into_lua(lua)
             }
@@ -2108,6 +2109,42 @@ impl mlua::UserData for RustMluaBuildSpecLua {
 }
 
 #[derive(Debug, Clone)]
+pub struct RustBinaryBuildSpecLua(pub RustBinaryBuildSpec);
+
+impl Typed for RustBinaryBuildSpecLua {
+    fn ty() -> Type {
+        Type::named("RustBinaryBuildSpec")
+    }
+}
+
+impl TypedUserData for RustBinaryBuildSpecLua {
+    fn add_methods<M: TypedDataMethods<Self>>(methods: &mut M) {
+        methods.document(
+            r#"The name of the binary (or crate) to install, optionally including a version specifier (e.g. `foo@1.0.0`)."#,
+        );
+        methods.add_method("binary", |_, this, ()| Ok(this.0.binary.clone()));
+
+        methods.document("Cargo features to enable when building");
+        methods.add_method("features", |_, this, ()| Ok(this.0.features.clone()));
+    }
+    fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {
+        docs.add("Specification for building a rock with the `rust-binary` build backend");
+    }
+}
+
+impl mlua::UserData for RustBinaryBuildSpecLua {
+    fn add_fields<F: mlua::UserDataFields<Self>>(fields: &mut F) {
+        let mut wrapper = mlua_extras::typed::WrappedBuilder::new(fields);
+        <Self as TypedUserData>::add_fields(&mut wrapper);
+    }
+
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        let mut wrapper = mlua_extras::typed::WrappedBuilder::new(methods);
+        <Self as TypedUserData>::add_methods(&mut wrapper);
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct CommandBuildSpecLua(pub CommandBuildSpec);
 
 impl Typed for CommandBuildSpecLua {
@@ -3208,7 +3245,8 @@ mod definitions_registry {
         PackageReqLua, PackageSpecLua, PartialLuaRockspecLua, PartialProjectTomlLua,
         PlatformSupportLua, ProjectLua, RemoteLuaRockspecLua, RemotePackageDBLua,
         RemoteProjectTomlLua, RemoteRockSourceLua, RockDescriptionLua, RockLayoutConfigLua,
-        RockLayoutLua, RustMluaBuildSpecLua, TreeLua, TreesitterParserBuildSpecLua, WorkspaceLua,
+        RockLayoutLua, RustBinaryBuildSpecLua, RustMluaBuildSpecLua, TreeLua,
+        TreesitterParserBuildSpecLua, WorkspaceLua,
     };
     use crate::definitions::LuxDefinition;
 
@@ -3248,6 +3286,7 @@ mod definitions_registry {
         "MakeBuildSpec" => MakeBuildSpecLua,
         "TreesitterParserBuildSpec" => TreesitterParserBuildSpecLua,
         "RustMluaBuildSpec" => RustMluaBuildSpecLua,
+        "RustBinaryBuildSpec" => RustBinaryBuildSpecLua,
         "CommandBuildSpec" => CommandBuildSpecLua,
         "InstallSpec" => InstallSpecLua,
         "BuildSpec" => BuildSpecLua,


### PR DESCRIPTION
Native implementation of the [luarocks-build-rust-binary](https://github.com/vhyrro/luarocks-build-rust-binary) build backend, which allows us to vendor Cargo dependencies.