### PR TITLE
ci(deps): revert bump actions-rust-lang/setup-rust-toolchain from 1 to 2

### DIFF
--- a/.github/workflows/cd-binstall.yml
+++ b/.github/workflows/cd-binstall.yml
@@ -75,7 +75,7 @@ jobs:
         run: brew install gpgme
 
       - name: Install Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         if: endsWith(matrix.target, 'windows-msvc')
 
       - name: Install MSVC Compiler Toolchain

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       # NOTE: We cannot cross-compile yet because of dynamically linked dependencies:
       # - gpgme -> lgpg-error, lgpgme

--- a/.github/workflows/dist-package-dry-run.yml
+++ b/.github/workflows/dist-package-dry-run.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: "Setup environment for MSVC"
         # mirrors .cargo/config.toml [target.x86_64-pc-windows-msvc] rustflags

--- a/.github/workflows/integration-msvc.yml
+++ b/.github/workflows/integration-msvc.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install MSVC Compiler Toolchain
         uses: ilammy/msvc-dev-cmd@v1
       - name: Install Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Lua
         uses: luarocks/gh-actions-lua@master
@@ -41,7 +41,7 @@ jobs:
           choco install -y --no-progress make cmake
 
       - name: Install Rust Toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
Reverts lumen-oss/lux#1931

This appears to have broken our release-please workflow.