### PR TITLE
fix(generate-rockspec): properly generate `source.branch`

### DIFF
--- a/lux-lib/src/git/mod.rs
+++ b/lux-lib/src/git/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::{
     git::url::RemoteGitUrl,
-    lua_rockspec::{DisplayAsLuaValue, DisplayLuaValue},
+    lua_rockspec::{DisplayAsLuaKV, DisplayAsLuaValue, DisplayLuaKV, DisplayLuaValue},
 };
 
 pub mod shorthand;
@@ -15,19 +15,52 @@ impl DisplayAsLuaValue for RemoteGitUrl {
     }
 }
 
+/// Specifies a git reference (tag or branch)
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum GitRef {
+    Tag(String),
+    Branch(String),
+}
+
 /// Specifies a source to be fetched from a git forge
-#[derive(Debug, PartialEq, Eq, Hash, Clone, lux_macros::DisplayAsLuaKV)]
-#[display_lua(key = "source")]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct GitSource {
     pub url: RemoteGitUrl,
-    #[display_lua(rename = "tag")]
-    pub checkout_ref: Option<String>,
+    pub git_ref: Option<GitRef>,
+}
+
+impl DisplayAsLuaKV for GitSource {
+    fn display_lua(&self) -> DisplayLuaKV {
+        let mut fields = vec![DisplayLuaKV {
+            key: "url".to_string(),
+            value: DisplayLuaValue::String(self.url.to_string()),
+        }];
+
+        if let Some(git_ref) = &self.git_ref {
+            match git_ref {
+                GitRef::Tag(tag) => fields.push(DisplayLuaKV {
+                    key: "tag".to_string(),
+                    value: DisplayLuaValue::String(tag.clone()),
+                }),
+                GitRef::Branch(branch) => fields.push(DisplayLuaKV {
+                    key: "branch".to_string(),
+                    value: DisplayLuaValue::String(branch.clone()),
+                }),
+            }
+        }
+
+        DisplayLuaKV {
+            key: "source".to_string(),
+            value: DisplayLuaValue::Table(fields),
+        }
+    }
 }
 
 impl Display for GitSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.checkout_ref {
-            Some(checkout_ref) => format!("{}@{}", self.url, checkout_ref).fmt(f),
+        match &self.git_ref {
+            Some(GitRef::Tag(tag)) => format!("{}@{}", self.url, tag).fmt(f),
+            Some(GitRef::Branch(branch)) => format!("{}@{}", self.url, branch).fmt(f),
             None => self.url.fmt(f),
         }
     }

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -953,7 +953,7 @@ mod tests {
             rockspec.local.source.default.source_spec,
             RockSourceSpec::Git(GitSource {
                 url: "https://hub.com/owner/example-project/".parse().unwrap(),
-                checkout_ref: Some("bar".into())
+                git_ref: Some(GitRef::Branch("bar".into()))
             })
         );
         assert_eq!(rockspec.local.test, PerPlatform::default());
@@ -972,7 +972,7 @@ mod tests {
             rockspec.local.source.default.source_spec,
             RockSourceSpec::Git(GitSource {
                 url: "https://hub.com/owner/example-project/".parse().unwrap(),
-                checkout_ref: Some("bar".into())
+                git_ref: Some(GitRef::Tag("bar".into()))
             })
         );
         let rockspec_content = "
@@ -1384,7 +1384,7 @@ mod tests {
             rockspec.local.source.default.source_spec,
             RockSourceSpec::Git(GitSource {
                 url: "https://hub.com/example-project/.git".parse().unwrap(),
-                checkout_ref: Some("bar".into())
+                git_ref: Some(GitRef::Branch("bar".into()))
             })
         );
         assert_eq!(
@@ -1396,7 +1396,7 @@ mod tests {
                 .unwrap(),
             RockSourceSpec::Git(GitSource {
                 url: "https://hub.com/example-project/.git".parse().unwrap(),
-                checkout_ref: Some("mac".into())
+                git_ref: Some(GitRef::Branch("mac".into()))
             })
         );
         assert_eq!(
@@ -1408,7 +1408,7 @@ mod tests {
                 .unwrap(),
             RockSourceSpec::Git(GitSource {
                 url: "https://winhub.com/example-project/.git".parse().unwrap(),
-                checkout_ref: Some("win".into())
+                git_ref: Some(GitRef::Branch("win".into()))
             })
         );
         let rockspec_content = "
@@ -1759,7 +1759,7 @@ mod tests {
         let package_req = "foo@1.0.5".parse().unwrap();
         let source = GitSource {
             url: "https://hub.com/owner/example-project.git".parse().unwrap(),
-            checkout_ref: Some("1.0.5".into()),
+            git_ref: Some(GitRef::Tag("1.0.5".into())),
         };
         let source_spec = RockSourceSpec::Git(source);
         let rockspec =

--- a/lux-lib/src/lua_rockspec/rock_source.rs
+++ b/lux-lib/src/lua_rockspec/rock_source.rs
@@ -5,6 +5,8 @@ use crate::{
     },
     lua_rockspec::per_platform_from_intermediate,
 };
+
+pub use crate::git::GitRef;
 use miette::Diagnostic;
 use reqwest::Url;
 use serde::{de, Deserialize, Deserializer};
@@ -82,11 +84,11 @@ impl TryFrom<RockSourceInternal> for RemoteRockSource {
             (source, None, None) => Ok(RockSourceSpec::default_from_source_url(source)),
             (SourceUrl::Git(url), Some(tag), None) => Ok(RockSourceSpec::Git(GitSource {
                 url,
-                checkout_ref: Some(tag),
+                git_ref: Some(GitRef::Tag(tag)),
             })),
             (SourceUrl::Git(url), None, Some(branch)) => Ok(RockSourceSpec::Git(GitSource {
                 url,
-                checkout_ref: Some(branch),
+                git_ref: Some(GitRef::Branch(branch)),
             })),
             _ => Err(RockSourceError::InvalidCombination),
         }?;
@@ -117,10 +119,7 @@ impl RockSourceSpec {
         match url {
             SourceUrl::File(path) => Self::File(path),
             SourceUrl::Url(url) => Self::Url(url),
-            SourceUrl::Git(url) => Self::Git(GitSource {
-                url,
-                checkout_ref: None,
-            }),
+            SourceUrl::Git(url) => Self::Git(GitSource { url, git_ref: None }),
         }
     }
 }
@@ -194,18 +193,18 @@ impl PartialOverride for RockSourceInternal {
     type Err = Infallible;
 
     fn apply_overrides(&self, override_spec: &Self) -> Result<Self, Self::Err> {
+        let (tag, branch) = match (&override_spec.tag, &override_spec.branch) {
+            (Some(tag), _) => (Some(tag.clone()), None),
+            (_, Some(branch)) => (None, Some(branch.clone())),
+            (None, None) => (self.tag.clone(), self.branch.clone()),
+        };
+
         Ok(Self {
             url: override_opt(override_spec.url.as_ref(), self.url.as_ref()),
             file: override_opt(override_spec.file.as_ref(), self.file.as_ref()),
             dir: override_opt(override_spec.dir.as_ref(), self.dir.as_ref()),
-            tag: match &override_spec.branch {
-                None => override_opt(override_spec.tag.as_ref(), self.tag.as_ref()),
-                _ => None,
-            },
-            branch: match &override_spec.tag {
-                None => override_opt(override_spec.branch.as_ref(), self.branch.as_ref()),
-                _ => None,
-            },
+            tag,
+            branch,
         })
     }
 }

--- a/lux-lib/src/operations/download.rs
+++ b/lux-lib/src/operations/download.rs
@@ -13,7 +13,7 @@ use url::{ParseError, Url};
 use crate::{
     config::Config,
     fs,
-    git::GitSource,
+    git::{GitRef, GitSource},
     lockfile::RemotePackageSourceUrl,
     lua_rockspec::{LuaRockspecError, RemoteLuaRockspec, RockSourceSpec},
     luarocks,
@@ -167,13 +167,20 @@ impl RemoteRockDownload {
     ) -> Result<Self, SearchAndDownloadError> {
         let package_spec = package_req.try_into()?;
         let source_url = Some(match &source_spec {
-            RockSourceSpec::Git(GitSource { url, checkout_ref }) => RemotePackageSourceUrl::Git {
-                url: url.to_string(),
-                checkout_ref: checkout_ref
-                    .clone()
-                    .ok_or(SearchAndDownloadError::MissingCheckoutRef(url.to_string()))?,
-                submodules: false, // unknown until the source is fetched
-            },
+            RockSourceSpec::Git(GitSource { url, git_ref }) => {
+                let checkout_ref = match git_ref {
+                    Some(GitRef::Tag(tag)) => tag.clone(),
+                    Some(GitRef::Branch(branch)) => branch.clone(),
+                    None => {
+                        return Err(SearchAndDownloadError::MissingCheckoutRef(url.to_string()))
+                    }
+                };
+                RemotePackageSourceUrl::Git {
+                    url: url.to_string(),
+                    checkout_ref,
+                    submodules: false, // unknown until the source is fetched
+                }
+            }
             RockSourceSpec::File(path) => RemotePackageSourceUrl::File { path: path.clone() },
             RockSourceSpec::Url(url) => RemotePackageSourceUrl::Url { url: url.clone() },
         });

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::git::url::RemoteGitUrlParseError;
-use crate::git::GitSource;
+use crate::git::{GitRef, GitSource};
 use crate::hash::HasIntegrity;
 use crate::lockfile::RemotePackageSourceUrl;
 use crate::lua_rockspec::{RemoteRockSource, RockSourceSpec};
@@ -70,7 +70,7 @@ where
                     url, checkout_ref, ..
                 } => RockSourceSpec::Git(GitSource {
                     url: url.parse()?,
-                    checkout_ref: Some(checkout_ref.clone()),
+                    git_ref: Some(GitRef::Tag(checkout_ref.clone())),
                 }),
                 RemotePackageSourceUrl::Url { url } => RockSourceSpec::Url(url.clone()),
                 RemotePackageSourceUrl::File { path } => RockSourceSpec::File(path.clone()),
@@ -278,18 +278,23 @@ async fn fetch_src_impl<R: Rockspec>(
                 let mut fetch_options = FetchOptions::new();
                 fetch_options.update_fetchhead(false);
                 fetch_options.remote_callbacks(callbacks);
-                if git.checkout_ref.is_none() {
+                let checkout_ref = match &git.git_ref {
+                    Some(GitRef::Tag(tag)) => Some(tag.as_str()),
+                    Some(GitRef::Branch(branch)) => Some(branch.as_str()),
+                    None => None,
+                };
+                if checkout_ref.is_none() {
                     fetch_options.depth(1);
                 };
                 let mut repo_builder = RepoBuilder::new();
                 repo_builder.fetch_options(fetch_options);
                 let repo = repo_builder.clone(&url, dest_dir)?;
 
-                let checkout_ref = match &git.checkout_ref {
+                let checkout_ref = match checkout_ref {
                     Some(checkout_ref) => {
                         let (object, _) = repo.revparse_ext(checkout_ref)?;
                         repo.checkout_tree(&object, None)?;
-                        checkout_ref.clone()
+                        checkout_ref.to_string()
                     }
                     None => {
                         let head = repo.head()?;

--- a/lux-lib/src/project/gen.rs
+++ b/lux-lib/src/project/gen.rs
@@ -43,6 +43,9 @@ pub(crate) struct RockSourceTemplate {
     /// The tag or revision to be checked out if the source URL is a git source.
     /// If unset, Lux will try to auto-detect it.
     tag: Option<String>,
+
+    /// The branch to be checked out if the source URL is a git source.
+    branch: Option<String>,
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -148,15 +151,22 @@ impl RockSourceTemplate {
             )?),
             None => None,
         };
+        let branch = match self.branch.as_ref() {
+            Some(branch) => Some(variables::substitute(
+                &[&package_spec, &Environment {}, &GitProject(project_root)],
+                branch,
+            )?),
+            None => None,
+        };
         match SourceUrl::from_str(&url_str)? {
             SourceUrl::File(_) | SourceUrl::Url(_) => Ok(RockSourceInternal {
                 url: Some(url_str.to_string()),
                 file,
                 dir,
-                branch: None,
+                branch,
                 tag,
             }),
-            SourceUrl::Git(_) if self.tag.is_none() => {
+            SourceUrl::Git(_) if self.tag.is_none() && self.branch.is_none() => {
                 if let Ok(repo) = Repository::open(project_root) {
                     let tag_or_rev = current_tag_or_revision(&repo)?;
                     Ok(RockSourceInternal {
@@ -175,7 +185,7 @@ impl RockSourceTemplate {
                 file,
                 dir,
                 tag,
-                branch: None,
+                branch,
             }),
         }
     }

--- a/lux-lib/src/project/project_toml.rs
+++ b/lux-lib/src/project/project_toml.rs
@@ -2,7 +2,7 @@
 
 use crate::fs;
 use crate::git::shorthand::RemoteGitUrlShorthand;
-use crate::git::GitSource;
+use crate::git::{GitRef, GitSource};
 use crate::hash::HasIntegrity;
 use crate::lockfile::OptState;
 use crate::lockfile::PinnedState;
@@ -102,18 +102,18 @@ where
                             ))),
                             (Some(git), Some(rev), None) => Ok(Some(RockSourceSpec::Git(GitSource {
                                 url: git.into(),
-                                checkout_ref: Some(rev),
+                                git_ref: Some(GitRef::Tag(rev)),
                             }))),
                             (Some(git), None, None) => Ok(Some(RockSourceSpec::Git(GitSource {
                                 url: git.into(),
-                                checkout_ref: Some(
+                                git_ref: Some(GitRef::Tag(
                                     entry
                                         .version
                                         .clone()
                                         .to_string()
                                         .trim_start_matches("=")
                                         .to_string(),
-                                ),
+                                )),
                             }))),
                             (None, None, Some(path)) => Ok(Some(RockSourceSpec::File(path))),
                             (_, _, Some(_)) => Err(de::Error::custom(format!(
@@ -1090,7 +1090,7 @@ mod tests {
     use url::Url;
 
     use crate::{
-        git::{url::RemoteGitUrl, GitSource},
+        git::{url::RemoteGitUrl, GitRef, GitSource},
         lua_rockspec::{PartialLuaRockspec, PerPlatform, RemoteLuaRockspec, RockSourceSpec},
         project::{Project, ProjectRoot, PROJECT_TOML},
         rockspec::{lua_dependency::LuaDependencySpec, Rockspec},
@@ -1608,6 +1608,31 @@ mod tests {
             .unwrap();
     }
 
+    #[test]
+    fn generate_git_source_with_branch() {
+        let rockspec_content = r#"
+            package = "test-package"
+            version = "1.0.0"
+            lua = ">=5.1"
+
+            [source]
+            url = "git+https://example.com/owner/repo.git"
+            branch = "main"
+
+            [build]
+            type = "builtin"
+        "#;
+
+        let toml = PartialProjectToml::new(PROJECT_TOML, rockspec_content, ProjectRoot::default())
+            .unwrap()
+            .into_remote(None)
+            .unwrap();
+
+        let lua = toml.to_lua_remote_rockspec_string().unwrap();
+        assert!(lua.contains("branch = \"main\""));
+        assert!(!lua.contains("tag = "));
+    }
+
     fn init_sample_project_repo(temp_dir: &assert_fs::TempDir) -> Repository {
         let sample_project = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources/test/sample-projects/source-template/");
@@ -1646,11 +1671,11 @@ mod tests {
         let source = remote_project_toml.source.current_platform();
         let source_spec = &source.source_spec;
         assert!(matches!(source_spec, &RockSourceSpec::Git { .. }));
-        if let RockSourceSpec::Git(GitSource { url, checkout_ref }) = source_spec {
+        if let RockSourceSpec::Git(GitSource { url, git_ref }) = source_spec {
             let expected_url: RemoteGitUrl =
                 "https://github.com/lumen-oss/lux.git".parse().unwrap();
             assert_eq!(url, &expected_url);
-            assert!(checkout_ref.is_some());
+            assert!(git_ref.is_some());
         }
         assert_eq!(source.unpack_dir, Some("lux-dev".into()));
     }
@@ -1666,11 +1691,11 @@ mod tests {
         let source = remote_project_toml.source.current_platform();
         let source_spec = &source.source_spec;
         assert!(matches!(source_spec, &RockSourceSpec::Git { .. }));
-        if let RockSourceSpec::Git(GitSource { url, checkout_ref }) = source_spec {
+        if let RockSourceSpec::Git(GitSource { url, git_ref }) = source_spec {
             let expected_url: RemoteGitUrl =
                 "https://github.com/lumen-oss/lux.git".parse().unwrap();
             assert_eq!(url, &expected_url);
-            assert_eq!(checkout_ref, &Some(tag_name.to_string()));
+            assert_eq!(git_ref, &Some(GitRef::Tag(tag_name.to_string())));
         }
         assert_eq!(source.unpack_dir, Some("lux-dev".into()));
     }

--- a/lux-lib/tests/install.rs
+++ b/lux-lib/tests/install.rs
@@ -3,7 +3,7 @@ use flaky_test::flaky_test;
 use itertools::Itertools;
 use lux_lib::{
     config::ConfigBuilder,
-    git::GitSource,
+    git::{GitRef, GitSource},
     lua_installation::detect_installed_lua_version,
     lua_rockspec::RockSourceSpec,
     lua_version::LuaVersion,
@@ -25,7 +25,7 @@ async fn install_git_package() {
                 url: "https://github.com/mrcjkb/rustaceanvim.git"
                     .parse()
                     .unwrap(),
-                checkout_ref: Some("v6.0.3".into()),
+                git_ref: Some(GitRef::Tag("v6.0.3".into())),
             }))
             .build();
     test_install(install_spec).await

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -19,7 +19,7 @@ use url::Url;
 use lux_lib::{
     build::BuildBehaviour,
     config::{tree::RockLayoutConfig, Config, ConfigBuilder},
-    git::GitSource,
+    git::{GitRef, GitSource},
     lockfile::{
         LocalPackage, LocalPackageHashes, LocalPackageId, LockConstraint, Lockfile, LockfileGuard,
         OptState, PinnedState, ReadOnly, ReadWrite,
@@ -1623,8 +1623,17 @@ impl Typed for GitSourceLua {
 impl TypedUserData for GitSourceLua {
     fn add_methods<M: TypedDataMethods<Self>>(methods: &mut M) {
         methods.add_method("url", |_, this, ()| Ok(this.0.url.to_string()));
-        methods.add_method("checkout_ref", |_, this, ()| {
-            Ok(this.0.checkout_ref.clone())
+        methods.add_method("tag", |_, this, ()| {
+            Ok(match &this.0.git_ref {
+                Some(GitRef::Tag(tag)) => Some(tag.clone()),
+                _ => None,
+            })
+        });
+        methods.add_method("branch", |_, this, ()| {
+            Ok(match &this.0.git_ref {
+                Some(GitRef::Branch(branch)) => Some(branch.clone()),
+                _ => None,
+            })
         });
     }
     fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {


### PR DESCRIPTION
Lux would incorrectly ignore `branch` declarations when generating lua rockspecs, instead favouring `tag = "revision"`. This PR makes it so that branch declarations prevent the autogenerated `tag` from appearing.