### PR TITLE
fix(build/rust-binary): auto-detect binaries

### DIFF
--- a/lux-lib/src/build/builtin.rs
+++ b/lux-lib/src/build/builtin.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 use thiserror::Error;
-use walkdir::{DirEntry, WalkDir};
+use walkdir::WalkDir;
 
 use crate::{
     build::{
@@ -119,7 +119,7 @@ impl BuildBackend for BuiltinBuildSpec {
         }
 
         let mut binaries = Vec::new();
-        for bin_script in autodetect_bin_scripts(build_dir) {
+        for bin_script in utils::detect_binaries(build_dir) {
             if let Some(target) = bin_script.file_name() {
                 let file_name = target.to_string_lossy().to_string();
                 let installed_bin_script =
@@ -215,15 +215,4 @@ fn autodetect_modules(
             lua_module.map(|lua_module| (lua_module, ModuleSpec::SourcePath(diff)))
         })
         .try_collect()
-}
-
-#[tracing::instrument(level = "trace")]
-fn autodetect_bin_scripts(build_dir: &Path) -> Vec<PathBuf> {
-    WalkDir::new(build_dir.join("src").join("bin"))
-        .into_iter()
-        .chain(WalkDir::new(build_dir.join("bin")))
-        .filter_map(|file| file.ok())
-        .filter(|file| file.clone().into_path().is_file())
-        .map(DirEntry::into_path)
-        .collect()
 }

--- a/lux-lib/src/build/rust_binary.rs
+++ b/lux-lib/src/build/rust_binary.rs
@@ -85,26 +85,28 @@ impl BuildBackend for RustBinaryBuildSpec {
             Err(source) => return Err(RustBinaryError::RustBuild { source }),
         }
 
-        let binary_name = self.binary.split('@').next().unwrap_or(&self.binary);
-        let binary_path = build_dir.join("bin").join(binary_name);
-        let installed_binary = utils::install_binary(
-            &binary_path,
-            binary_name,
-            args.tree,
-            args.lua,
-            args.deploy,
-            config,
-        )
-        .await
-        .map_err(|source| RustBinaryError::InstallBinary {
-            file_name: binary_name.to_string(),
-            source,
-        })?;
-
-        let binaries = installed_binary
-            .file_name()
-            .map(|file_name| vec![file_name.into()])
-            .unwrap_or_default();
+        let mut binaries = Vec::new();
+        for bin_script in utils::detect_binaries(build_dir) {
+            if let Some(target) = bin_script.file_name() {
+                let file_name = target.to_string_lossy().to_string();
+                let installed_bin_script = utils::install_binary(
+                    &bin_script,
+                    &file_name,
+                    args.tree,
+                    args.lua,
+                    args.deploy,
+                    config,
+                )
+                .await
+                .map_err(|err| RustBinaryError::InstallBinary {
+                    file_name: file_name.to_string(),
+                    source: err,
+                })?;
+                if let Some(bin_script_file_name) = installed_bin_script.file_name() {
+                    binaries.push(bin_script_file_name.into());
+                }
+            }
+        }
 
         Ok(BuildInfo { binaries })
     }

--- a/lux-lib/src/build/utils.rs
+++ b/lux-lib/src/build/utils.rs
@@ -23,6 +23,7 @@ use std::{
 use target_lexicon::Triple;
 use thiserror::Error;
 use tokio::process::Command;
+use walkdir::{DirEntry, WalkDir};
 use which::which;
 
 #[cfg(unix)]
@@ -944,6 +945,17 @@ pub(crate) fn format_path(path: &Path) -> String {
             .map(|str| str.to_string())
             .unwrap_or(format!("'{path_str}'"))
     }
+}
+
+#[tracing::instrument(level = "trace")]
+pub(crate) fn detect_binaries(build_dir: &Path) -> Vec<PathBuf> {
+    WalkDir::new(build_dir.join("src").join("bin"))
+        .into_iter()
+        .chain(WalkDir::new(build_dir.join("bin")))
+        .filter_map(|file| file.ok())
+        .filter(|file| file.clone().into_path().is_file())
+        .map(DirEntry::into_path)
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of trying to install the `build.binary`, we just auto-detect binaries in `src/bin` and `bin/`, like the `builtin` build backend does.