### PR TITLE
fix(build-workspace)!: record deps as entrypoints in lockfile

### DIFF
--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -1250,17 +1250,6 @@ impl Lockfile<ReadWrite> {
         }
     }
 
-    pub(crate) fn remove_entrypoint(&mut self, rock: &LocalPackage) {
-        if let Some(index) = self
-            .lock
-            .entrypoints
-            .iter()
-            .position(|pkg_id| *pkg_id == rock.id())
-        {
-            self.lock.entrypoints.remove(index);
-        }
-    }
-
     fn add(&mut self, rock: &LocalPackage) {
         // Since rocks entries are mutable, we only add the dependency if it
         // has not already been added.

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -205,7 +205,6 @@ async fn build_project(
     lockfile.add_entrypoint(&package);
     for dep in dependencies {
         lockfile.add_dependency(&package, &dep);
-        lockfile.remove_entrypoint(&dep);
     }
     Ok(package)
 }


### PR DESCRIPTION
Problem: When building a workspace, we install dependencies as entrypoints, but we remove them from the entrypoints list in the workspace tree's lockfile. As a result, commands like `lx test` set up invalid `LUA_PATH` and `LUA_CPATH` entries for the affected dependencies when using a non-default layout like `--nvim`.

Solution: Don't remove dependencies from the lockfile's `entrypoints` list.