### PR TITLE
fix!(build/rust-binary): require `package`, not `binary` field

### DIFF
--- a/lux-lib/src/build/rust_binary.rs
+++ b/lux-lib/src/build/rust_binary.rs
@@ -71,32 +71,20 @@ impl BuildBackend for RustBinaryBuildSpec {
             .map(|vendor_dir| vendor_dir.join("cargo"))
             .filter(|dir| dir.is_dir());
 
-        // NOTE: `cargo install <crate>@<version>` installs from crates.io.
-        // When offline, the crates.io index is unavailable.
-        let crate_dir = if cargo_vendor_dir.is_some() {
-            let package = self
-                .package
-                .as_deref()
-                .unwrap_or_else(|| self.binary.split('@').next().unwrap_or(&self.binary));
-            Some(
-                find_cargo_package_dir(config, build_dir, package)
-                    .await?
-                    .to_slash_lossy()
-                    .to_string(),
-            )
+        let crate_dir = if let Some(package) = &self.package {
+            find_cargo_package_dir(config, build_dir, package)
+                .await?
+                .to_slash_lossy()
+                .to_string()
         } else {
-            None
+            format!("{}", build_dir.display())
         };
 
-        if let Some(crate_dir) = &crate_dir {
-            install_args.push("--path");
-            install_args.push(crate_dir);
-            install_args.push("--offline");
-        } else {
-            install_args.push(&self.binary);
-        }
+        install_args.push("--path");
+        install_args.push(&crate_dir);
 
         if let Some(cargo_vendor_dir) = &cargo_vendor_dir {
+            install_args.push("--offline");
             utils::prepare_cargo_vendor_config(config, build_dir, cargo_vendor_dir).await?;
         }
 

--- a/lux-lib/src/lua_rockspec/build/mod.rs
+++ b/lux-lib/src/lua_rockspec/build/mod.rs
@@ -71,8 +71,6 @@ pub enum BuildSpecInternalError {
     ModulesHaveListElements,
     #[error("no 'modules' specified for the 'rust-mlua' build backend")]
     NoModulesSpecified,
-    #[error("no 'binary' specified for the 'rust-binary' build backend")]
-    NoBinarySpecified,
     #[error("no 'lang' specified for 'treesitter-parser' build backend")]
     NoTreesitterParserLanguageSpecified,
     #[error("invalid 'rust-mlua' modules format")]
@@ -178,9 +176,6 @@ impl BuildSpec {
                     .collect(),
             })),
             BuildType::RustBinary => Some(BuildBackendSpec::RustBinary(RustBinaryBuildSpec {
-                binary: internal
-                    .binary
-                    .ok_or(BuildSpecInternalError::NoBinarySpecified)?,
                 package: internal.package,
                 features: internal.features.unwrap_or_default(),
             })),
@@ -760,7 +755,7 @@ impl BuildType {
             },
             &BuildType::RustBinary => unsafe {
                 Some(
-                    PackageReq::parse("luarocks-build-rust-binary >= 3.0.0")
+                    PackageReq::parse("luarocks-build-rust-binary >= 4.0.0")
                         .unwrap_unchecked()
                         .into(),
                 )

--- a/lux-lib/src/lua_rockspec/build/rust_binary.rs
+++ b/lux-lib/src/lua_rockspec/build/rust_binary.rs
@@ -1,11 +1,8 @@
 /// Specification for building a rock with the `rust-binary` build backend
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct RustBinaryBuildSpec {
-    /// The name of the binary (or crate) to install, optionally including
-    /// a version specifier (e.g. `foo@1.0.0`).
-    pub binary: String,
-    /// The cargo package to build, if it differs from `binary`.
-    /// Used to locate the package within the source directory.
+    /// The name of the crate to install binaries from.
+    /// Must be specified in multi-package workspaces.
     pub package: Option<String>,
     /// Cargo features to enable when building.
     pub features: Vec<String>,

--- a/lux-lib/src/lua_rockspec/mod.rs
+++ b/lux-lib/src/lua_rockspec/mod.rs
@@ -1682,7 +1682,7 @@ mod tests {
     }\n
     build = {\n
         type = 'rust-binary',\n
-        binary = 'foo@1.0.0',\n
+        package = 'foo',\n
         features = {'extra', 'features'},\n
     }\n
             ";
@@ -1690,7 +1690,7 @@ mod tests {
         let build_spec = rockspec.local.build.current_platform();
         if let Some(BuildBackendSpec::RustBinary(build_spec)) = build_spec.build_backend.to_owned()
         {
-            assert_eq!(build_spec.binary, "foo@1.0.0");
+            assert_eq!(build_spec.package, Some("foo".to_string()));
             assert_eq!(build_spec.features, vec!["extra", "features"]);
         } else {
             panic!("Expected RustBinary build backend");

--- a/lux-lua/src/lua_impls.rs
+++ b/lux-lua/src/lua_impls.rs
@@ -2131,7 +2131,7 @@ impl TypedUserData for RustBinaryBuildSpecLua {
         methods.document(
             r#"The name of the binary (or crate) to install, optionally including a version specifier (e.g. `foo@1.0.0`)."#,
         );
-        methods.add_method("binary", |_, this, ()| Ok(this.0.binary.clone()));
+        methods.add_method("package", |_, this, ()| Ok(this.0.package.clone()));
 
         methods.document("Cargo features to enable when building");
         methods.add_method("features", |_, this, ()| Ok(this.0.features.clone()));


### PR DESCRIPTION
Problem: `cargo install ... <package>@<version>` requires access to crates.io and ignores the rockspec/lux.toml source (and bypasses the integrity check). We shouldn't support it.

Solution: By specifying a `package`, we can search the cargo manifest for the package to build in the source tree.

This will also require an update to the luarocks build backend.

Depends on https://github.com/vhyrro/luarocks-build-rust-binary/pull/7, and a version 4.0.0 being released.