### PR TITLE
perf: exclude vcs-ignored files when hashing & copying sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3576,6 +3576,7 @@ dependencies = [
  "auth-git2",
  "bon",
  "bytes",
+ "camino",
  "cc",
  "chumsky",
  "clap 4.6.4",

--- a/lux-lib/Cargo.toml
+++ b/lux-lib/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 async-recursion = "1.1"
 bon = { version = "3.9", features = ["implied-bounds"] }
 bytes = "1.11"
+camino = "1.1"
 cc = { version = "1.2", features = ["parallel"] }
 chumsky = "0.13"
 clap = { version = "4.6", features = ["derive"], optional = true }

--- a/lux-lib/src/fs/tokio.rs
+++ b/lux-lib/src/fs/tokio.rs
@@ -1,10 +1,8 @@
 use super::FsError;
 #[cfg(unix)]
 use std::fs::Permissions;
-use std::io;
 use std::path::Path;
 use tokio::fs;
-use walkdir::WalkDir;
 
 /// Wrapped [`fs::read`].
 pub(crate) async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>, FsError> {
@@ -49,39 +47,6 @@ pub(crate) async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result
         to: to.to_path_buf(),
         source,
     })
-}
-
-/// Recursively copies the contents of `src` into `dest`, including hidden files,
-/// but skipping VCS directories such as `.git`.
-pub(crate) async fn copy_dir_contents(
-    src: impl AsRef<Path>,
-    dest: impl AsRef<Path>,
-) -> Result<(), FsError> {
-    let src = src.as_ref();
-    let dest = dest.as_ref();
-    for path in WalkDir::new(src)
-        .into_iter()
-        .filter_entry(|entry| {
-            !matches!(
-                entry.file_name().to_string_lossy().to_string().as_str(),
-                ".git" | ".jj" | ".hg" | "_darcs" | ".svn" | ".bzr"
-            )
-        })
-        .filter_map(Result::ok)
-        .filter_map(|entry| entry.file_type().is_file().then(|| entry.into_path()))
-    {
-        let relative = path.strip_prefix(src).map_err(|source| FsError::Copy {
-            from: path.to_path_buf(),
-            to: dest.to_path_buf(),
-            source: io::Error::other(source),
-        })?;
-        let target = dest.join(relative);
-        if let Some(parent) = target.parent() {
-            create_dir_all(parent).await?;
-        }
-        copy(&path, &target).await?;
-    }
-    Ok(())
 }
 
 /// Wrapped [`fs::create_dir_all`].

--- a/lux-lib/src/hash.rs
+++ b/lux-lib/src/hash.rs
@@ -1,5 +1,7 @@
 use bytes::Bytes;
-use nix_nar::Encoder;
+use camino::Utf8Path;
+use ignore::gitignore::Gitignore;
+use nix_nar::{Encoder, FileSystem, FileSystemMetadata, NativeFileSystem};
 use ssri::{Algorithm, Integrity, IntegrityOpts};
 use std::fs::File;
 use std::future::Future;
@@ -13,13 +15,17 @@ pub trait HasIntegrity {
 impl HasIntegrity for PathBuf {
     #[tracing::instrument(level = "trace", skip_all)]
     async fn hash(&self) -> io::Result<Integrity> {
-        let path = self.clone();
+        // Canonicalising ensures a symlinked directory
+        // is hashed by its contents rather than as a symlink.
+        let path = std::fs::canonicalize(self)?;
         tokio::task::spawn_blocking(move || {
             let mut integrity_opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
             if path.is_dir() {
                 // NOTE: To ensure our source hashes are compatible with Nix,
                 // we encode the path to the Nix Archive (NAR) format.
-                let mut enc = Encoder::new(&path).map_err(io::Error::other)?;
+                let filesystem = VcsExcludingFileSystem::new(&path);
+                let mut enc =
+                    Encoder::new_with_filesystem(path, filesystem).map_err(io::Error::other)?;
                 io::copy(&mut enc, &mut integrity_opts)?;
             } else if path.is_file() {
                 hash_file(&path, &mut integrity_opts)?;
@@ -56,6 +62,58 @@ fn hash_file(path: &Path, integrity_opts: &mut IntegrityOpts) -> io::Result<()> 
     let mut file = File::open(path)?;
     io::copy(&mut file, integrity_opts)?;
     Ok(())
+}
+
+/// A [`FileSystem`] that excludes VCS directories (e.g. `.git`, `.jj`) and
+/// files ignored by the project's `.gitignore` from the encoded
+/// NAR, as their contents are not deterministic and are not part of a
+/// package's sources.
+struct VcsExcludingFileSystem {
+    gitignore: Gitignore,
+}
+
+impl VcsExcludingFileSystem {
+    fn new(root: &Path) -> Self {
+        let (gitignore, err) = Gitignore::new(root.join(".gitignore"));
+        if let Some(err) = err {
+            tracing::debug!(
+                message =
+                    format!("failed to parse `.gitignore` in {}: {err}", root.display()).as_str()
+            );
+        }
+        Self { gitignore }
+    }
+}
+
+fn is_vcs_dir(name: &str) -> bool {
+    matches!(name, ".git" | ".jj" | ".hg" | "_darcs" | ".svn" | ".bzr")
+}
+
+impl FileSystem for VcsExcludingFileSystem {
+    type File = std::fs::File;
+
+    fn open(&self, path: &Utf8Path) -> io::Result<Self::File> {
+        FileSystem::open(&NativeFileSystem {}, path)
+    }
+
+    fn read_dir(&self, path: &Utf8Path) -> io::Result<Vec<String>> {
+        Ok(FileSystem::read_dir(&NativeFileSystem {}, path)?
+            .into_iter()
+            .filter(|name| !is_vcs_dir(name))
+            .filter(|name| {
+                let full = path.join(name);
+                let is_dir = full.as_std_path().is_dir();
+                !self
+                    .gitignore
+                    .matched(full.as_std_path(), is_dir)
+                    .is_ignore()
+            })
+            .collect())
+    }
+
+    fn metadata(&self, path: &Utf8Path) -> io::Result<FileSystemMetadata> {
+        FileSystem::metadata(&NativeFileSystem {}, path)
+    }
 }
 
 #[cfg(test)]
@@ -187,6 +245,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_hash_ignores_vcs_directories() {
+        let temp = assert_fs::TempDir::new().unwrap();
+        write(temp.child("src.lua").path(), "return true").unwrap();
+        temp.child(".git").create_dir_all().unwrap();
+        write(temp.child(".git/config").path(), "nondeterministic").unwrap();
+        temp.child(".jj").create_dir_all().unwrap();
+        write(temp.child(".jj/repo").path(), "nondeterministic").unwrap();
+
+        let hash_with_vcs = temp.path().to_path_buf().hash().await.unwrap();
+
+        let temp2 = assert_fs::TempDir::new().unwrap();
+        write(temp2.child("src.lua").path(), "return true").unwrap();
+
+        let hash_without_vcs = temp2.path().to_path_buf().hash().await.unwrap();
+
+        assert_eq!(hash_with_vcs, hash_without_vcs);
+    }
+
+    #[tokio::test]
+    async fn test_hash_ignores_gitignored_but_not_other_ignored_files() {
+        let temp = assert_fs::TempDir::new().unwrap();
+        write(temp.child("src.lua").path(), "return true").unwrap();
+        temp.child(".gitignore").write_str(".foo/\n").unwrap();
+        temp.child(".ignore").write_str("target/\n").unwrap();
+        temp.child(".foo").create_dir_all().unwrap();
+        write(temp.child(".foo/env").path(), "bar").unwrap();
+        temp.child("target").create_dir_all().unwrap();
+        write(temp.child("target/build.o").path(), "blob").unwrap();
+
+        let filtered = temp.path().to_path_buf().hash().await.unwrap();
+
+        let expected_tree = assert_fs::TempDir::new().unwrap();
+        write(expected_tree.child("src.lua").path(), "return true").unwrap();
+        expected_tree
+            .child(".gitignore")
+            .write_str(".foo/\n")
+            .unwrap();
+        expected_tree
+            .child(".ignore")
+            .write_str("target/\n")
+            .unwrap();
+        expected_tree.child("target").create_dir_all().unwrap();
+        write(expected_tree.child("target/build.o").path(), "blob").unwrap();
+        let expected = expected_tree.path().to_path_buf().hash().await.unwrap();
+
+        assert_eq!(filtered, expected);
+    }
+
+    #[tokio::test]
+    async fn test_hash_matches_plain_nar_without_vcs_dirs() {
+        let temp = assert_fs::TempDir::new().unwrap();
+        write(temp.child("src.lua").path(), "return true").unwrap();
+        temp.child("lua").create_dir_all().unwrap();
+        write(temp.child("lua/foo.lua").path(), "return 1").unwrap();
+
+        let filtered = temp.path().to_path_buf().hash().await.unwrap();
+
+        let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
+        let mut enc = Encoder::new(temp.path()).unwrap();
+        io::copy(&mut enc, &mut opts).unwrap();
+        let plain = opts.result();
+
+        assert_eq!(filtered, plain);
+    }
+
+    #[tokio::test]
     async fn test_hash_with_symlinks() {
         let temp = assert_fs::TempDir::new().unwrap();
 
@@ -218,5 +342,21 @@ mod tests {
             let nix_hash = nix_hash(temp.path());
             assert_eq!(hash1, nix_hash);
         }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_hash_dereferences_symlinked_directory() {
+        let outer = assert_fs::TempDir::new().unwrap();
+        let real = assert_fs::TempDir::new().unwrap();
+        write(real.child("src.lua").path(), "return true").unwrap();
+
+        let link = outer.path().join("link");
+        std::os::unix::fs::symlink(real.path(), &link).unwrap();
+
+        let hash_via_link = link.hash().await.unwrap();
+        let hash_real = real.path().to_path_buf().hash().await.unwrap();
+
+        assert_eq!(hash_via_link, hash_real);
     }
 }

--- a/lux-lib/src/operations/fetch.rs
+++ b/lux-lib/src/operations/fetch.rs
@@ -1,3 +1,4 @@
+use crate::build::utils::recursive_copy_dir;
 use crate::config::Config;
 use crate::git::url::RemoteGitUrlParseError;
 use crate::git::{GitRef, GitSource};
@@ -325,7 +326,7 @@ async fn fetch_src_impl<R: Rockspec>(
             }
         }
         RockSourceSpec::Url(url) => {
-            tracing::debug!(message = format!("📥 Downloading {url}").as_str());
+            tracing::debug!(message = format!("Downloading {url}").as_str());
 
             // NOTE: We don't enforce HTTPS when fetching sources because some rockspecs
             // have HTTP URLs in `source.url`.
@@ -365,11 +366,12 @@ async fn fetch_src_impl<R: Rockspec>(
             }
         }
         RockSourceSpec::File(path) => {
-            tracing::debug!(message = format!("📋 Copying {}", path.display()).as_str());
+            tracing::debug!(message = format!("Copying {}", path.display()).as_str());
 
             let hash = if path.is_dir() {
-                fs::tokio::copy_dir_contents(path, dest_dir).await?;
-                dest_dir.hash().await.map_err(FetchSrcError::Hash)?
+                let hash = path.hash().await.map_err(FetchSrcError::Hash)?;
+                recursive_copy_dir(path, dest_dir).await?;
+                hash
             } else {
                 let mut file = fs::sync::open(path)?;
                 let mut buffer = Vec::new();


### PR DESCRIPTION
Fixes #1916.

Instead of copying everything except for `.git` and then hashing everything, we hash everything except for `.git` and `.gitignore`d files and then copy excluding ignore files.