### PR TITLE
feat!: relocate `src/` directory on `--nvim`

### DIFF
--- a/lux-lib/src/config/tree.rs
+++ b/lux-lib/src/config/tree.rs
@@ -4,20 +4,25 @@ use std::path::PathBuf;
 /// Template configuration for a rock's tree layout
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct RockLayoutConfig {
-    /// The root of a packages `etc` directory.
-    /// If unset (the default), the root is the package root.
+    /// The root for relocated directories (etc, src).
+    /// If unset (the default), directories are placed in the package directory.
     /// If set, it is a directory relative to the given Lua version's install tree root.
     /// With the `--nvim` preset, this is `site/pack/lux`.
-    pub(crate) etc_root: Option<PathBuf>,
+    #[serde(alias = "etc_root")]
+    pub(crate) root: Option<PathBuf>,
     /// The `etc` directory for non-optional packages
     /// Default: `etc` With the `--nvim` preset, this is `start`
-    /// Note: If `etc_root` is set, the package ID is appended.
+    /// Note: If `root` is set, the package ID is appended.
     pub(crate) etc: PathBuf,
     /// The `etc` directory for optional packages
     /// Default: `etc`
     /// With the `--nvim` preset, this is `opt`
-    /// Note: If `etc_root` is set, the package ID is appended.
+    /// Note: If `root` is set, the package ID is appended.
     pub(crate) opt_etc: PathBuf,
+    /// The `src` directory name
+    /// Default: `src`
+    /// With the `--nvim` preset, this is `lua`
+    pub(crate) src: PathBuf,
     /// The `conf` directory name
     /// Default: `conf`
     pub(crate) conf: PathBuf,
@@ -28,14 +33,16 @@ pub struct RockLayoutConfig {
 
 impl RockLayoutConfig {
     /// Creates a `RockLayoutConfig` for use with Neovim
-    /// - `etc_root`: `site/pack/lux`
+    /// - `root`: `site/pack/lux`
     /// - `etc`: `start`
     /// - `opt_etc`: `opt`
+    /// - `src`: `lua`
     pub fn new_nvim_layout() -> Self {
         Self {
-            etc_root: Some("site/pack/lux".into()),
+            root: Some("site/pack/lux".into()),
             etc: "start".into(),
             opt_etc: "opt".into(),
+            src: "lua".into(),
             conf: "conf".into(),
             doc: "doc".into(),
         }
@@ -49,9 +56,10 @@ impl RockLayoutConfig {
 impl Default for RockLayoutConfig {
     fn default() -> Self {
         Self {
-            etc_root: None,
+            root: None,
             etc: "etc".into(),
             opt_etc: "etc".into(),
+            src: "src".into(),
             conf: "conf".into(),
             doc: "doc".into(),
         }

--- a/lux-lib/src/config/tree.rs
+++ b/lux-lib/src/config/tree.rs
@@ -23,6 +23,9 @@ pub struct RockLayoutConfig {
     /// Default: `src`
     /// With the `--nvim` preset, this is `lua`
     pub(crate) src: PathBuf,
+    /// The `lib` directory name
+    /// Default: `lib`
+    pub(crate) lib: PathBuf,
     /// The `conf` directory name
     /// Default: `conf`
     pub(crate) conf: PathBuf,
@@ -37,12 +40,14 @@ impl RockLayoutConfig {
     /// - `etc`: `start`
     /// - `opt_etc`: `opt`
     /// - `src`: `lua`
+    /// - `lib`: `lib`
     pub fn new_nvim_layout() -> Self {
         Self {
             root: Some("site/pack/lux".into()),
             etc: "start".into(),
             opt_etc: "opt".into(),
             src: "lua".into(),
+            lib: "lib".into(),
             conf: "conf".into(),
             doc: "doc".into(),
         }
@@ -60,6 +65,7 @@ impl Default for RockLayoutConfig {
             etc: "etc".into(),
             opt_etc: "etc".into(),
             src: "src".into(),
+            lib: "lib".into(),
             conf: "conf".into(),
             doc: "doc".into(),
         }

--- a/lux-lib/src/config/tree.rs
+++ b/lux-lib/src/config/tree.rs
@@ -9,29 +9,29 @@ pub struct RockLayoutConfig {
     /// If set, it is a directory relative to the given Lua version's install tree root.
     /// With the `--nvim` preset, this is `site/pack/lux`.
     #[serde(alias = "etc_root")]
-    pub(crate) root: Option<PathBuf>,
+    pub root: Option<PathBuf>,
     /// The `etc` directory for non-optional packages
     /// Default: `etc` With the `--nvim` preset, this is `start`
     /// Note: If `root` is set, the package ID is appended.
-    pub(crate) etc: PathBuf,
+    pub etc: PathBuf,
     /// The `etc` directory for optional packages
     /// Default: `etc`
     /// With the `--nvim` preset, this is `opt`
     /// Note: If `root` is set, the package ID is appended.
-    pub(crate) opt_etc: PathBuf,
+    pub opt_etc: PathBuf,
     /// The `src` directory name
     /// Default: `src`
     /// With the `--nvim` preset, this is `lua`
-    pub(crate) src: PathBuf,
+    pub src: PathBuf,
     /// The `lib` directory name
     /// Default: `lib`
-    pub(crate) lib: PathBuf,
+    pub lib: PathBuf,
     /// The `conf` directory name
     /// Default: `conf`
-    pub(crate) conf: PathBuf,
+    pub conf: PathBuf,
     /// The `doc` directory name
     /// Default: `doc`
-    pub(crate) doc: PathBuf,
+    pub doc: PathBuf,
 }
 
 impl RockLayoutConfig {

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -891,6 +891,10 @@ impl<P: LockfilePermissions> Lockfile<P> {
         self.lock.get(id)
     }
 
+    pub fn entrypoint_layout(&self) -> &RockLayoutConfig {
+        &self.entrypoint_layout
+    }
+
     /// Unsafe because this assumes a prior check if the package is present
     ///
     /// # Safety

--- a/lux-lib/src/tree/dist.rs
+++ b/lux-lib/src/tree/dist.rs
@@ -12,9 +12,6 @@ use crate::{
 use miette::{Diagnostic, Result};
 use thiserror::Error;
 
-const SRC_DIR_NAME: &str = "lua";
-const LIB_DIR_NAME: &str = "lib";
-
 #[derive(Error, Debug, Diagnostic)]
 #[non_exhaustive]
 #[error(
@@ -110,9 +107,9 @@ impl InstallTree for FlatDistTree {
     fn entrypoint(&self, package: &LocalPackage) -> io::Result<RockLayout> {
         self.guard_no_conflicting_package(package)?;
         Ok(mk_rock_layout(
-            SRC_DIR_NAME,
-            LIB_DIR_NAME,
-            self,
+            &self.root(),
+            &self.bin(),
+            &self.root_for(package),
             package,
             &self.0.entrypoint_layout,
         ))
@@ -121,9 +118,9 @@ impl InstallTree for FlatDistTree {
     fn dependency(&self, package: &LocalPackage) -> io::Result<RockLayout> {
         self.guard_no_conflicting_package(package)?;
         Ok(mk_rock_layout(
-            SRC_DIR_NAME,
-            LIB_DIR_NAME,
-            self,
+            &self.root(),
+            &self.bin(),
+            &self.root_for(package),
             package,
             &RockLayoutConfig::default(),
         ))
@@ -153,9 +150,9 @@ impl InstallTree for FlatDistTree {
             RockLayoutConfig::default()
         };
         Ok(mk_rock_layout(
-            SRC_DIR_NAME,
-            LIB_DIR_NAME,
-            self,
+            &self.root(),
+            &self.bin(),
+            &self.root_for(package),
             package,
             &layout_config,
         ))

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -258,6 +258,7 @@ impl InstallTree for Tree {
 
     fn entrypoint(&self, package: &LocalPackage) -> io::Result<RockLayout> {
         let rock_layout = self.entrypoint_layout(package);
+        fs::sync::create_dir_all(&rock_layout.rock_path).map_err(io::Error::other)?;
         fs::sync::create_dir_all(&rock_layout.lib).map_err(io::Error::other)?;
         fs::sync::create_dir_all(&rock_layout.src).map_err(io::Error::other)?;
         Ok(rock_layout)
@@ -265,6 +266,7 @@ impl InstallTree for Tree {
 
     fn dependency(&self, package: &LocalPackage) -> io::Result<RockLayout> {
         let rock_layout = self.dependency_layout(package);
+        fs::sync::create_dir_all(&rock_layout.rock_path).map_err(io::Error::other)?;
         fs::sync::create_dir_all(&rock_layout.lib).map_err(io::Error::other)?;
         fs::sync::create_dir_all(&rock_layout.src).map_err(io::Error::other)?;
         Ok(rock_layout)

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -7,7 +7,11 @@ use crate::{
     package::{PackageName, PackageReq},
     variables::{GetVariableError, HasVariables},
 };
-use std::{collections::HashMap, io, path::PathBuf};
+use std::{
+    collections::HashMap,
+    io,
+    path::{Path, PathBuf},
+};
 
 use itertools::Itertools;
 use miette::Diagnostic;
@@ -222,12 +226,24 @@ impl Tree {
 
     /// Create a [`RockLayout`] for an entrypoint
     pub(crate) fn entrypoint_layout(&self, package: &LocalPackage) -> RockLayout {
-        mk_rock_layout("src", "lib", self, package, &self.entrypoint_layout)
+        mk_rock_layout(
+            &self.root(),
+            &self.bin(),
+            &self.root_for(package),
+            package,
+            &self.entrypoint_layout,
+        )
     }
 
     /// Create a [`RockLayout`] for a dependency
     fn dependency_layout(&self, package: &LocalPackage) -> RockLayout {
-        mk_rock_layout("src", "lib", self, package, &RockLayoutConfig::default())
+        mk_rock_layout(
+            &self.root(),
+            &self.bin(),
+            &self.root_for(package),
+            package,
+            &RockLayoutConfig::default(),
+        )
     }
 }
 
@@ -362,17 +378,15 @@ impl RockMatches {
 }
 
 /// Create a [`RockLayout`] for a package.
-fn mk_rock_layout(
-    src_dir_name: &str,
-    lib_dir_name: &str,
-    tree: &impl InstallTree,
+pub fn mk_rock_layout(
+    tree_root: &Path,
+    bin: &Path,
+    rock_path: &Path,
     package: &LocalPackage,
     layout_config: &RockLayoutConfig,
 ) -> RockLayout {
-    let rock_path = tree.root_for(package);
-    let bin = tree.bin();
     let (etc, lib, src) = if let Some(ref root) = layout_config.root {
-        let base = tree.root().join(root);
+        let base = tree_root.join(root);
 
         let etc = match package.spec.opt {
             OptState::Required => base.join(&layout_config.etc),
@@ -386,8 +400,8 @@ fn mk_rock_layout(
         (etc, lib, src)
     } else {
         let etc = rock_path.join(&layout_config.etc);
-        let lib = rock_path.join(lib_dir_name);
-        let src = rock_path.join(src_dir_name);
+        let lib = rock_path.join(&layout_config.lib);
+        let src = rock_path.join(&layout_config.src);
 
         (etc, lib, src)
     };
@@ -395,11 +409,11 @@ fn mk_rock_layout(
     let doc = etc.join(&layout_config.doc);
 
     RockLayout {
-        rock_path,
+        rock_path: rock_path.to_path_buf(),
         etc,
         lib,
         src,
-        bin,
+        bin: bin.to_path_buf(),
         conf,
         doc,
     }

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -371,22 +371,25 @@ fn mk_rock_layout(
 ) -> RockLayout {
     let rock_path = tree.root_for(package);
     let bin = tree.bin();
-    let root = match layout_config.root {
-        Some(ref root) => tree.root().join(root),
-        None => rock_path.clone(),
-    };
-    let mut etc = match package.spec.opt {
-        OptState::Required => root.join(&layout_config.etc),
-        OptState::Optional => root.join(&layout_config.opt_etc),
-    };
-    if layout_config.root.is_some() {
-        etc = etc.join(format!("{}", package.name()));
-    }
-    let lib = rock_path.join(lib_dir_name);
-    let src = if layout_config.root.is_some() {
-        etc.join(&layout_config.src)
+    let (etc, lib, src) = if let Some(ref root) = layout_config.root {
+        let base = tree.root().join(root);
+
+        let etc = match package.spec.opt {
+            OptState::Required => base.join(&layout_config.etc),
+            OptState::Optional => base.join(&layout_config.opt_etc),
+        }
+        .join(format!("{}", package.name()));
+
+        let lib = etc.join(&layout_config.lib);
+        let src = etc.join(&layout_config.src);
+
+        (etc, lib, src)
     } else {
-        rock_path.join(src_dir_name)
+        let etc = rock_path.join(&layout_config.etc);
+        let lib = rock_path.join(lib_dir_name);
+        let src = rock_path.join(src_dir_name);
+
+        (etc, lib, src)
     };
     let conf = etc.join(&layout_config.conf);
     let doc = etc.join(&layout_config.doc);
@@ -580,7 +583,7 @@ mod tests {
                 bin: tree_path.join("5.1/bin"),
                 rock_path: tree_path.join(format!("5.1/{id}-neorg@8.0.0-1")),
                 etc: tree_path.join("5.1/site/pack/lux/start/neorg"),
-                lib: tree_path.join(format!("5.1/{id}-neorg@8.0.0-1/lib")),
+                lib: tree_path.join("5.1/site/pack/lux/start/neorg/lib"),
                 src: tree_path.join("5.1/site/pack/lux/start/neorg/lua"),
                 conf: tree_path.join("5.1/site/pack/lux/start/neorg/conf"),
                 doc: tree_path.join("5.1/site/pack/lux/start/neorg/doc"),

--- a/lux-lib/src/tree/mod.rs
+++ b/lux-lib/src/tree/mod.rs
@@ -371,19 +371,23 @@ fn mk_rock_layout(
 ) -> RockLayout {
     let rock_path = tree.root_for(package);
     let bin = tree.bin();
-    let etc_root = match layout_config.etc_root {
-        Some(ref etc_root) => tree.root().join(etc_root),
+    let root = match layout_config.root {
+        Some(ref root) => tree.root().join(root),
         None => rock_path.clone(),
     };
     let mut etc = match package.spec.opt {
-        OptState::Required => etc_root.join(&layout_config.etc),
-        OptState::Optional => etc_root.join(&layout_config.opt_etc),
+        OptState::Required => root.join(&layout_config.etc),
+        OptState::Optional => root.join(&layout_config.opt_etc),
     };
-    if layout_config.etc_root.is_some() {
+    if layout_config.root.is_some() {
         etc = etc.join(format!("{}", package.name()));
     }
     let lib = rock_path.join(lib_dir_name);
-    let src = rock_path.join(src_dir_name);
+    let src = if layout_config.root.is_some() {
+        etc.join(&layout_config.src)
+    } else {
+        rock_path.join(src_dir_name)
+    };
     let conf = etc.join(&layout_config.conf);
     let doc = etc.join(&layout_config.doc);
 
@@ -407,7 +411,7 @@ mod tests {
     use insta::assert_yaml_snapshot;
 
     use crate::{
-        config::ConfigBuilder,
+        config::{tree::RockLayoutConfig, ConfigBuilder},
         lockfile::{LocalPackage, LocalPackageHashes, LockConstraint},
         lua_version::LuaVersion,
         package::{PackageName, PackageSpec, PackageVersion},
@@ -528,6 +532,60 @@ mod tests {
             .collect_vec();
 
         assert_yaml_snapshot!(sorted_result)
+    }
+
+    #[test]
+    fn rock_layout_nvim() {
+        let tree_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test/sample-tree");
+
+        let temp = assert_fs::TempDir::new().unwrap();
+        temp.copy_from(&tree_path, &["**"]).unwrap();
+
+        let tree_path = temp.to_path_buf();
+
+        let config = ConfigBuilder::new()
+            .unwrap()
+            .user_tree(Some(tree_path.clone()))
+            .entrypoint_layout(RockLayoutConfig::new_nvim_layout())
+            .build()
+            .unwrap();
+
+        let tree = config.user_tree(LuaVersion::Lua51).unwrap();
+
+        let mock_hashes = LocalPackageHashes {
+            rockspec: "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek="
+                .parse()
+                .unwrap(),
+            source: "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek="
+                .parse()
+                .unwrap(),
+        };
+
+        let package = LocalPackage::from(
+            &PackageSpec::parse("neorg".into(), "8.0.0-1".into()).unwrap(),
+            LockConstraint::Unconstrained,
+            RockBinaries::default(),
+            RemotePackageSource::Test,
+            None,
+            mock_hashes,
+        );
+
+        let id = package.id();
+        let neorg = tree.entrypoint(&package).unwrap();
+
+        assert_eq!(
+            neorg,
+            RockLayout {
+                bin: tree_path.join("5.1/bin"),
+                rock_path: tree_path.join(format!("5.1/{id}-neorg@8.0.0-1")),
+                etc: tree_path.join("5.1/site/pack/lux/start/neorg"),
+                lib: tree_path.join(format!("5.1/{id}-neorg@8.0.0-1/lib")),
+                src: tree_path.join("5.1/site/pack/lux/start/neorg/lua"),
+                conf: tree_path.join("5.1/site/pack/lux/start/neorg/conf"),
+                doc: tree_path.join("5.1/site/pack/lux/start/neorg/doc"),
+            }
+        );
     }
 
     #[test]

--- a/lux-lua/src/loader.rs
+++ b/lux-lua/src/loader.rs
@@ -5,7 +5,11 @@ use std::{
     rc::Rc,
 };
 
-use lux_lib::lockfile::{LocalPackageId, Lockfile, ReadOnly};
+use lux_lib::{
+    config::tree::RockLayoutConfig,
+    lockfile::{LocalPackage, LocalPackageId, Lockfile, ReadOnly},
+    tree::{mk_rock_layout, RockLayout},
+};
 use mlua::prelude::*;
 use path_absolutize::Absolutize;
 
@@ -31,7 +35,35 @@ fn current_file(lua: &Lua) -> Option<String> {
     })?
 }
 
-fn load_file(lua: &Lua, module: &str, path: &Path) -> mlua::Result<Option<mlua::Function>> {
+fn rock_layout(
+    tree_root: &Path,
+    package_id: &LocalPackageId,
+    package: &LocalPackage,
+    lockfile: &Lockfile<ReadOnly>,
+) -> RockLayout {
+    let config = if lockfile.is_entrypoint(package_id) {
+        lockfile.entrypoint_layout()
+    } else {
+        &RockLayoutConfig::default()
+    };
+
+    let rock_path = tree_root.join(format!(
+        "{}-{}@{}",
+        package_id,
+        package.name(),
+        package.version()
+    ));
+
+    mk_rock_layout(
+        tree_root,
+        &tree_root.join("bin"),
+        &rock_path,
+        package,
+        config,
+    )
+}
+
+fn load_file(lua: &Lua, module: &str, layout: &RockLayout) -> mlua::Result<Option<mlua::Function>> {
     let module_path = module.replace('.', std::path::MAIN_SEPARATOR_STR);
 
     #[cfg(not(target_env = "msvc"))]
@@ -40,10 +72,10 @@ fn load_file(lua: &Lua, module: &str, path: &Path) -> mlua::Result<Option<mlua::
     #[cfg(target_env = "msvc")]
     let c_dylib_extension = "dll";
 
-    let src_lua = path.join("src").join(format!("{module_path}.lua"));
-    let src_init = path.join("src").join(&module_path).join("init.lua");
-    let lib = path
-        .join("lib")
+    let src_lua = layout.src.join(format!("{module_path}.lua"));
+    let src_init = layout.src.join(&module_path).join("init.lua");
+    let lib = layout
+        .lib
         .join(format!("{module_path}.{c_dylib_extension}"));
 
     if let Some(file) = [src_lua, src_init].into_iter().find(|file| file.exists()) {
@@ -193,16 +225,16 @@ fn load_from_workspace_tree(
         return Ok(None);
     };
 
-    let path = tree_root.join(format!("{dep_id}-{}@{}", dep.name(), dep.version()));
-    load_file(lua, module, &path)
+    let layout = rock_layout(tree_root, dep_id, dep, &lockfile);
+    load_file(lua, module, &layout)
 }
 
 fn load_from_installed_tree(lua: &Lua, module: &str) -> mlua::Result<Option<mlua::Function>> {
     for tree_root in find_trees_from_package_path(lua)?.iter() {
         if let Some(lockfile) = cached_lockfile(tree_root) {
             for (id, package) in lockfile.rocks() {
-                let path = tree_root.join(format!("{id}-{}@{}", package.name(), package.version()));
-                if let Some(loader) = load_file(lua, module, &path)? {
+                let layout = rock_layout(tree_root, id, package, &lockfile);
+                if let Some(loader) = load_file(lua, module, &layout)? {
                     return Ok(Some(loader));
                 }
             }
@@ -522,6 +554,78 @@ mod tests {
             .unwrap();
         let foo_loaded: String = lua.globals().get("foo_loaded").unwrap();
         assert_eq!(foo_loaded, "yes");
+    }
+
+    #[test]
+    fn test_load_from_nvim_layout() {
+        let tree = TempDir::new().unwrap();
+        let nvim_lockfile = format!(
+            r#"{{
+  "version": "1.0.0",
+  "rocks": {{
+    "{FOO_HASH}": {{
+      "name": "foo",
+      "version": "1.0.0-1",
+      "pinned": false,
+      "opt": false,
+      "dependencies": [],
+      "constraint": null,
+      "binaries": [],
+      "source": "local",
+      "hashes": {{
+        "rockspec": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "source": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }}
+    }}
+  }},
+  "entrypoints": ["{FOO_HASH}"],
+  "root": "site/pack/lux",
+  "etc": "start",
+  "opt_etc": "opt",
+  "src": "lua",
+  "lib": "lib",
+  "conf": "conf",
+  "doc": "doc"
+}}"#
+        );
+
+        tree.child("5.1")
+            .child("lux.lock")
+            .write_str(&nvim_lockfile)
+            .unwrap();
+
+        tree.child("5.1")
+            .child("site")
+            .child("pack")
+            .child("lux")
+            .child("start")
+            .child("foo")
+            .child("lua")
+            .child("foo.lua")
+            .write_str("_G.foo_loaded = 'nvim'\n")
+            .unwrap();
+
+        let lua = Lua::new();
+        load_loader(&lua).unwrap();
+        let src_dir = tree
+            .path()
+            .join("5.1")
+            .join("site")
+            .join("pack")
+            .join("lux")
+            .join("start")
+            .join("foo")
+            .join("lua");
+
+        lua.globals()
+            .get::<mlua::Table>("package")
+            .unwrap()
+            .set("path", format!("{}/?.lua", src_dir.display()))
+            .unwrap();
+
+        lua.load("require('foo')").exec().unwrap();
+        let foo_loaded: String = lua.globals().get("foo_loaded").unwrap();
+        assert_eq!(foo_loaded, "nvim");
     }
 
     #[test]


### PR DESCRIPTION
Fixes code loading problems in `lux.nvim`. Would we consider this breaking? I've maintained backwards compatibility with the old lockfile format with a serde alias.