### PR TITLE
fix(sync)!: support transitive build dependencies

### DIFF
--- a/lux-cli/src/add.rs
+++ b/lux-cli/src/add.rs
@@ -10,8 +10,7 @@ use lux_lib::{
 use miette::Result;
 
 use crate::workspace::{
-    sync_build_dependencies_if_locked, sync_dependencies_if_locked,
-    sync_test_dependencies_if_locked, PackageReqOrGitShorthand,
+    sync_dependencies_if_locked, sync_test_dependencies_if_locked, PackageReqOrGitShorthand,
 };
 
 #[derive(clap::Args)]
@@ -113,11 +112,8 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
             .await?;
     }
 
-    if !data.package_req.is_empty() {
+    if !data.package_req.is_empty() || !build_packages.is_empty() {
         sync_dependencies_if_locked(&workspace, &config).await?;
-    }
-    if !build_packages.is_empty() {
-        sync_build_dependencies_if_locked(&workspace, &config).await?;
     }
     if !test_packages.is_empty() {
         sync_test_dependencies_if_locked(&workspace, &config).await?;

--- a/lux-cli/src/add.rs
+++ b/lux-cli/src/add.rs
@@ -9,9 +9,7 @@ use lux_lib::{
 
 use miette::Result;
 
-use crate::workspace::{
-    sync_dependencies_if_locked, sync_test_dependencies_if_locked, PackageReqOrGitShorthand,
-};
+use crate::workspace::{sync_dependencies_if_locked, PackageReqOrGitShorthand};
 
 #[derive(clap::Args)]
 pub struct Add {
@@ -112,12 +110,7 @@ pub async fn add(data: Add, config: Config) -> Result<()> {
             .await?;
     }
 
-    if !data.package_req.is_empty() || !build_packages.is_empty() {
-        sync_dependencies_if_locked(&workspace, &config).await?;
-    }
-    if !test_packages.is_empty() {
-        sync_test_dependencies_if_locked(&workspace, &config).await?;
-    }
+    sync_dependencies_if_locked(&workspace, &config).await?;
 
     Ok(())
 }

--- a/lux-cli/src/check.rs
+++ b/lux-cli/src/check.rs
@@ -10,7 +10,7 @@ use miette::{miette, Result};
 use crate::{
     args::OutputFormat,
     utils::path::{classify_path, PathTarget},
-    workspace::{sync_dependencies_if_locked, sync_test_dependencies_if_locked},
+    workspace::sync_dependencies_if_locked,
 };
 
 #[derive(Args)]
@@ -56,7 +56,6 @@ pub async fn check(args: Check, config: Config) -> Result<()> {
     let (workspace_dirs, rc_files) = match target {
         PathTarget::Workspace(workspace) => {
             sync_dependencies_if_locked(&workspace, &config).await?;
-            sync_test_dependencies_if_locked(&workspace, &config).await?;
 
             let dirs = workspace
                 .members()

--- a/lux-cli/src/pin.rs
+++ b/lux-cli/src/pin.rs
@@ -88,12 +88,6 @@ pub async fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState)
                     .await
                     .wrap_err("syncing dependencies with the project lockfile failed.")?;
             }
-            if !build_packages.is_empty() {
-                operations::Sync::new(&workspace, &config)
-                    .sync_build_dependencies()
-                    .await
-                    .wrap_err("syncing build dependencies with the project lockfile failed.")?;
-            }
             if !test_packages.is_empty() {
                 operations::Sync::new(&workspace, &config)
                     .sync_test_dependencies()

--- a/lux-cli/src/pin.rs
+++ b/lux-cli/src/pin.rs
@@ -82,18 +82,11 @@ pub async fn set_pinned_state(data: ChangePin, config: Config, pin: PinnedState)
                     )
                     .await?;
             }
-            if !packages.is_empty() {
-                operations::Sync::new(&workspace, &config)
-                    .sync_dependencies()
-                    .await
-                    .wrap_err("syncing dependencies with the project lockfile failed.")?;
-            }
-            if !test_packages.is_empty() {
-                operations::Sync::new(&workspace, &config)
-                    .sync_test_dependencies()
-                    .await
-                    .wrap_err("syncing test dependencies with the project lockfile failed.")?;
-            }
+            operations::Sync::new(&workspace, &config)
+                .test(!test_packages.is_empty())
+                .sync()
+                .await
+                .wrap_err("syncing dependencies with the workspace lockfile failed.")?;
         }
         None => {
             let tree = config.user_tree(LuaVersion::from(&config)?.clone())?;

--- a/lux-cli/src/remove.rs
+++ b/lux-cli/src/remove.rs
@@ -6,10 +6,7 @@ use lux_lib::{
 
 use miette::{IntoDiagnostic, Result};
 
-use crate::workspace::{
-    sync_build_dependencies_if_locked, sync_dependencies_if_locked,
-    sync_test_dependencies_if_locked,
-};
+use crate::workspace::{sync_dependencies_if_locked, sync_test_dependencies_if_locked};
 
 #[derive(Args)]
 pub struct Remove {
@@ -61,11 +58,8 @@ pub async fn remove(data: Remove, config: Config) -> Result<()> {
             .await?;
     }
 
-    if !data.depencencies.is_empty() {
+    if !data.depencencies.is_empty() || !build_packages.is_empty() {
         sync_dependencies_if_locked(&workspace, &config).await?;
-    }
-    if !build_packages.is_empty() {
-        sync_build_dependencies_if_locked(&workspace, &config).await?;
     }
     if !test_packages.is_empty() {
         sync_test_dependencies_if_locked(&workspace, &config).await?;

--- a/lux-cli/src/remove.rs
+++ b/lux-cli/src/remove.rs
@@ -6,7 +6,7 @@ use lux_lib::{
 
 use miette::{IntoDiagnostic, Result};
 
-use crate::workspace::{sync_dependencies_if_locked, sync_test_dependencies_if_locked};
+use crate::workspace::sync_dependencies_if_locked;
 
 #[derive(Args)]
 pub struct Remove {
@@ -58,11 +58,6 @@ pub async fn remove(data: Remove, config: Config) -> Result<()> {
             .await?;
     }
 
-    if !data.depencencies.is_empty() || !build_packages.is_empty() {
-        sync_dependencies_if_locked(&workspace, &config).await?;
-    }
-    if !test_packages.is_empty() {
-        sync_test_dependencies_if_locked(&workspace, &config).await?;
-    }
+    sync_dependencies_if_locked(&workspace, &config).await?;
     Ok(())
 }

--- a/lux-cli/src/sync.rs
+++ b/lux-cli/src/sync.rs
@@ -19,11 +19,6 @@ pub async fn sync(args: SyncProject, config: Config) -> Result<()> {
         .sync_dependencies()
         .await?;
 
-    let build_report = Sync::new(&workspace, &config)
-        .validate_integrity(false)
-        .sync_build_dependencies()
-        .await?;
-
     let test_report = Sync::new(&workspace, &config)
         .validate_integrity(false)
         .sync_test_dependencies()
@@ -32,14 +27,12 @@ pub async fn sync(args: SyncProject, config: Config) -> Result<()> {
     let added: Vec<&LocalPackage> = dep_report
         .added()
         .iter()
-        .chain(build_report.added().iter())
         .chain(test_report.added().iter())
         .collect();
 
     let removed: Vec<&LocalPackage> = dep_report
         .removed()
         .iter()
-        .chain(build_report.removed().iter())
         .chain(test_report.removed().iter())
         .collect();
 

--- a/lux-cli/src/sync.rs
+++ b/lux-cli/src/sync.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use lux_lib::{config::Config, lockfile::LocalPackage, operations::Sync, workspace::Workspace};
+use lux_lib::{config::Config, operations::Sync, workspace::Workspace};
 
 use miette::Result;
 
@@ -14,37 +14,21 @@ pub struct SyncProject {
 pub async fn sync(args: SyncProject, config: Config) -> Result<()> {
     let workspace = Workspace::current_or_err()?;
 
-    let dep_report = Sync::new(&workspace, &config)
+    let report = Sync::new(&workspace, &config)
         .validate_integrity(!args.no_integrity_check)
-        .sync_dependencies()
+        .test(true)
+        .sync()
         .await?;
 
-    let test_report = Sync::new(&workspace, &config)
-        .validate_integrity(false)
-        .sync_test_dependencies()
-        .await?;
-
-    let added: Vec<&LocalPackage> = dep_report
-        .added()
-        .iter()
-        .chain(test_report.added().iter())
-        .collect();
-
-    let removed: Vec<&LocalPackage> = dep_report
-        .removed()
-        .iter()
-        .chain(test_report.removed().iter())
-        .collect();
-
-    if added.is_empty() && removed.is_empty() {
+    if report.added().is_empty() && report.removed().is_empty() {
         println!("Already in sync.");
         return Ok(());
     }
 
-    for pkg in added {
+    for pkg in report.added() {
         println!("+ {} {}", pkg.name(), pkg.version());
     }
-    for pkg in removed {
+    for pkg in report.removed() {
         println!("- {} {}", pkg.name(), pkg.version());
     }
 

--- a/lux-cli/src/workspace.rs
+++ b/lux-cli/src/workspace.rs
@@ -80,13 +80,10 @@ pub async fn sync_dependencies_if_locked(workspace: &Workspace, config: &Config)
     // NOTE: We only update the lockfile if one exists.
     // Otherwise, the next `lx build` will remove the packages.
     Sync::new(workspace, config)
-        .sync_test_dependencies()
+        .test(true)
+        .sync()
         .await
-        .wrap_err("syncing test dependencies with the project lockfile failed.")?;
-    Sync::new(workspace, config)
-        .sync_dependencies()
-        .await
-        .wrap_err("syncing dependencies with the project lockfile failed.")?;
+        .wrap_err("syncing dependencies with the workspace lockfile failed.")?;
     Ok(())
 }
 

--- a/lux-cli/src/workspace.rs
+++ b/lux-cli/src/workspace.rs
@@ -80,20 +80,13 @@ pub async fn sync_dependencies_if_locked(workspace: &Workspace, config: &Config)
     // NOTE: We only update the lockfile if one exists.
     // Otherwise, the next `lx build` will remove the packages.
     Sync::new(workspace, config)
-        .sync_dependencies()
-        .await
-        .wrap_err("syncing dependencies with the project lockfile failed.")?;
-    Ok(())
-}
-
-pub async fn sync_test_dependencies_if_locked(
-    workspace: &Workspace,
-    config: &Config,
-) -> Result<()> {
-    Sync::new(workspace, config)
         .sync_test_dependencies()
         .await
         .wrap_err("syncing test dependencies with the project lockfile failed.")?;
+    Sync::new(workspace, config)
+        .sync_dependencies()
+        .await
+        .wrap_err("syncing dependencies with the project lockfile failed.")?;
     Ok(())
 }
 

--- a/lux-cli/src/workspace.rs
+++ b/lux-cli/src/workspace.rs
@@ -86,17 +86,6 @@ pub async fn sync_dependencies_if_locked(workspace: &Workspace, config: &Config)
     Ok(())
 }
 
-pub async fn sync_build_dependencies_if_locked(
-    workspace: &Workspace,
-    config: &Config,
-) -> Result<()> {
-    Sync::new(workspace, config)
-        .sync_build_dependencies()
-        .await
-        .wrap_err("syncing build dependencies with the project lockfile failed.")?;
-    Ok(())
-}
-
 pub async fn sync_test_dependencies_if_locked(
     workspace: &Workspace,
     config: &Config,

--- a/lux-lib/resources/test/lux.lock
+++ b/lux-lib/resources/test/lux.lock
@@ -5,11 +5,6 @@
       "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663": {
         "name": "say",
         "version": "1.4.1-3",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": null,
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -24,11 +19,7 @@
       "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536": {
         "name": "nvim-nio",
         "version": "1.7.0-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=1.7.0, <1.8.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -42,11 +33,7 @@
       "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696": {
         "name": "say",
         "version": "1.4.1-3",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=1.4.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -61,11 +48,7 @@
       "53e23ed902788b3579e6c96d44c45c308987012d4e87d00d1b4ba0da88ce29f6": {
         "name": "nui.nvim",
         "version": "0.3.0-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": "==0.3.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -80,11 +63,7 @@
       "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a": {
         "name": "pathlib.nvim",
         "version": "2.2.3-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=2.2.0, <2.3.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -98,11 +77,7 @@
       "9e1642247f9208a7e65e1e76461b2adc6f35fe644ce4cdf9f7fa6f5a12c8845e": {
         "name": "nvim-nio",
         "version": "1.10.1-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=1.8.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -116,13 +91,9 @@
       "acdfde00d122aac481c18c906d483478bb536741beb025becc11782a075d125b": {
         "name": "luassert",
         "version": "1.9.0-1",
-        "pinned": false,
-        "opt": false,
         "dependencies": [
           "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696"
         ],
-        "constraint": null,
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -137,9 +108,6 @@
       "b7fa2fc76ac7b515ab09c4982a9805528218639fda3b3a86a49825f3cf42bd0b": {
         "name": "lua-cjson",
         "version": "2.1.0-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": "==2.1.0",
         "binaries": [
           "json2lua",
@@ -158,11 +126,7 @@
       "c00abab54b42135a2957c647032e5487fc18e4171039d79dd48e7d9f84b5759e": {
         "name": "plenary.nvim",
         "version": "0.1.4-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": "==0.1.4",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -176,11 +140,7 @@
       "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8": {
         "name": "lua-utils.nvim",
         "version": "1.0.2-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": "==1.0.2",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -194,8 +154,6 @@
       "fdd927c4d96d1063ce66246cfd5ecb1939a8f8e8425f29428894b43586fb72cd": {
         "name": "neorg",
         "version": "8.8.1-1",
-        "pinned": false,
-        "opt": false,
         "dependencies": [
           "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536",
           "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8",
@@ -204,7 +162,6 @@
           "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a"
         ],
         "constraint": "==8.8.1",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",

--- a/lux-lib/resources/test/sample-projects/busted-with-lockfile/lux.lock
+++ b/lux-lib/resources/test/sample-projects/busted-with-lockfile/lux.lock
@@ -5,11 +5,7 @@
       "01a3c364614bddff7370223a5a9c4580f8e62d144384148444c518ec5367a59b": {
         "name": "mediator_lua",
         "version": "1.1.2-0",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=1.1.1",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -20,14 +16,24 @@
           "source": "sha256-+vWFn9IIG+Tp5PuIc6LcZffv8/2T1t0U2mX44SP8/5s="
         }
       },
+      "0c1551a18e14018d6694a82036fac28c807e983f9d357c5d5ad377328324cef3": {
+        "name": "dkjson",
+        "version": "2.11-1",
+        "constraint": ">=2.1.0",
+        "source": "luarocks_rockspec+https://luarocks.org/",
+        "source_url": {
+          "type": "url",
+          "url": "https://dkolf.de/dkjson-lua/dkjson-2.11.tar.gz"
+        },
+        "hashes": {
+          "rockspec": "sha256-UTm5B7j105MBx/C45QoJrB0Fo4YZhjZkwvdM0BzWbzo=",
+          "source": "sha256-ehaa9oG8O+c4ER845qgHd6MgOmAsECOv6u2q0vIu4pg="
+        }
+      },
       "287e827f4a088d41bba04af5f61a13614346c16fe8150eb7c4246e67d6fd163e": {
         "name": "lua-term",
         "version": "0.8-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=0.1",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "url",
@@ -38,37 +44,30 @@
           "source": "sha256-j/lPOQ6p2YxzRpk3PKOwzlANZRsqscuNfSM2/Ft5ze0="
         }
       },
-      "316ac0b30e04e86a253d64886f3b110bd0508267474e6b58a3b973bd6857dbf4": {
+      "2bd1c8e4fea66a88aeb65c1c8a3d0efdf188d681d2d47f163b976a771545aac9": {
         "name": "penlight",
-        "version": "1.14.0-3",
-        "pinned": false,
-        "opt": false,
+        "version": "1.15.0-1",
         "dependencies": [
-          "832fd9862ce671c0c9777855d4c8b19f9ad9c2679fb5466c3a183785a51b76b0"
+          "611b19eca413e8557258c177563402d31094cde79f82d340f5648d2ac8f3b8a1"
         ],
-        "constraint": ">=1.3.2",
-        "binaries": [],
+        "constraint": ">=1.15.0",
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
-          "type": "git",
-          "url": "https://github.com/lunarmodules/penlight.git",
-          "ref": "1.14.0"
+          "type": "url",
+          "url": "https://luarocks.org/penlight-1.15.0-1.src.rock"
         },
         "hashes": {
-          "rockspec": "sha256-8ckXDAqsbgL9zOIH3b4HOxasdAXGzBnr+bR6nkAHrOE=",
-          "source": "sha256-4zAt0GgQEkg9toaUaDn3ST3RvjLUDsuOzrKi9lhq0fQ="
+          "rockspec": "sha256-blt3sqlz+76U8RAtPtfvEqw4+VACI90TFHn+fTcQlVQ=",
+          "source": "sha256-uhOLi7yRb0Kttbh2xI0lQRT0FuiGeQL4w0/qJ4gUCXM="
         }
       },
       "455cd98d50c6191a9685cffcda4ce783efbb957934625e134c39f43bd5df6818": {
         "name": "luassert",
         "version": "1.9.0-1",
-        "pinned": false,
-        "opt": false,
         "dependencies": [
           "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696"
         ],
         "constraint": ">=1.9.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -83,11 +82,7 @@
       "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696": {
         "name": "say",
         "version": "1.4.1-3",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
         "constraint": ">=1.4.0",
-        "binaries": [],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -99,101 +94,17 @@
           "source": "sha256-IjNkK1leVtYgbEjUqguVMjbdW+0BHAOCE0pazrVuF50="
         }
       },
-      "56b98be57b1a97b869fd8ded0d2c0b9ce0b6b052e2d5abf84d060748617b2c90": {
-        "name": "busted",
-        "version": "2.2.0-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [
-          "a6c5176043cb3de56336b7de119443dbb3d9e024be1d50e06289ad4b4959a2da",
-          "6b6b31ff9421e8d0e092bce3f54ba8991132952efb5652f0cda52e3c5ad71d66",
-          "e4f17b9e67313bbd5e90f425672fc8998dd0bfa43335f7c57ed2de7a799e07a6",
-          "6ce29c2c535c40246c386c056f24689344cddb56ec397473931431e6b67694d2",
-          "455cd98d50c6191a9685cffcda4ce783efbb957934625e134c39f43bd5df6818",
-          "287e827f4a088d41bba04af5f61a13614346c16fe8150eb7c4246e67d6fd163e",
-          "316ac0b30e04e86a253d64886f3b110bd0508267474e6b58a3b973bd6857dbf4",
-          "01a3c364614bddff7370223a5a9c4580f8e62d144384148444c518ec5367a59b"
-        ],
-        "constraint": null,
-        "binaries": [
-          "busted"
-        ],
-        "source": "luarocks_rockspec+https://luarocks.org/",
-        "source_url": {
-          "type": "git",
-          "url": "https://github.com/lunarmodules/busted.git",
-          "ref": "v2.2.0"
-        },
-        "hashes": {
-          "rockspec": "sha256-zj6KqOotJVv+BaqYLin0yifoNTVWvg3oeByQyiiZn0A=",
-          "source": "sha256-5LxPqmoUwR3XaIToKUgap0L/sNS9uOV080MIenyLnl8="
-        }
-      },
-      "6b6b31ff9421e8d0e092bce3f54ba8991132952efb5652f0cda52e3c5ad71d66": {
-        "name": "luasystem",
-        "version": "0.6.2-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": ">=0.2.0",
-        "binaries": [],
-        "source": "luarocks_rockspec+https://luarocks.org/",
-        "source_url": {
-          "type": "git",
-          "url": "https://github.com/lunarmodules/luasystem.git",
-          "ref": "v0.6.2"
-        },
-        "hashes": {
-          "rockspec": "sha256-VQWPp4Ce7gQeuY4tocbfr9L58M8lrXQZMyX0MhRq22g=",
-          "source": "sha256-EcKs8W8UAbyA5WCt75tGO2osNgFbL8SNUl78vKSy82o="
-        }
-      },
-      "6ce29c2c535c40246c386c056f24689344cddb56ec397473931431e6b67694d2": {
-        "name": "say",
-        "version": "1.4.1-3",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": ">=1.4",
-        "binaries": [],
-        "source": "luarocks_rockspec+https://luarocks.org/",
-        "source_url": {
-          "type": "git",
-          "url": "https://github.com/lunarmodules/say.git",
-          "ref": "v1.4.1"
-        },
-        "hashes": {
-          "rockspec": "sha256-WFKt1iWeyjO9A8SG0KUX8tkS9JvMqoVM8CKBUguuK0Y=",
-          "source": "sha256-IjNkK1leVtYgbEjUqguVMjbdW+0BHAOCE0pazrVuF50="
-        }
-      },
-      "832fd9862ce671c0c9777855d4c8b19f9ad9c2679fb5466c3a183785a51b76b0": {
-        "name": "luafilesystem",
-        "version": "1.8.0-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": null,
-        "binaries": [],
-        "source": "luarocks_rockspec+https://luarocks.org/",
-        "source_url": {
-          "type": "git",
-          "url": "https://github.com/keplerproject/luafilesystem",
-          "ref": "v1_8_0"
-        },
-        "hashes": {
-          "rockspec": "sha256-ylWfvz35v68L9Sa92bQHDfFylaS7PEmZr62cBfRU06I=",
-          "source": "sha256-pEA+Z1pkykWLTT6NHQ5lo8roOh2P0fiHtnK+byTkF5o="
-        }
-      },
-      "a6c5176043cb3de56336b7de119443dbb3d9e024be1d50e06289ad4b4959a2da": {
+      "5abed54457baf9037ff989a1ec78172ee7483d87e794bc9175dbed61f08be72c": {
         "name": "lua_cliargs",
         "version": "3.0.2-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": "==3.0",
-        "binaries": [],
+        "constraint": ">=3.0",
+        "binaries": [
+          "watch-tests.sh",
+          "release",
+          "lint",
+          "docs",
+          "coverage"
+        ],
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
           "type": "git",
@@ -205,27 +116,81 @@
           "source": "sha256-wL3qBQ8Lu3q8DK2Kaeo1dgzIHd8evaxFYJg47CcQiSg="
         }
       },
-      "e4f17b9e67313bbd5e90f425672fc8998dd0bfa43335f7c57ed2de7a799e07a6": {
-        "name": "dkjson",
-        "version": "2.8-1",
-        "pinned": false,
-        "opt": false,
-        "dependencies": [],
-        "constraint": ">=2.1.0",
-        "binaries": [],
+      "611b19eca413e8557258c177563402d31094cde79f82d340f5648d2ac8f3b8a1": {
+        "name": "luafilesystem",
+        "version": "1.9.0-1",
         "source": "luarocks_rockspec+https://luarocks.org/",
         "source_url": {
-          "type": "url",
-          "url": "http://dkolf.de/dkjson-lua/dkjson-2.8.tar.gz"
+          "type": "git",
+          "url": "https://github.com/lunarmodules/luafilesystem",
+          "ref": "v1_9_0"
         },
         "hashes": {
-          "rockspec": "sha256-arasJeX7yQ2Rg70RyepiGNvLdiyQz8Wn4HXrdTEIBBg=",
-          "source": "sha256-JOjNO+uRwchh63uz+8m9QYu/+a1KpdBHGBYlgjajFTI="
+          "rockspec": "sha256-Mrv7QKI6EAY6jzMrh0VWAZIy5KAem82cDPtCIRji4ck=",
+          "source": "sha256-xoNJra/yqxRG11TePcUKrAUU6cwypGnXIoLKZXNaoW0="
+        }
+      },
+      "6ce29c2c535c40246c386c056f24689344cddb56ec397473931431e6b67694d2": {
+        "name": "say",
+        "version": "1.4.1-3",
+        "constraint": ">=1.4",
+        "source": "luarocks_rockspec+https://luarocks.org/",
+        "source_url": {
+          "type": "git",
+          "url": "https://github.com/lunarmodules/say.git",
+          "ref": "v1.4.1"
+        },
+        "hashes": {
+          "rockspec": "sha256-WFKt1iWeyjO9A8SG0KUX8tkS9JvMqoVM8CKBUguuK0Y=",
+          "source": "sha256-IjNkK1leVtYgbEjUqguVMjbdW+0BHAOCE0pazrVuF50="
+        }
+      },
+      "aa700d6a934caa749d578927c97e22211ffabf97234705d63e95dc6403f6aafe": {
+        "name": "busted",
+        "version": "2.3.0-1",
+        "dependencies": [
+          "5abed54457baf9037ff989a1ec78172ee7483d87e794bc9175dbed61f08be72c",
+          "fe607fc3a725b032acf5722632cf6993702c56ffa7c9f65e28f9d0324c17be34",
+          "0c1551a18e14018d6694a82036fac28c807e983f9d357c5d5ad377328324cef3",
+          "6ce29c2c535c40246c386c056f24689344cddb56ec397473931431e6b67694d2",
+          "455cd98d50c6191a9685cffcda4ce783efbb957934625e134c39f43bd5df6818",
+          "287e827f4a088d41bba04af5f61a13614346c16fe8150eb7c4246e67d6fd163e",
+          "2bd1c8e4fea66a88aeb65c1c8a3d0efdf188d681d2d47f163b976a771545aac9",
+          "01a3c364614bddff7370223a5a9c4580f8e62d144384148444c518ec5367a59b"
+        ],
+        "binaries": [
+          "busted",
+          "busted"
+        ],
+        "source": "luarocks_rockspec+https://luarocks.org/",
+        "source_url": {
+          "type": "git",
+          "url": "https://github.com/lunarmodules/busted.git",
+          "ref": "v2.3.0"
+        },
+        "hashes": {
+          "rockspec": "sha256-JCyIPhIqs8DLMRjnKaaLUFbeqcTc4yYMRd6BPMAMxLU=",
+          "source": "sha256-ZSfnbsDiaIo/abVpwb/LV5Ktp5wFSZQNO0OdbnjqVSs="
+        }
+      },
+      "fe607fc3a725b032acf5722632cf6993702c56ffa7c9f65e28f9d0324c17be34": {
+        "name": "luasystem",
+        "version": "0.7.1-1",
+        "constraint": ">=0.2.0",
+        "source": "luarocks_rockspec+https://luarocks.org/",
+        "source_url": {
+          "type": "git",
+          "url": "https://github.com/lunarmodules/luasystem.git",
+          "ref": "v0.7.1"
+        },
+        "hashes": {
+          "rockspec": "sha256-n3pn+G32Jo5bHKswt1MwPB9KCBKfCz3pNRBLP/9UFoI=",
+          "source": "sha256-HxOtwWyAYOxTQXm0KyJVvSNTxWOJnn4pnX0FFu4HYh4="
         }
       }
     },
     "entrypoints": [
-      "56b98be57b1a97b869fd8ded0d2c0b9ce0b6b052e2d5abf84d060748617b2c90"
+      "aa700d6a934caa749d578927c97e22211ffabf97234705d63e95dc6403f6aafe"
     ]
   }
 }

--- a/lux-lib/resources/test/sample-projects/lockfile-missing-deps/lux.lock
+++ b/lux-lib/resources/test/sample-projects/lockfile-missing-deps/lux.lock
@@ -4,13 +4,11 @@
     "04bfd5b08a74ba37c05241ef51d7afc47e1f3379c872dca34d99031b1ea7b855": {
       "name": "neorg",
       "version": "8.0.0-1",
-      "pinned": false,
       "dependencies": [
         "99930d308895ccd027772f32eb777cebdb8668c32f4602036e237f0a46fcc0d9",
         "985b1994517e6433d3e9ed05882a13069e7458f4646eabb451cc3964674c3c11"
       ],
       "constraint": "=8.0.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -24,10 +22,7 @@
     "085d597b2652e6dd9793a12fc57fca6d63575201113ba0bfe197f941264eb83f": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "dependencies": [],
       "constraint": ">=1.4.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -42,10 +37,7 @@
     "306b1bc37b09349a902e436efffb1161bbbdb46fafd5dc54b6e071ef5259b68a": {
       "name": "nvim-nio",
       "version": "1.10.1-1",
-      "pinned": false,
-      "dependencies": [],
       "constraint": ">=1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -59,12 +51,9 @@
     "735d981050a43b2a36eb5621968fee7e6962ac1f673c9244a18039bf28594316": {
       "name": "luassert",
       "version": "1.9.0-1",
-      "pinned": false,
       "dependencies": [
         "085d597b2652e6dd9793a12fc57fca6d63575201113ba0bfe197f941264eb83f"
       ],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -79,10 +68,7 @@
     "77a8e249ed3119392da5a9f20c88954cacf7ac6d2ccb7b78e037a218c6afc166": {
       "name": "nvim-nio",
       "version": "1.7.0-1",
-      "pinned": false,
-      "dependencies": [],
       "constraint": ">=1.7.0, <1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -96,10 +82,6 @@
     "985b1994517e6433d3e9ed05882a13069e7458f4646eabb451cc3964674c3c11": {
       "name": "lua-utils.nvim",
       "version": "1.0.2-1",
-      "pinned": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -113,10 +95,6 @@
     "99930d308895ccd027772f32eb777cebdb8668c32f4602036e237f0a46fcc0d9": {
       "name": "nvim-nio",
       "version": "1.10.1-1",
-      "pinned": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -130,12 +108,10 @@
     "aa8d78a5981bc7a1a0ab12216849259a68e41c4203d495051ab57c24074f63f8": {
       "name": "pathlib.nvim",
       "version": "2.2.3-1",
-      "pinned": false,
       "dependencies": [
         "306b1bc37b09349a902e436efffb1161bbbdb46fafd5dc54b6e071ef5259b68a"
       ],
       "constraint": ">=2.2.0, <2.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -149,10 +125,7 @@
     "b171325ee5f129f7561a01d258ba38164d141e7cfddbf3c740edb28dd848ca2f": {
       "name": "nui.nvim",
       "version": "0.3.0-1",
-      "pinned": false,
-      "dependencies": [],
       "constraint": "=0.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -167,12 +140,10 @@
     "b49da3f0e8cc9fd87681b92011f04fbe1d9acedcdb1bae652040e5c16d33be29": {
       "name": "plenary.nvim",
       "version": "0.1.4-1",
-      "pinned": false,
       "dependencies": [
         "735d981050a43b2a36eb5621968fee7e6962ac1f673c9244a18039bf28594316"
       ],
       "constraint": "=0.1.4",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -186,7 +157,6 @@
     "bf813f9f333f9efc8108b86386ea8a2a7aeaff1d5cdf470449d5e5242e3794d3": {
       "name": "neorg",
       "version": "8.8.1-1",
-      "pinned": false,
       "dependencies": [
         "77a8e249ed3119392da5a9f20c88954cacf7ac6d2ccb7b78e037a218c6afc166",
         "fb56666f3cfc66910e00c89bcfa81361660a0a4edfd528baadbedcd4ac89390a",
@@ -195,7 +165,6 @@
         "aa8d78a5981bc7a1a0ab12216849259a68e41c4203d495051ab57c24074f63f8"
       ],
       "constraint": "=8.8.1",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -209,9 +178,6 @@
     "e7c4c9fcd3cb6fe33c1c0a2ab8cdbbe8ee81d11334277d1f5631c80317770769": {
       "name": "lua-cjson",
       "version": "2.1.0-1",
-      "pinned": false,
-      "dependencies": [],
-      "constraint": null,
       "binaries": [
         "lua2json",
         "json2lua"
@@ -229,10 +195,6 @@
     "f98575efb520794ce8828bf0f5088047e745c27cd102cde14d4f6ad933efa00d": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -247,10 +209,7 @@
     "fb56666f3cfc66910e00c89bcfa81361660a0a4edfd528baadbedcd4ac89390a": {
       "name": "lua-utils.nvim",
       "version": "1.0.2-1",
-      "pinned": false,
-      "dependencies": [],
       "constraint": "=1.0.2",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",

--- a/lux-lib/resources/test/sample-tree/5.1/lux.lock
+++ b/lux-lib/resources/test/sample-tree/5.1/lux.lock
@@ -4,11 +4,6 @@
     "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -23,11 +18,7 @@
     "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536": {
       "name": "nvim-nio",
       "version": "1.7.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.7.0, <1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -41,11 +32,7 @@
     "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.4.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -60,11 +47,7 @@
     "53e23ed902788b3579e6c96d44c45c308987012d4e87d00d1b4ba0da88ce29f6": {
       "name": "nui.nvim",
       "version": "0.3.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==0.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -79,11 +62,7 @@
     "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a": {
       "name": "pathlib.nvim",
       "version": "2.2.3-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=2.2.0, <2.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -97,11 +76,7 @@
     "9e1642247f9208a7e65e1e76461b2adc6f35fe644ce4cdf9f7fa6f5a12c8845e": {
       "name": "nvim-nio",
       "version": "1.10.1-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -115,13 +90,9 @@
     "acdfde00d122aac481c18c906d483478bb536741beb025becc11782a075d125b": {
       "name": "luassert",
       "version": "1.9.0-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696"
       ],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -136,9 +107,6 @@
     "b7fa2fc76ac7b515ab09c4982a9805528218639fda3b3a86a49825f3cf42bd0b": {
       "name": "lua-cjson",
       "version": "2.1.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==2.1.0",
       "binaries": [
         "json2lua",
@@ -157,11 +125,7 @@
     "c00abab54b42135a2957c647032e5487fc18e4171039d79dd48e7d9f84b5759e": {
       "name": "plenary.nvim",
       "version": "0.1.4-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==0.1.4",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -175,11 +139,7 @@
     "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8": {
       "name": "lua-utils.nvim",
       "version": "1.0.2-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==1.0.2",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -193,8 +153,6 @@
     "fdd927c4d96d1063ce66246cfd5ecb1939a8f8e8425f29428894b43586fb72cd": {
       "name": "neorg",
       "version": "8.8.1-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536",
         "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8",
@@ -203,7 +161,6 @@
         "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a"
       ],
       "constraint": "==8.8.1",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -64,6 +64,10 @@ impl PinnedState {
             Self::Pinned => true,
         }
     }
+
+    fn is_default(&self) -> bool {
+        &Self::default() == self
+    }
 }
 
 impl Serialize for PinnedState {
@@ -102,6 +106,10 @@ impl OptState {
             Self::Required => false,
             Self::Optional => true,
         }
+    }
+
+    fn is_default(&self) -> bool {
+        &Self::default() == self
     }
 }
 
@@ -152,6 +160,7 @@ pub(crate) struct LocalPackageSpec {
     pub pinned: PinnedState,
     pub opt: OptState,
     pub dependencies: Vec<LocalPackageId>,
+    pub build_dependencies: Vec<LocalPackageId>,
     // TODO: Deserialize this directly into a `LuaPackageReq`
     pub constraint: Option<String>,
     pub binaries: RockBinaries,
@@ -214,11 +223,13 @@ impl Display for LocalPackageId {
 }
 
 impl LocalPackageSpec {
-    pub fn new(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
         name: &PackageName,
         version: &PackageVersion,
         constraint: LockConstraint,
         dependencies: Vec<LocalPackageId>,
+        build_dependencies: Vec<LocalPackageId>,
         pinned: &PinnedState,
         opt: &OptState,
         binaries: RockBinaries,
@@ -229,6 +240,7 @@ impl LocalPackageSpec {
             pinned: *pinned,
             opt: *opt,
             dependencies,
+            build_dependencies,
             constraint: match constraint {
                 LockConstraint::Unconstrained => None,
                 LockConstraint::Constrained(version_req) => Some(version_req.to_string()),
@@ -275,6 +287,10 @@ impl LocalPackageSpec {
         self.dependencies.iter().collect()
     }
 
+    pub fn build_dependencies(&self) -> Vec<&LocalPackageId> {
+        self.build_dependencies.iter().collect()
+    }
+
     pub fn binaries(&self) -> Vec<&PathBuf> {
         self.binaries.iter().collect()
     }
@@ -284,7 +300,23 @@ impl LocalPackageSpec {
     }
 
     pub fn into_package_req(self) -> PackageReq {
-        PackageSpec::new(self.name, self.version).into_package_req()
+        match self.constraint() {
+            LockConstraint::Unconstrained => self.name.into(),
+            LockConstraint::Constrained(version_req) => PackageReq {
+                name: self.name,
+                version_req,
+            },
+        }
+    }
+
+    pub(crate) fn as_package_req(&self) -> PackageReq {
+        match self.constraint() {
+            LockConstraint::Unconstrained => self.name.clone().into(),
+            LockConstraint::Constrained(version_req) => PackageReq {
+                name: self.name.clone(),
+                version_req: version_req.clone(),
+            },
+        }
     }
 }
 
@@ -346,12 +378,20 @@ impl LocalPackage {
 struct LocalPackageIntermediate {
     name: PackageName,
     version: PackageVersion,
+    #[serde(default, skip_serializing_if = "PinnedState::is_default")]
     pinned: PinnedState,
+    #[serde(default, skip_serializing_if = "OptState::is_default")]
     opt: OptState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     dependencies: Vec<LocalPackageId>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    build_dependencies: Vec<LocalPackageId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     constraint: Option<String>,
+    #[serde(default, skip_serializing_if = "RockBinaries::is_default")]
     binaries: RockBinaries,
     source: RemotePackageSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     source_url: Option<RemotePackageSourceUrl>,
     hashes: LocalPackageHashes,
 }
@@ -367,6 +407,7 @@ impl TryFrom<LocalPackageIntermediate> for LocalPackage {
                 &value.version,
                 constraint,
                 value.dependencies,
+                value.build_dependencies,
                 &value.pinned,
                 &value.opt,
                 value.binaries,
@@ -386,6 +427,7 @@ impl From<&LocalPackage> for LocalPackageIntermediate {
             pinned: value.spec.pinned,
             opt: value.spec.opt,
             dependencies: value.spec.dependencies.clone(),
+            build_dependencies: value.spec.build_dependencies.clone(),
             constraint: value.spec.constraint.clone(),
             binaries: value.spec.binaries.clone(),
             source: value.source.clone(),
@@ -429,6 +471,7 @@ impl LocalPackage {
                 package.version(),
                 constraint,
                 Vec::default(),
+                Vec::default(),
                 &PinnedState::Unpinned,
                 &OptState::Required,
                 binaries,
@@ -465,6 +508,10 @@ impl LocalPackage {
 
     pub fn dependencies(&self) -> Vec<&LocalPackageId> {
         self.spec.dependencies()
+    }
+
+    pub fn build_dependencies(&self) -> Vec<&LocalPackageId> {
+        self.spec.build_dependencies()
     }
 
     pub fn constraint(&self) -> LockConstraint {
@@ -1287,6 +1334,31 @@ impl Lockfile<ReadWrite> {
                 target
             });
         self.add(dependency);
+    }
+
+    /// Add a build dependency for a package.
+    pub(crate) fn add_build_dependency(
+        &mut self,
+        target: &LocalPackage,
+        dependency: &LocalPackage,
+    ) {
+        self.lock
+            .rocks
+            .entry(target.id())
+            .and_modify(|rock| {
+                let id = dependency.id();
+                if !rock.spec.build_dependencies.contains(&id) {
+                    rock.spec.build_dependencies.push(id);
+                }
+            })
+            .or_insert_with(|| {
+                let id = dependency.id();
+                let mut target = target.clone();
+                if !target.spec.build_dependencies.contains(&id) {
+                    target.spec.build_dependencies.push(id);
+                }
+                target
+            });
     }
 
     pub(crate) fn remove(&mut self, target: &LocalPackage) {

--- a/lux-lib/src/lockfile/mod.rs
+++ b/lux-lib/src/lockfile/mod.rs
@@ -1054,6 +1054,14 @@ impl<P: LockfilePermissions> WorkspaceLockfile<P> {
         }
     }
 
+    pub(crate) fn local_pkg_locks(&self) -> Vec<LocalPackageLock> {
+        vec![
+            self.dependencies.clone(),
+            self.test_dependencies.clone(),
+            self.build_dependencies.clone(),
+        ]
+    }
+
     fn flush(&self) -> io::Result<()> {
         let content = serde_json::to_string_pretty(&self)?;
 

--- a/lux-lib/src/lockfile/snapshots/lux_lib__lockfile__tests__add_rocks.snap
+++ b/lux-lib/src/lockfile/snapshots/lux_lib__lockfile__tests__add_rocks.snap
@@ -9,11 +9,6 @@ expression: lockfile
     "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -28,11 +23,7 @@ expression: lockfile
     "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536": {
       "name": "nvim-nio",
       "version": "1.7.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.7.0, <1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -46,11 +37,7 @@ expression: lockfile
     "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.4.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -65,11 +52,7 @@ expression: lockfile
     "53e23ed902788b3579e6c96d44c45c308987012d4e87d00d1b4ba0da88ce29f6": {
       "name": "nui.nvim",
       "version": "0.3.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==0.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -84,11 +67,7 @@ expression: lockfile
     "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a": {
       "name": "pathlib.nvim",
       "version": "2.2.3-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=2.2.0, <2.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -103,12 +82,8 @@ expression: lockfile
       "name": "test2",
       "version": "0.1.0-1",
       "pinned": true,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.0.0",
-      "binaries": [],
       "source": "test+foo_bar",
-      "source_url": null,
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
         "source": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek="
@@ -117,15 +92,10 @@ expression: lockfile
     "9aee9941c7f659d37f722216138a3913b8861f8d31d52da5601a39d9a30e9d4e": {
       "name": "test1",
       "version": "0.1.0-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "70c39f3bec3b9799890eb8dd8501115136faa83d7c0eb9448b9a9d933e178335"
       ],
-      "constraint": null,
-      "binaries": [],
       "source": "test+foo_bar",
-      "source_url": null,
       "hashes": {
         "rockspec": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
         "source": "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek="
@@ -134,11 +104,7 @@ expression: lockfile
     "9e1642247f9208a7e65e1e76461b2adc6f35fe644ce4cdf9f7fa6f5a12c8845e": {
       "name": "nvim-nio",
       "version": "1.10.1-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -152,13 +118,9 @@ expression: lockfile
     "acdfde00d122aac481c18c906d483478bb536741beb025becc11782a075d125b": {
       "name": "luassert",
       "version": "1.9.0-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696"
       ],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -173,9 +135,6 @@ expression: lockfile
     "b7fa2fc76ac7b515ab09c4982a9805528218639fda3b3a86a49825f3cf42bd0b": {
       "name": "lua-cjson",
       "version": "2.1.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==2.1.0",
       "binaries": [
         "json2lua",
@@ -194,11 +153,7 @@ expression: lockfile
     "c00abab54b42135a2957c647032e5487fc18e4171039d79dd48e7d9f84b5759e": {
       "name": "plenary.nvim",
       "version": "0.1.4-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==0.1.4",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -212,11 +167,7 @@ expression: lockfile
     "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8": {
       "name": "lua-utils.nvim",
       "version": "1.0.2-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==1.0.2",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -230,8 +181,6 @@ expression: lockfile
     "fdd927c4d96d1063ce66246cfd5ecb1939a8f8e8425f29428894b43586fb72cd": {
       "name": "neorg",
       "version": "8.8.1-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536",
         "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8",
@@ -240,7 +189,6 @@ expression: lockfile
         "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a"
       ],
       "constraint": "==8.8.1",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",

--- a/lux-lib/src/lockfile/snapshots/lux_lib__lockfile__tests__parse_lockfile.snap
+++ b/lux-lib/src/lockfile/snapshots/lux_lib__lockfile__tests__parse_lockfile.snap
@@ -9,11 +9,6 @@ expression: lockfile
     "0e7601c45f13611fa5b85cb3ba46a554ad6fb6c4546776b310c9ebfc5581e663": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -28,11 +23,7 @@ expression: lockfile
     "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536": {
       "name": "nvim-nio",
       "version": "1.7.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.7.0, <1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -46,11 +37,7 @@ expression: lockfile
     "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696": {
       "name": "say",
       "version": "1.4.1-3",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.4.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -65,11 +52,7 @@ expression: lockfile
     "53e23ed902788b3579e6c96d44c45c308987012d4e87d00d1b4ba0da88ce29f6": {
       "name": "nui.nvim",
       "version": "0.3.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==0.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -84,11 +67,7 @@ expression: lockfile
     "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a": {
       "name": "pathlib.nvim",
       "version": "2.2.3-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=2.2.0, <2.3.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -102,11 +81,7 @@ expression: lockfile
     "9e1642247f9208a7e65e1e76461b2adc6f35fe644ce4cdf9f7fa6f5a12c8845e": {
       "name": "nvim-nio",
       "version": "1.10.1-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": ">=1.8.0",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -120,13 +95,9 @@ expression: lockfile
     "acdfde00d122aac481c18c906d483478bb536741beb025becc11782a075d125b": {
       "name": "luassert",
       "version": "1.9.0-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "4e9592a499c9ced4f8ce366db9db7d9c0dd1424ea8d4c8c16c1550ea3a61a696"
       ],
-      "constraint": null,
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "git",
@@ -141,9 +112,6 @@ expression: lockfile
     "b7fa2fc76ac7b515ab09c4982a9805528218639fda3b3a86a49825f3cf42bd0b": {
       "name": "lua-cjson",
       "version": "2.1.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==2.1.0",
       "binaries": [
         "json2lua",
@@ -162,11 +130,7 @@ expression: lockfile
     "c00abab54b42135a2957c647032e5487fc18e4171039d79dd48e7d9f84b5759e": {
       "name": "plenary.nvim",
       "version": "0.1.4-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==0.1.4",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -180,11 +144,7 @@ expression: lockfile
     "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8": {
       "name": "lua-utils.nvim",
       "version": "1.0.2-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
       "constraint": "==1.0.2",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",
@@ -198,8 +158,6 @@ expression: lockfile
     "fdd927c4d96d1063ce66246cfd5ecb1939a8f8e8425f29428894b43586fb72cd": {
       "name": "neorg",
       "version": "8.8.1-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": [
         "3762e98c2b422658125cbb99ab9323b07bd53ee3f278bc5bb94440f43d4a4536",
         "e991f460b0f85e6e5be982e6cf0d64c345852c389fe225c9facdbebbc9d8a1d8",
@@ -208,7 +166,6 @@ expression: lockfile
         "633b8427bcfd6db2c9ad5037e6a074a9b872389e4e40ec3b63ba725f3a213a6a"
       ],
       "constraint": "==8.8.1",
-      "binaries": [],
       "source": "luarocks_rockspec+https://luarocks.org/",
       "source_url": {
         "type": "url",

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -51,9 +51,6 @@ pub enum BuildWorkspaceError {
     #[error("syncing dependencies with the project lockfile failed")]
     #[diagnostic(forward(0))]
     SyncDependencies(#[source] SyncError),
-    #[error("syncing build dependencies with the project lockfile failed")]
-    #[diagnostic(forward(0))]
-    SyncBuildDependencies(#[source] SyncError),
     #[error("error building the workspace")]
     #[diagnostic(forward(0))]
     Build(#[from] BuildError),

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -193,10 +193,16 @@ async fn build_project(
         })
         .cloned()
         .collect_vec();
+
+    let build_lockfile = workspace.build_tree(config)?.lockfile()?;
+
     let mut lockfile = lockfile.write_guard();
     lockfile.add_entrypoint(&package);
     for dep in dependencies {
         lockfile.add_dependency(&package, &dep);
+    }
+    for dep in build_lockfile.rocks().values() {
+        lockfile.add_build_dependency(&package, dep);
     }
     Ok(package)
 }

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -102,11 +102,6 @@ async fn do_build(args: BuildWorkspace<'_>) -> Result<Vec<LocalPackage>, BuildWo
             .sync_dependencies()
             .await
             .map_err(BuildWorkspaceError::SyncDependencies)?;
-
-        Sync::new(workspace, config)
-            .sync_build_dependencies()
-            .await
-            .map_err(BuildWorkspaceError::SyncBuildDependencies)?;
     } else {
         let luarocks = LuaRocksInstallation::new(config, build_tree.clone())?;
         let mut dependencies_to_install = Vec::new();

--- a/lux-lib/src/operations/build_workspace.rs
+++ b/lux-lib/src/operations/build_workspace.rs
@@ -48,7 +48,7 @@ pub enum BuildWorkspaceError {
     #[error("error installind build dependencies")]
     #[diagnostic(forward(0))]
     InstallBuildDependencies(#[source] InstallError),
-    #[error("syncing dependencies with the project lockfile failed")]
+    #[error("syncing dependencies with the workspace lockfile failed")]
     #[diagnostic(forward(0))]
     SyncDependencies(#[source] SyncError),
     #[error("error building the workspace")]
@@ -96,7 +96,7 @@ async fn do_build(args: BuildWorkspace<'_>) -> Result<Vec<LocalPackage>, BuildWo
     let lua = LuaInstallation::new_from_config(config).await?;
     if !args.no_lock {
         Sync::new(workspace, config)
-            .sync_dependencies()
+            .sync()
             .await
             .map_err(BuildWorkspaceError::SyncDependencies)?;
     } else {

--- a/lux-lib/src/operations/install/mod.rs
+++ b/lux-lib/src/operations/install/mod.rs
@@ -207,7 +207,7 @@ where
     let (dep_tx, mut dep_rx) = tokio::sync::mpsc::unbounded_channel();
     let (build_dep_tx, build_dep_rx) = tokio::sync::mpsc::unbounded_channel();
     let (build_dep_install_done_tx, mut build_dep_install_done_rx) =
-        tokio::sync::mpsc::unbounded_channel::<PackageName>();
+        tokio::sync::mpsc::unbounded_channel::<(LocalPackage, PackageInstallData)>();
 
     let lockfile = tree.lockfile()?;
     let build_lockfile = tree.build_tree(config)?.lockfile()?;
@@ -235,7 +235,8 @@ where
     let mut scheduled_packages: HashSet<LocalPackageId> = HashSet::new();
     let mut installed_packages: HashMap<LocalPackageId, (LocalPackage, tree::EntryType)> =
         HashMap::new();
-    let mut installed_build_deps: HashSet<PackageName> = HashSet::new();
+    let mut installed_build_deps: HashMap<LocalPackageId, (LocalPackage, PackageInstallData)> =
+        HashMap::new();
     let mut ongoing_installs: FuturesUnordered<
         tracing::instrument::Instrumented<tokio::task::JoinHandle<InstallWorkerOutput>>,
     > = FuturesUnordered::new();
@@ -265,9 +266,9 @@ where
                 }
                 build_deps_done = true;
             }
-            name = build_dep_install_done_rx.recv(), if !build_dep_rx_drained => {
-                if let Some(name) = name {
-                    installed_build_deps.insert(name);
+            build_dep = build_dep_install_done_rx.recv(), if !build_dep_rx_drained => {
+                if let Some((build_dep, install_data)) = build_dep {
+                    installed_build_deps.insert(build_dep.spec.id(), (build_dep, install_data));
                 } else {
                     build_dep_rx_drained = true;
                 }
@@ -285,7 +286,10 @@ where
             &all_packages,
             &scheduled_packages,
             &build_lockfile,
-            &installed_build_deps,
+            &installed_build_deps
+                .values()
+                .map(|(pkg, _)| pkg.name().clone())
+                .collect(),
         ) {
             if max_jobs > 0 && ongoing_installs.len() >= max_jobs {
                 if let Err(err) =
@@ -317,6 +321,12 @@ where
                         *is_entrypoint,
                         &all_packages,
                         &installed_packages,
+                    )?;
+                    lockfile.add_build_dependencies(
+                        package_id,
+                        package,
+                        &all_packages,
+                        &installed_build_deps,
                     )?;
                 }
                 Ok::<_, io::Error>(())
@@ -373,7 +383,7 @@ fn spawn_build_deps_worker<T>(
     tree: &T,
     lua: Arc<LuaInstallation>,
     mut build_dep_rx: UnboundedReceiver<PackageInstallData>,
-    build_dep_install_done_tx: UnboundedSender<PackageName>,
+    build_dep_install_done_tx: UnboundedSender<(LocalPackage, PackageInstallData)>,
 ) -> tracing::instrument::Instrumented<JoinHandle<Result<(), InstallError>>>
 where
     T: InstallTree + Clone + Send + Sync + 'static,
@@ -391,7 +401,7 @@ where
                     package = package.to_string(),
                     version = rockspec.version().to_string()
                 );
-                async {
+                let pkg = async {
                     let build_tree = tree.build_tree(&config)?;
                     let mut build_lockfile = build_tree.lockfile()?.write_guard();
                     let pkg = Build::new()
@@ -404,13 +414,13 @@ where
                         .behaviour(build_dep_spec.build_behaviour)
                         .build()
                         .await
-                        .map_err(|err| InstallError::BuildDependency(package.clone(), err))?;
+                        .map_err(|err| InstallError::BuildDependency(package, err))?;
                     build_lockfile.add_entrypoint(&pkg);
-                    Ok::<_, InstallError>(())
+                    Ok::<_, InstallError>(pkg)
                 }
                 .instrument(span)
                 .await?;
-                let _ = build_dep_install_done_tx.send(package);
+                let _ = build_dep_install_done_tx.send((pkg, build_dep_spec));
             }
             Ok::<(), InstallError>(())
         }
@@ -569,6 +579,14 @@ trait LockfileExt {
         all_packages: &HashMap<LocalPackageId, PackageInstallData>,
         installed_packages: &HashMap<LocalPackageId, (LocalPackage, tree::EntryType)>,
     ) -> io::Result<()>;
+
+    fn add_build_dependencies(
+        self,
+        id: &LocalPackageId,
+        pkg: &LocalPackage,
+        all_packages: &HashMap<LocalPackageId, PackageInstallData>,
+        build_dependencies: &HashMap<LocalPackageId, (LocalPackage, PackageInstallData)>,
+    ) -> io::Result<()>;
 }
 
 impl LockfileExt for &mut Lockfile<ReadWrite> {
@@ -599,6 +617,38 @@ impl LockfileExt for &mut Lockfile<ReadWrite> {
                         r#"
 error writing dependencies to the lockfile.
 A required dependency was not installed correctly.
+This is likely because an install thread panicked and was interrupted unexpectedly.
+
+[THIS IS A BUG!]
+"#,
+                    ))?,
+            );
+        }
+        Ok(())
+    }
+
+    fn add_build_dependencies(
+        self,
+        id: &LocalPackageId,
+        pkg: &LocalPackage,
+        all_packages: &HashMap<LocalPackageId, PackageInstallData>,
+        build_dependencies: &HashMap<LocalPackageId, (LocalPackage, PackageInstallData)>,
+    ) -> io::Result<()> {
+        for dependency_id in all_packages
+            .get(id)
+            .map(|pkg| pkg.spec.build_dependencies())
+            .unwrap_or_default()
+            .into_iter()
+        {
+            self.add_build_dependency(
+                pkg,
+                build_dependencies
+                    .get(dependency_id)
+                    .map(|(pkg, _)| pkg)
+                    .ok_or(io::Error::other(
+                        r#"
+error writing build dependencies to the lockfile.
+A required build dependency was not installed correctly.
 This is likely because an install thread panicked and was interrupted unexpectedly.
 
 [THIS IS A BUG!]

--- a/lux-lib/src/operations/install_project.rs
+++ b/lux-lib/src/operations/install_project.rs
@@ -115,9 +115,14 @@ impl<
 
         let lockfile = tree.lockfile()?;
         let mut lockfile = lockfile.write_guard();
+        let build_lockfile = tree.build_tree(config)?.lockfile()?;
+
         lockfile.add_entrypoint(&package);
         for dep in dependencies {
             lockfile.add_dependency(&package, &dep);
+        }
+        for dep in build_lockfile.rocks().values() {
+            lockfile.add_build_dependency(&package, dep);
         }
         Ok(package)
     }

--- a/lux-lib/src/operations/install_rockspec.rs
+++ b/lux-lib/src/operations/install_rockspec.rs
@@ -145,10 +145,15 @@ impl<
             .await?;
 
         let lockfile = tree.lockfile()?;
+        let build_lockfile = tree.build_tree(config)?.lockfile()?;
+
         let mut lockfile = lockfile.write_guard();
         lockfile.add_entrypoint(&package);
         for dep in dependencies {
             lockfile.add_dependency(&package, &dep);
+        }
+        for dep in build_lockfile.rocks().values() {
+            lockfile.add_build_dependency(&package, dep);
         }
         Ok(package)
     }

--- a/lux-lib/src/operations/resolve.rs
+++ b/lux-lib/src/operations/resolve.rs
@@ -225,8 +225,11 @@ where
                             }
 
                             // NOTE: We don't need to install build dependencies to install binary rocks.
-                            if !matches!(downloaded_rock, RemoteRockDownload::BinaryRock { .. }) {
-                                let build_dependencies = build_dependencies_to_install(rockspec)
+                            let build_dependencies = if !matches!(
+                                downloaded_rock,
+                                RemoteRockDownload::BinaryRock { .. }
+                            ) {
+                                let packages = build_dependencies_to_install(rockspec)
                                     .into_iter()
                                     .filter_map(|name| {
                                         rockspec
@@ -269,7 +272,7 @@ where
                                 Resolve::new()
                                     .dependencies_tx(build_dependencies_tx.clone())
                                     .build_dependencies_tx(build_dependencies_tx.clone())
-                                    .packages(build_dependencies)
+                                    .packages(packages)
                                     .parent_packages(Arc::new(
                                         parent_packages
                                             .iter()
@@ -282,8 +285,10 @@ where
                                     .maybe_build_lockfile(build_lockfile.clone())
                                     .config(&config)
                                     .get_all_dependencies()
-                                    .await?;
-                            }
+                                    .await?
+                            } else {
+                                Vec::new()
+                            };
 
                             let dependencies = rockspec
                                 .dependencies()
@@ -338,6 +343,7 @@ where
                                 rockspec.version(),
                                 constraint,
                                 dependencies,
+                                build_dependencies,
                                 &pin,
                                 &opt,
                                 rockspec.binaries(),

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -269,7 +269,7 @@ async fn do_sync(
         .added
         .extend(to_add.iter().map(|(_, pkg)| pkg).cloned());
 
-    let package_db = workspace_lockfile.local_pkg_lock(lock_type).clone().into();
+    let package_db = workspace_lockfile.local_pkg_locks().into();
 
     Install::new(args.config)
         .package_db(package_db)

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -55,47 +55,17 @@ impl<State> SyncBuilder<'_, State>
 where
     State: sync_builder::State + sync_builder::IsComplete,
 {
+    // Syncs build dependencies & regular dependencies.
     pub async fn sync_dependencies(self) -> Result<SyncReport, SyncError> {
-        do_sync(self._build(), &LocalPackageLockType::Regular).await
+        let args = self._build();
+        let build_report = do_sync(&args, &LocalPackageLockType::Build).await?;
+        let mut report = do_sync(&args, &LocalPackageLockType::Regular).await?;
+        report.merge(build_report);
+        Ok(report)
     }
 
-    pub async fn sync_test_dependencies(mut self) -> Result<SyncReport, SyncError> {
-        for project in self.workspace.members() {
-            let toml = project.toml().into_local()?;
-            for test_dep in toml
-                .test()
-                .current_platform()
-                .test_dependencies(project)
-                .iter()
-                .filter(|test_dep| {
-                    !toml
-                        .test_dependencies()
-                        .current_platform()
-                        .iter()
-                        .any(|dep| dep.name() == test_dep.name())
-                })
-                .cloned()
-            {
-                self.extra_packages.push(test_dep);
-            }
-        }
-        do_sync(self._build(), &LocalPackageLockType::Test).await
-    }
-
-    pub async fn sync_build_dependencies(mut self) -> Result<SyncReport, SyncError> {
-        for project in self.workspace.members() {
-            let toml = project.toml().into_local()?;
-            if let Some(backend) = operations::resolve::luarocks_build_backend_name(&toml) {
-                self = self.add_package(backend.into());
-                if cfg!(target_family = "unix") {
-                    let luarocks = unsafe {
-                        PackageReq::new_unchecked("luarocks".into(), Some(LUAROCKS_VERSION.into()))
-                    };
-                    self = self.add_package(luarocks);
-                }
-            }
-        }
-        do_sync(self._build(), &LocalPackageLockType::Build).await
+    pub async fn sync_test_dependencies(self) -> Result<SyncReport, SyncError> {
+        do_sync(&self._build(), &LocalPackageLockType::Test).await
     }
 }
 
@@ -111,6 +81,11 @@ impl SyncReport {
     }
     pub fn removed(&self) -> &[LocalPackage] {
         &self.removed
+    }
+
+    fn merge(&mut self, other: SyncReport) {
+        self.added.extend(other.added);
+        self.removed.extend(other.removed);
     }
 }
 
@@ -156,7 +131,7 @@ pub enum SyncError {
 
 #[tracing::instrument(name = "Syncing dependencies", skip_all)]
 async fn do_sync(
-    args: Sync<'_>,
+    args: &Sync<'_>,
     lock_type: &LocalPackageLockType,
 ) -> Result<SyncReport, SyncError> {
     // NOTE(vhyrro): tools like cc and pkg-config leak cargo:rerun-if-env-changed
@@ -202,9 +177,46 @@ async fn do_sync(
             ),
         }
     }
+
+    let mut extra_packages = args.extra_packages.iter().cloned().collect_vec();
+    if lock_type == &LocalPackageLockType::Build {
+        for project in args.workspace.members() {
+            let toml = project.toml().into_local()?;
+            if let Some(backend) = operations::resolve::luarocks_build_backend_name(&toml) {
+                extra_packages.push(backend.into());
+                if cfg!(target_family = "unix") {
+                    let luarocks = unsafe {
+                        PackageReq::new_unchecked("luarocks".into(), Some(LUAROCKS_VERSION.into()))
+                    };
+                    extra_packages.push(luarocks);
+                }
+            }
+        }
+    } else if lock_type == &LocalPackageLockType::Test {
+        for project in args.workspace.members() {
+            let toml = project.toml().into_local()?;
+            for test_dep in toml
+                .test()
+                .current_platform()
+                .test_dependencies(project)
+                .iter()
+                .filter(|test_dep| {
+                    !toml
+                        .test_dependencies()
+                        .current_platform()
+                        .iter()
+                        .any(|dep| dep.name() == test_dep.name())
+                })
+                .cloned()
+            {
+                extra_packages.push(test_dep);
+            }
+        }
+    }
+
     let packages = packages
         .into_iter()
-        .chain(args.extra_packages.into_iter().map_into())
+        .chain(extra_packages.into_iter().map_into())
         .collect_vec();
 
     let strategy = if args.fast.unwrap_or(false) {

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -60,18 +60,54 @@ where
     State: sync_builder::State + sync_builder::IsComplete,
 {
     pub async fn sync(self) -> Result<SyncReport, SyncError> {
-        let args = self._build();
+        let mut args = self._build();
         let test_report = if args.test.unwrap_or(false) {
             Some(do_sync(&args, &LocalPackageLockType::Test).await?)
         } else {
             None
         };
-        let build_report = do_sync(&args, &LocalPackageLockType::Build).await?;
         let mut report = do_sync(&args, &LocalPackageLockType::Regular).await?;
+
+        // `do_sync` removes dependencies that aren't listed in the workspace lockfile
+        // or in `args.extra_packages`.
+        // To prevent loss of transitive build dependencies, we resolve them, and
+        // add them to `args.extra_packages` before syncing the workspace's build dependencies.
+        let lockfile = args.workspace.tree(args.config)?.lockfile()?;
+        let test_tree = args.workspace.test_tree(args.config)?;
+        let test_build_lockfile = test_tree.build_tree(args.config)?.lockfile()?;
+        let build_lockfile = args.workspace.build_tree(args.config)?.lockfile()?;
+        let transitive_build_dependencies = lockfile
+            .local_pkg_lock()
+            .rocks()
+            .values()
+            .flat_map(|rock| rock.build_dependencies())
+            .filter_map(|dep_id| build_lockfile.get(dep_id))
+            .chain(
+                test_tree
+                    .lockfile()?
+                    .local_pkg_lock()
+                    .rocks()
+                    .values()
+                    .flat_map(|rock| rock.build_dependencies())
+                    .filter_map(|dep_id| test_build_lockfile.get(dep_id)),
+            )
+            .map(|pkg| pkg.spec.as_package_req())
+            .collect_vec();
+        args.extra_packages.extend(transitive_build_dependencies);
+
+        let build_report = do_sync(&args, &LocalPackageLockType::Build).await?;
+
+        operations::GenLuaRc::new()
+            .config(args.config)
+            .workspace(args.workspace)
+            .generate_luarc()
+            .await?;
+
         report.merge(build_report);
         if let Some(test_report) = test_report {
             report.merge(test_report);
         }
+
         Ok(report)
     }
 }
@@ -223,7 +259,7 @@ async fn do_sync(
 
     let packages = packages
         .into_iter()
-        .chain(extra_packages.into_iter().map_into())
+        .chain(extra_packages.into_iter().unique().map_into())
         .collect_vec();
 
     let strategy = if args.fast.unwrap_or(false) {
@@ -340,19 +376,7 @@ async fn do_sync(
         // Sync the newly added packages back to the workspace lockfile
         let dest_lockfile = tree.lockfile()?;
         workspace_lockfile.sync(dest_lockfile.local_pkg_lock(), lock_type);
-        if lock_type != &LocalPackageLockType::Build {
-            // ...including transitive build dependencies
-            let tree = args.workspace.build_tree(args.config)?;
-            let dest_lockfile = tree.lockfile()?;
-            workspace_lockfile.sync(dest_lockfile.local_pkg_lock(), &LocalPackageLockType::Build);
-        }
     }
-
-    operations::GenLuaRc::new()
-        .config(args.config)
-        .workspace(args.workspace)
-        .generate_luarc()
-        .await?;
 
     Ok(report)
 }

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -36,6 +36,10 @@ pub struct Sync<'a> {
 
     /// Whether to validate the integrity of installed packages.
     validate_integrity: Option<bool>,
+
+    /// Whether to sync test dependencies
+    test: Option<bool>,
+
     /// When `true`, skip filesystem existence checks and rely on the install tree's lockfile
     /// alone.
     fast: Option<bool>,
@@ -55,17 +59,20 @@ impl<State> SyncBuilder<'_, State>
 where
     State: sync_builder::State + sync_builder::IsComplete,
 {
-    // Syncs build dependencies & regular dependencies.
-    pub async fn sync_dependencies(self) -> Result<SyncReport, SyncError> {
+    pub async fn sync(self) -> Result<SyncReport, SyncError> {
         let args = self._build();
+        let test_report = if args.test.unwrap_or(false) {
+            Some(do_sync(&args, &LocalPackageLockType::Test).await?)
+        } else {
+            None
+        };
         let build_report = do_sync(&args, &LocalPackageLockType::Build).await?;
         let mut report = do_sync(&args, &LocalPackageLockType::Regular).await?;
         report.merge(build_report);
+        if let Some(test_report) = test_report {
+            report.merge(test_report);
+        }
         Ok(report)
-    }
-
-    pub async fn sync_test_dependencies(self) -> Result<SyncReport, SyncError> {
-        do_sync(&self._build(), &LocalPackageLockType::Test).await
     }
 }
 
@@ -376,10 +383,7 @@ mod tests {
             .unwrap();
         let workspace = Workspace::from_exact(temp_dir.path()).unwrap().unwrap();
         let config = ConfigBuilder::new().unwrap().build().unwrap();
-        let report = Sync::new(&workspace, &config)
-            .sync_dependencies()
-            .await
-            .unwrap();
+        let report = Sync::new(&workspace, &config).sync().await.unwrap();
         assert!(report.removed.is_empty());
         assert!(!report.added.is_empty());
 
@@ -409,7 +413,7 @@ mod tests {
         {
             let report = Sync::new(&workspace, &config)
                 .add_package(PackageReq::new("toml-edit".into(), None).unwrap())
-                .sync_dependencies()
+                .sync()
                 .await
                 .unwrap();
             assert!(report.removed.is_empty());
@@ -446,7 +450,7 @@ mod tests {
         {
             let report = Sync::new(&workspace, &config)
                 .add_package(PackageReq::new("toml-edit".into(), None).unwrap())
-                .sync_dependencies()
+                .sync()
                 .await
                 .unwrap();
             assert!(report.removed.is_empty());
@@ -481,13 +485,10 @@ mod tests {
         // First sync to create the tree and lockfile
         Sync::new(&workspace, &config)
             .add_package(PackageReq::new("toml-edit".into(), None).unwrap())
-            .sync_dependencies()
+            .sync()
             .await
             .unwrap();
-        let report = Sync::new(&workspace, &config)
-            .sync_dependencies()
-            .await
-            .unwrap();
+        let report = Sync::new(&workspace, &config).sync().await.unwrap();
         assert!(!report.removed.is_empty());
         assert!(report.added.is_empty());
 

--- a/lux-lib/src/operations/sync.rs
+++ b/lux-lib/src/operations/sync.rs
@@ -335,6 +335,8 @@ async fn do_sync(
         workspace_lockfile.sync(dest_lockfile.local_pkg_lock(), lock_type);
         if lock_type != &LocalPackageLockType::Build {
             // ...including transitive build dependencies
+            let tree = args.workspace.build_tree(args.config)?;
+            let dest_lockfile = tree.lockfile()?;
             workspace_lockfile.sync(dest_lockfile.local_pkg_lock(), &LocalPackageLockType::Build);
         }
     }

--- a/lux-lib/src/operations/test.rs
+++ b/lux-lib/src/operations/test.rs
@@ -165,9 +165,7 @@ async fn run_project_tests(
         let rockspec = project.toml().into_local()?;
         ensure_test_dependencies(workspace, project, rockspec, &test_config).await?;
     } else {
-        Sync::new(workspace, &test_config)
-            .sync_test_dependencies()
-            .await?;
+        Sync::new(workspace, &test_config).test(true).sync().await?;
     }
 
     BuildWorkspace::new(workspace, &test_config)

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -145,7 +145,7 @@ async fn update_workspace(
     let mut project_lockfile = workspace.lockfile()?.write_guard();
     let tree = workspace.tree(args.config)?;
 
-    let dep_report = super::Sync::new(&workspace, args.config)
+    let dep_sync_report = super::Sync::new(&workspace, args.config)
         .validate_integrity(args.validate_integrity.unwrap_or(false))
         .sync_dependencies()
         .await?;
@@ -158,16 +158,14 @@ async fn update_workspace(
         args.config,
         &args.packages,
     )
-    .await?
-    .into_iter()
-    .chain(dep_report.added)
-    .chain(dep_report.removed);
+    .await?;
 
     let test_tree = workspace.test_tree(args.config)?;
-    let dep_report = super::Sync::new(&workspace, args.config)
+    let test_dep_sync_report = super::Sync::new(&workspace, args.config)
         .validate_integrity(false)
         .sync_test_dependencies()
         .await?;
+
     let updated_test_dependencies = update_dependency_tree(
         test_tree,
         &mut project_lockfile,
@@ -176,17 +174,10 @@ async fn update_workspace(
         args.config,
         &args.test_dependencies,
     )
-    .await?
-    .into_iter()
-    .chain(dep_report.added)
-    .chain(dep_report.removed);
+    .await?;
 
     let build_tree = workspace.build_tree(args.config)?;
 
-    let dep_report = super::Sync::new(&workspace, args.config)
-        .validate_integrity(false)
-        .sync_build_dependencies()
-        .await?;
     let updated_build_dependencies = update_dependency_tree(
         build_tree,
         &mut project_lockfile,
@@ -195,15 +186,16 @@ async fn update_workspace(
         args.config,
         &args.build_dependencies,
     )
-    .await?
-    .into_iter()
-    .chain(dep_report.added)
-    .chain(dep_report.removed);
+    .await?;
 
     Ok(updated_dependencies
         .into_iter()
-        .chain(updated_test_dependencies)
+        .chain(dep_sync_report.added)
+        .chain(dep_sync_report.removed)
         .chain(updated_build_dependencies)
+        .chain(updated_test_dependencies)
+        .chain(test_dep_sync_report.added)
+        .chain(test_dep_sync_report.removed)
         .collect_vec())
 }
 

--- a/lux-lib/src/operations/update.rs
+++ b/lux-lib/src/operations/update.rs
@@ -145,9 +145,10 @@ async fn update_workspace(
     let mut project_lockfile = workspace.lockfile()?.write_guard();
     let tree = workspace.tree(args.config)?;
 
-    let dep_sync_report = super::Sync::new(&workspace, args.config)
+    let sync_report = super::Sync::new(&workspace, args.config)
         .validate_integrity(args.validate_integrity.unwrap_or(false))
-        .sync_dependencies()
+        .test(true)
+        .sync()
         .await?;
 
     let updated_dependencies = update_dependency_tree(
@@ -161,10 +162,6 @@ async fn update_workspace(
     .await?;
 
     let test_tree = workspace.test_tree(args.config)?;
-    let test_dep_sync_report = super::Sync::new(&workspace, args.config)
-        .validate_integrity(false)
-        .sync_test_dependencies()
-        .await?;
 
     let updated_test_dependencies = update_dependency_tree(
         test_tree,
@@ -190,12 +187,10 @@ async fn update_workspace(
 
     Ok(updated_dependencies
         .into_iter()
-        .chain(dep_sync_report.added)
-        .chain(dep_sync_report.removed)
+        .chain(sync_report.added)
+        .chain(sync_report.removed)
         .chain(updated_build_dependencies)
         .chain(updated_test_dependencies)
-        .chain(test_dep_sync_report.added)
-        .chain(test_dep_sync_report.removed)
         .collect_vec())
 }
 

--- a/lux-lib/src/operations/vendor.rs
+++ b/lux-lib/src/operations/vendor.rs
@@ -194,7 +194,7 @@ async fn mk_resolve_args(
             // yet generated a lockfile).
             let lockfile = workspace.try_lockfile()?;
             let package_db = match lockfile {
-                Some(lockfile) if !no_lock => lockfile.local_pkg_lock(&lock_type).clone().into(),
+                Some(lockfile) if !no_lock => lockfile.local_pkg_locks().into(),
                 _ => RemotePackageDB::from_config(config).await?,
             };
             let mut install_specs = Vec::new();

--- a/lux-lib/src/remote_package_db/mod.rs
+++ b/lux-lib/src/remote_package_db/mod.rs
@@ -19,7 +19,7 @@ pub struct RemotePackageDB(Impl);
 #[derive(Clone, Debug)]
 enum Impl {
     LuarocksManifests(Vec<Manifest>),
-    Lock(LocalPackageLock),
+    LocalPackageLocks(Vec<LocalPackageLock>),
 }
 
 #[derive(Error, Debug, Diagnostic)]
@@ -90,14 +90,19 @@ impl RemotePackageDB {
                     None => Err(SearchError::RockNotFound(package_req.clone())),
                 }
             }
-            Impl::Lock(lockfile) => {
-                match lockfile.has_rock(package_req, filter).map(|local_package| {
-                    RemotePackage::new(
-                        PackageSpec::new(local_package.spec.name, local_package.spec.version),
-                        local_package.source,
-                        local_package.source_url,
-                    )
-                }) {
+            Impl::LocalPackageLocks(locks) => {
+                match locks
+                    .iter()
+                    .filter_map(|lock| lock.has_rock(package_req, filter.clone()))
+                    .map(|local_package| {
+                        RemotePackage::new(
+                            PackageSpec::new(local_package.spec.name, local_package.spec.version),
+                            local_package.source,
+                            local_package.source_url,
+                        )
+                    })
+                    .next()
+                {
                     Some(package) => Ok(package),
                     None => Err(SearchError::RockNotFoundInLockfile(package_req.clone())),
                 }
@@ -133,9 +138,9 @@ impl RemotePackageDB {
                         })
                 })
                 .collect(),
-            Impl::Lock(lockfile) => lockfile
-                .rocks()
-                .values()
+            Impl::LocalPackageLocks(locks) => locks
+                .iter()
+                .flat_map(|lock| lock.rocks().values())
                 .filter_map(|package| {
                     // NOTE: This doesn't group packages by name, but we don't care for now,
                     // as we shouldn't need to use this function with a lockfile.
@@ -175,8 +180,8 @@ impl From<Manifest> for RemotePackageDB {
     }
 }
 
-impl From<LocalPackageLock> for RemotePackageDB {
-    fn from(lock: LocalPackageLock) -> Self {
-        Self(Impl::Lock(lock))
+impl From<Vec<LocalPackageLock>> for RemotePackageDB {
+    fn from(locks: Vec<LocalPackageLock>) -> Self {
+        Self(Impl::LocalPackageLocks(locks))
     }
 }

--- a/lux-lib/src/rockspec/mod.rs
+++ b/lux-lib/src/rockspec/mod.rs
@@ -136,6 +136,12 @@ impl<T: Rockspec> LuaVersionCompatibility for T {
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct RockBinaries(Vec<PathBuf>);
 
+impl RockBinaries {
+    pub(crate) fn is_default(&self) -> bool {
+        &Self::default() == self
+    }
+}
+
 impl Deref for RockBinaries {
     type Target = Vec<PathBuf>;
 

--- a/lux-lib/tests/sync.rs
+++ b/lux-lib/tests/sync.rs
@@ -23,8 +23,9 @@ async fn sync_test_dependencies_empty_project() {
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
+        .test(true)
         .fast(true)
-        .sync_test_dependencies()
+        .sync()
         .await
         .unwrap();
 
@@ -71,8 +72,9 @@ async fn sync_multi_projects_same_dependencies() {
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
+        .test(true)
         .fast(true)
-        .sync_test_dependencies()
+        .sync()
         .await
         .unwrap();
 }
@@ -120,7 +122,7 @@ fallo = "2.2.0"
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
-        .sync_dependencies()
+        .sync()
         .await
         .unwrap();
 
@@ -132,7 +134,7 @@ fallo = "2.2.0"
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
-        .sync_dependencies()
+        .sync()
         .await
         .unwrap();
 
@@ -157,7 +159,7 @@ async fn sync_dependencies_adds_luarocks_build_backend() {
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
-        .sync_dependencies()
+        .sync()
         .await
         .unwrap();
 
@@ -184,7 +186,7 @@ async fn sync_dependencies_adds_transitive_build_dependencies() {
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
-        .sync_dependencies()
+        .sync()
         .await
         .unwrap();
 

--- a/lux-lib/tests/sync.rs
+++ b/lux-lib/tests/sync.rs
@@ -146,7 +146,7 @@ fallo = "2.2.0"
 /// Non-regression: https://github.com/lumen-oss/lux/issues/1892
 #[cfg(not(target_os = "windows"))]
 #[flaky_test(tokio, times = 5)]
-async fn sync_build_dependencies_adds_luarocks_build_backend() {
+async fn sync_dependencies_adds_luarocks_build_backend() {
     let sample_project_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("resources/test/sample-projects/luarocks-build-backend/");
     let _ = tokio::fs::remove_dir_all(sample_project_dir.join(".lux")).await;
@@ -157,7 +157,7 @@ async fn sync_build_dependencies_adds_luarocks_build_backend() {
 
     Sync::new(&workspace, &config)
         .validate_integrity(cfg!(not(target_os = "windows")))
-        .sync_build_dependencies()
+        .sync_dependencies()
         .await
         .unwrap();
 

--- a/lux-lib/tests/sync.rs
+++ b/lux-lib/tests/sync.rs
@@ -18,7 +18,7 @@ async fn sync_test_dependencies_empty_project() {
     let workspace = Workspace::from_exact(temp_dir.path()).unwrap().unwrap();
     let config = ConfigBuilder::new().unwrap().build().unwrap();
 
-    let lockfile_before_sync =
+    let lockfile_content_before_sync =
         String::from_utf8(tokio::fs::read(workspace.lockfile_path()).await.unwrap());
 
     Sync::new(&workspace, &config)
@@ -29,31 +29,31 @@ async fn sync_test_dependencies_empty_project() {
         .await
         .unwrap();
 
-    let lockfile_after_sync =
+    let lockfile_content_after_sync =
         String::from_utf8(tokio::fs::read(workspace.lockfile_path()).await.unwrap());
 
     if cfg!(not(target_os = "windows")) {
         // Source hashes are different on Windows
-        assert_eq!(lockfile_before_sync, lockfile_after_sync);
+        assert_eq!(lockfile_content_before_sync, lockfile_content_after_sync);
     }
 
     let test_tree = workspace.tree(&config).unwrap().test_tree(&config).unwrap();
 
     assert!(matches!(
         test_tree
-            .match_rocks(&"busted@2.2.0-1".parse().unwrap())
+            .match_rocks(&"busted@2.3.0-1".parse().unwrap())
             .unwrap(),
         RockMatches::Single { .. }
     ));
     assert!(matches!(
         test_tree
-            .match_rocks(&"penlight@1.14.0-3".parse().unwrap())
+            .match_rocks(&"penlight@1.15.0-1".parse().unwrap())
             .unwrap(),
         RockMatches::Single { .. }
     ));
     assert!(matches!(
         test_tree
-            .match_rocks(&"luafilesystem@1.8.0-1".parse().unwrap())
+            .match_rocks(&"luafilesystem@1.9.0-1".parse().unwrap())
             .unwrap(),
         RockMatches::Single { .. }
     ));

--- a/lux-lib/tests/vendor.rs
+++ b/lux-lib/tests/vendor.rs
@@ -31,13 +31,13 @@ async fn vendor_dependencies() {
         .await
         .unwrap();
 
-    let busted_rockspec = vendor_dir.child("busted-2.2.0-1.rockspec");
+    let busted_rockspec = vendor_dir.child("busted-2.3.0-1.rockspec");
     busted_rockspec.assert(predicate::path::is_file());
-    let busted_dir = vendor_dir.child("busted@2.2.0-1");
+    let busted_dir = vendor_dir.child("busted@2.3.0-1");
     busted_dir.assert(predicate::path::is_dir());
-    let luasystem_rockspec = vendor_dir.child("luasystem-0.6.2-1.rockspec");
+    let luasystem_rockspec = vendor_dir.child("luasystem-0.7.1-1.rockspec");
     luasystem_rockspec.assert(predicate::path::is_file());
-    let luasystem_dir = vendor_dir.child("luasystem@0.6.2-1");
+    let luasystem_dir = vendor_dir.child("luasystem@0.7.1-1");
     luasystem_dir.assert(predicate::path::is_dir());
     let say_rockspec = vendor_dir.child("say-1.4.1-3.rockspec");
     say_rockspec.assert(predicate::path::is_file());

--- a/lux-lua/src/loader.rs
+++ b/lux-lua/src/loader.rs
@@ -276,11 +276,6 @@ mod tests {
     "{FOO_HASH}": {{
       "name": "foo",
       "version": "1.0.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "local",
       "hashes": {{
         "rockspec": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -301,11 +296,7 @@ mod tests {
     "{MAIN_HASH}": {{
       "name": "main",
       "version": "1.0.0-1",
-      "pinned": false,
-      "opt": false,
       "dependencies": ["{FOO_HASH}"],
-      "constraint": null,
-      "binaries": [],
       "source": "local",
       "hashes": {{
         "rockspec": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -315,11 +306,6 @@ mod tests {
     "{FOO_HASH}": {{
       "name": "foo",
       "version": "1.0.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "local",
       "hashes": {{
         "rockspec": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -566,11 +552,6 @@ mod tests {
     "{FOO_HASH}": {{
       "name": "foo",
       "version": "1.0.0-1",
-      "pinned": false,
-      "opt": false,
-      "dependencies": [],
-      "constraint": null,
-      "binaries": [],
       "source": "local",
       "hashes": {{
         "rockspec": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/lux-lua/src/operations.rs
+++ b/lux-lua/src/operations.rs
@@ -222,19 +222,11 @@ impl TypedUserData for OperationsModule {
                     .sync_dependencies()
                     .await
                     .into_lua_err()?;
-                let build = Sync::new(&workspace.0, &config.0)
-                    .sync_build_dependencies()
-                    .await
-                    .into_lua_err()?;
                 let test = Sync::new(&workspace.0, &config.0)
                     .sync_test_dependencies()
                     .await
                     .into_lua_err()?;
-                Ok((
-                    SyncReportLua(deps),
-                    SyncReportLua(build),
-                    SyncReportLua(test),
-                ))
+                Ok((SyncReportLua(deps), SyncReportLua(test)))
             },
         );
 
@@ -247,21 +239,6 @@ impl TypedUserData for OperationsModule {
                 let _runtime = lua_runtime().enter();
                 Sync::new(&workspace.0, &config.0)
                     .sync_dependencies()
-                    .await
-                    .into_lua_err()
-                    .map(SyncReportLua)
-            },
-        );
-
-        methods.document("Sync workspace build dependencies");
-        methods.param("workspace", "Workspace to sync");
-        methods.param("config", "Lux config");
-        methods.add_async_function(
-            "sync_build_dependencies",
-            |_, (workspace, config): (WorkspaceLua, ConfigLua)| async move {
-                let _runtime = lua_runtime().enter();
-                Sync::new(&workspace.0, &config.0)
-                    .sync_build_dependencies()
                     .await
                     .into_lua_err()
                     .map(SyncReportLua)

--- a/lux-lua/src/operations.rs
+++ b/lux-lua/src/operations.rs
@@ -218,15 +218,12 @@ impl TypedUserData for OperationsModule {
             "sync",
             |_, (workspace, config): (WorkspaceLua, ConfigLua)| async move {
                 let _runtime = lua_runtime().enter();
-                let deps = Sync::new(&workspace.0, &config.0)
-                    .sync_dependencies()
+                Sync::new(&workspace.0, &config.0)
+                    .test(true)
+                    .sync()
                     .await
-                    .into_lua_err()?;
-                let test = Sync::new(&workspace.0, &config.0)
-                    .sync_test_dependencies()
-                    .await
-                    .into_lua_err()?;
-                Ok((SyncReportLua(deps), SyncReportLua(test)))
+                    .into_lua_err()
+                    .map(SyncReportLua)
             },
         );
 
@@ -238,7 +235,7 @@ impl TypedUserData for OperationsModule {
             |_, (workspace, config): (WorkspaceLua, ConfigLua)| async move {
                 let _runtime = lua_runtime().enter();
                 Sync::new(&workspace.0, &config.0)
-                    .sync_dependencies()
+                    .sync()
                     .await
                     .into_lua_err()
                     .map(SyncReportLua)
@@ -248,17 +245,6 @@ impl TypedUserData for OperationsModule {
         methods.document("Sync workspace test dependencies");
         methods.param("workspace", "Workspace to sync");
         methods.param("config", "Lux config");
-        methods.add_async_function(
-            "sync_test_dependencies",
-            |_, (workspace, config): (WorkspaceLua, ConfigLua)| async move {
-                let _runtime = lua_runtime().enter();
-                Sync::new(&workspace.0, &config.0)
-                    .sync_test_dependencies()
-                    .await
-                    .into_lua_err()
-                    .map(SyncReportLua)
-            },
-        );
 
         methods.document("Build a workspace");
         methods.param("workspace", "Workspace to build");


### PR DESCRIPTION
This is a breaking change for the `operations::Sync` UX and the lockfile format.
The lockfile format changes are backward compatible, but not forward, so trying to use a newer lockfile will fail with an older Lux version.

Fixes #1925.

The core logic changes are in:

- `lux-lib::operations::sync`
- `lux-lib::operations::install`
- `lux-lib::operations::resolve`